### PR TITLE
Add ETA and progress details to sync progress bar

### DIFF
--- a/djsupport/cli.py
+++ b/djsupport/cli.py
@@ -195,7 +195,14 @@ def sync(
         pl_report = PlaylistReport(name=pl.name, path=pl.path)
         matched_uris: list[str] = []
 
-        with click.progressbar(pl.track_ids, label=f"Matching: {pl.name}") as bar:
+        with click.progressbar(
+            pl.track_ids,
+            label=f"Matching: {pl.name}",
+            show_eta=True,
+            show_percent=True,
+            show_pos=True,
+            item_show_func=lambda tid: tracks[tid].display[:50] if tid and tid in tracks else "",
+        ) as bar:
             for tid in bar:
                 track = tracks.get(tid)
                 if track is None:


### PR DESCRIPTION
## Summary
- Enables ETA, percentage complete, and position counter (e.g. `1470/3500`) on the sync progress bar
- Shows the current track name being matched, truncated to 50 chars
- No new dependencies — uses existing Click progressbar options

## Test plan
- [ ] Run `djsupport sync` on a large library and verify ETA, percentage, counter, and track name display
- [ ] Verify progress bar still works correctly for single-playlist syncs (`--playlist`)
- [ ] Verify `--dry-run` mode shows the same progress details

🤖 Generated with [Claude Code](https://claude.com/claude-code)