### PR TITLE
feat: Add Beatport DJ chart import

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,8 @@ build/
 # App-specific state (personal data)
 .djsupport_cache*
 .djsupport_playlists*
+.djsupport_beatport_cache*
+.djsupport_beatport_playlists*
 .djsupport_config.json
 *.xml
 !tests/fixtures/*.xml

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Added
 
+- `djsupport beatport <url>` command — import a Beatport DJ chart as a Spotify playlist
+- `djsupport/beatport.py` module — scrapes Beatport chart pages via `__NEXT_DATA__` JSON extraction (no headless browser needed)
+- Beatport-specific cache (`.djsupport_beatport_cache.json`) and state (`.djsupport_beatport_playlists.json`), fully isolated from Rekordbox
+- Anti-bot challenge detection with clear user messaging
+- Security hardening: HTTPS-only URL validation, 5MB response size limit, redirect validation
+- `requests>=2.28` dependency for Beatport HTTP fetching
+- 44 new tests for Beatport module (URL validation, duration parsing, track parsing, chart data extraction, fetch error handling)
+- `source_type` field on `PlaylistState` to distinguish Rekordbox and Beatport sources
+- `source_label` field on `SyncReport` for dynamic Markdown table headers
 - Duration-based tie-breaking in matcher scoring — disambiguates original/radio/extended versions using Rekordbox `TotalTime` and Spotify `duration_ms`
 - Plain-text fallback search strategy (Strategy 5) — runs without `artist:`/`track:` field prefixes when field-specific searches return nothing, improving matches for misspelled artist/track names
 - `duration` field on `Track` dataclass, parsed from Rekordbox XML `TotalTime` attribute
@@ -29,6 +38,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - Duplicate tracks in Spotify playlists — different Rekordbox entries (e.g., remixes) resolving to the same Spotify URI are now deduplicated before playlist creation
 
 ### Changed
+
+- `PlaylistState.rekordbox_path` renamed to `source_path` (v1 state files migrated automatically)
+- `MatchedTrack.rekordbox_name` renamed to `source_name` for source-agnostic reporting
+- Extracted `_match_and_sync_playlist()` shared helper from `sync` command — both `sync` and `beatport` use it
+- `STATE_VERSION` bumped to 2 with automatic v1 migration logic
 
 - Early exit optimization in `match_track` — skips remaining search strategies when Strategy 1 finds a high-confidence exact match (score >= 95), reducing API calls by 40-60% on large library syncs
 - Updated README with all current features, flags, and usage examples

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -63,6 +63,8 @@ djsupport sync --state-path state.json   # Custom playlist state file location
 djsupport beatport <url> --dry-run                  # Preview matches
 djsupport beatport <url> --threshold 90              # Minimum match confidence
 djsupport beatport <url> --no-cache                  # Bypass Beatport match cache
+djsupport beatport <url> --retry                     # Retry previously failed matches
+djsupport beatport <url> --retry-days 3              # Auto-retry failures older than N days (default 7)
 djsupport beatport <url> --cache-path my.json        # Custom Beatport cache file
 djsupport beatport <url> --state-path my.json        # Custom Beatport state file
 djsupport beatport <url> --prefix "dj"               # Prefix for playlist name

--- a/djsupport/beatport.py
+++ b/djsupport/beatport.py
@@ -11,7 +11,7 @@ BEATPORT_CHART_URL_PREFIX = "beatport.com/chart/"
 BEATPORT_CHART_PATTERN = re.compile(
     r"^https://(www\.)?beatport\.com/chart/[\w-]+/\d+/?$"
 )
-USER_AGENT = "Mozilla/5.0 (compatible; djsupport/0.3.0)"
+USER_AGENT = "Mozilla/5.0 (compatible; djsupport/0.2.0)"
 REQUEST_TIMEOUT = (5, 30)  # (connect, read) seconds
 MAX_RESPONSE_SIZE = 5 * 1024 * 1024  # 5 MB
 
@@ -89,10 +89,10 @@ def fetch_chart(url: str) -> tuple[str, str, list[Track]]:
         )
 
     data = json.loads(match.group(1))
-    return _parse_chart_data(data, url)
+    return _parse_chart_data(data)
 
 
-def _parse_chart_data(data: dict, url: str) -> tuple[str, str, list[Track]]:
+def _parse_chart_data(data: dict) -> tuple[str, str, list[Track]]:
     """Extract chart info and tracks from __NEXT_DATA__ JSON."""
     try:
         queries = data["props"]["pageProps"]["dehydratedState"]["queries"]
@@ -115,7 +115,7 @@ def _parse_chart_data(data: dict, url: str) -> tuple[str, str, list[Track]]:
 
     if not track_query:
         raise BeatportParseError(
-            f"Could not locate track data in chart page queries. "
+            "Could not locate track data in chart page queries. "
             f"Found {len(queries)} queries but none contained track results."
         )
 

--- a/djsupport/beatport.py
+++ b/djsupport/beatport.py
@@ -1,0 +1,178 @@
+"""Beatport DJ chart scraper."""
+
+import json
+import re
+
+import requests
+
+from djsupport.rekordbox import Track
+
+BEATPORT_CHART_URL_PREFIX = "beatport.com/chart/"
+BEATPORT_CHART_PATTERN = re.compile(
+    r"^https://(www\.)?beatport\.com/chart/[\w-]+/\d+/?$"
+)
+USER_AGENT = "Mozilla/5.0 (compatible; djsupport/0.3.0)"
+REQUEST_TIMEOUT = (5, 30)  # (connect, read) seconds
+MAX_RESPONSE_SIZE = 5 * 1024 * 1024  # 5 MB
+
+
+class BeatportParseError(Exception):
+    """Raised when chart page structure cannot be parsed."""
+
+
+class InvalidBeatportURL(ValueError):
+    """Raised when a URL is not a valid Beatport chart URL."""
+
+
+def validate_url(url: str) -> str:
+    """Validate and normalize a Beatport chart URL.
+
+    Raises InvalidBeatportURL if the URL doesn't match the expected pattern.
+    """
+    url = url.split("?")[0].rstrip("/")  # strip query params and trailing slash
+    if not BEATPORT_CHART_PATTERN.match(url):
+        raise InvalidBeatportURL(
+            f"Not a valid Beatport chart URL: {url}\n"
+            "Expected: https://www.beatport.com/chart/<name>/<id>"
+        )
+    return url
+
+
+def fetch_chart(url: str) -> tuple[str, str, list[Track]]:
+    """Fetch and parse a Beatport DJ chart page.
+
+    Returns (chart_name, curator, tracks) where tracks are ordered by chart position.
+    Raises BeatportParseError on structure issues, requests.RequestException on network issues.
+    """
+    response = requests.get(
+        url,
+        headers={"User-Agent": USER_AGENT},
+        timeout=REQUEST_TIMEOUT,
+        stream=True,
+    )
+    response.raise_for_status()
+
+    # Read with size limit
+    chunks = []
+    size = 0
+    for chunk in response.iter_content(chunk_size=8192, decode_unicode=False):
+        size += len(chunk)
+        if size > MAX_RESPONSE_SIZE:
+            response.close()
+            raise BeatportParseError("Response too large — does not look like a chart page.")
+        chunks.append(chunk)
+    html = b"".join(chunks).decode(response.encoding or "utf-8")
+
+    # Validate final URL after redirects
+    final_url = response.url
+    if BEATPORT_CHART_URL_PREFIX not in final_url:
+        raise BeatportParseError(
+            f"Beatport redirected to an unexpected URL: {final_url}"
+        )
+
+    # Extract __NEXT_DATA__ JSON via regex (no BeautifulSoup needed)
+    match = re.search(
+        r'<script\s+id="__NEXT_DATA__"\s*[^>]*>(.*?)</script>',
+        html,
+        re.DOTALL,
+    )
+    if not match:
+        # Detect anti-bot challenge page
+        if "/human-test/" in html or "findProof" in html:
+            raise BeatportParseError(
+                "Beatport returned an anti-bot challenge page. "
+                "This may be temporary — try again in a few minutes."
+            )
+        raise BeatportParseError(
+            "Could not find chart data on page. "
+            "Beatport may have changed their page structure."
+        )
+
+    data = json.loads(match.group(1))
+    return _parse_chart_data(data, url)
+
+
+def _parse_chart_data(data: dict, url: str) -> tuple[str, str, list[Track]]:
+    """Extract chart info and tracks from __NEXT_DATA__ JSON."""
+    try:
+        queries = data["props"]["pageProps"]["dehydratedState"]["queries"]
+    except (KeyError, TypeError) as e:
+        raise BeatportParseError(
+            f"Unexpected page data structure (missing key: {e}). "
+            "Beatport may have changed their page format."
+        ) from e
+
+    # Find the query containing track results
+    track_query = None
+    for q in queries:
+        if not isinstance(q, dict):
+            continue
+        results = q.get("state", {}).get("data", {}).get("results")
+        if isinstance(results, list) and results and isinstance(results[0], dict):
+            if "artists" in results[0]:
+                track_query = q
+                break
+
+    if not track_query:
+        raise BeatportParseError(
+            f"Could not locate track data in chart page queries. "
+            f"Found {len(queries)} queries but none contained track results."
+        )
+
+    results = track_query["state"]["data"]["results"]
+
+    # Extract chart metadata from page props
+    page_props = data["props"]["pageProps"]
+    chart_name = page_props.get("chart", {}).get("name", "Unknown Chart")
+    curator = page_props.get("chart", {}).get("dj", {}).get("name", "Unknown")
+
+    tracks = [_parse_track(item, i) for i, item in enumerate(results)]
+    return chart_name, curator, tracks
+
+
+def _parse_duration(length_str: str) -> int:
+    """Parse a duration string like '4:44' or '1:04:30' to seconds.
+
+    Returns 0 on unparseable input.
+    """
+    if not length_str or ":" not in length_str:
+        return 0
+    parts = length_str.split(":")
+    try:
+        if len(parts) == 2:
+            return int(parts[0]) * 60 + int(parts[1])
+        if len(parts) == 3:
+            return int(parts[0]) * 3600 + int(parts[1]) * 60 + int(parts[2])
+    except ValueError:
+        return 0
+    return 0
+
+
+def _parse_track(item: dict, position: int) -> Track:
+    """Convert a Beatport track JSON object to a Track dataclass."""
+    raw_artists = item.get("artists", [])
+    if not isinstance(raw_artists, list):
+        raw_artists = []
+    artists = ", ".join(
+        a["name"] for a in raw_artists
+        if isinstance(a, dict) and "name" in a
+    )
+
+    mix_name = item.get("mix_name", "")
+    title = item.get("name", "")
+
+    # Append mix name if it's not "Original Mix" (adds noise to matching)
+    if mix_name and mix_name != "Original Mix":
+        title = f"{title} ({mix_name})"
+
+    return Track(
+        track_id=f"bp-{item.get('id', position)}",
+        name=title,
+        artist=artists,
+        album=item.get("release", {}).get("name", ""),
+        remixer="",
+        label=item.get("release", {}).get("label", {}).get("name", ""),
+        genre=item.get("genre", {}).get("name", ""),
+        date_added="",
+        duration=_parse_duration(item.get("length", "")),
+    )

--- a/djsupport/cli.py
+++ b/djsupport/cli.py
@@ -352,6 +352,8 @@ DEFAULT_BEATPORT_STATE_PATH = ".djsupport_beatport_playlists.json"
 @click.option("--dry-run", is_flag=True, help="Preview without modifying Spotify.")
 @click.option("--threshold", "-t", default=80, show_default=True, help="Minimum match confidence (0-100).")
 @click.option("--no-cache", is_flag=True, help="Bypass match cache.")
+@click.option("--retry", is_flag=True, help="Force retry all previously failed matches.")
+@click.option("--retry-days", default=7, show_default=True, help="Auto-retry failures older than N days.")
 @click.option("--cache-path", default=DEFAULT_BEATPORT_CACHE_PATH, show_default=True, help="Path to Beatport match cache.")
 @click.option("--state-path", default=DEFAULT_BEATPORT_STATE_PATH, show_default=True, help="Path to Beatport playlist state.")
 @click.option("--report", "report_path", type=click.Path(), default=None, help="Save Markdown report.")
@@ -363,6 +365,8 @@ def beatport(
     dry_run: bool,
     threshold: int,
     no_cache: bool,
+    retry: bool,
+    retry_days: int,
     cache_path: str,
     state_path: str,
     report_path: str | None,
@@ -443,6 +447,8 @@ def beatport(
             dry_run=dry_run,
             incremental=incremental,
             prefix=actual_prefix,
+            retry_days=retry_days,
+            retry=retry,
             source_type="beatport",
         )
     except RateLimitError as e:

--- a/djsupport/matcher.py
+++ b/djsupport/matcher.py
@@ -136,10 +136,14 @@ def _classify_version_match(track: Track, result: dict) -> str:
 
 
 def _duration_penalty(track_duration_s: int, result_duration_ms: int) -> float:
-    """Penalty for duration mismatch between Rekordbox and Spotify tracks.
+    """Penalty for duration mismatch between source and Spotify tracks.
 
     Returns 0 when durations are unavailable or within 30s of each other.
-    Beyond 30s, applies 10 points per additional 30s, capped at 30.
+    Beyond 30s, applies 5 points per additional 30s, capped at 15.
+
+    The cap is intentionally low so that duration alone cannot reject an
+    otherwise strong artist+title match — common when Beatport lists extended
+    DJ versions and Spotify only has shorter radio edits.
     """
     if track_duration_s <= 0 or result_duration_ms <= 0:
         return 0.0
@@ -148,7 +152,7 @@ def _duration_penalty(track_duration_s: int, result_duration_ms: int) -> float:
     if diff <= 30:
         return 0.0
     excess = diff - 30
-    return min(30.0, (excess / 30) * 10)
+    return min(15.0, (excess / 30) * 5)
 
 
 def _score_result(track: Track, result: dict) -> float:

--- a/djsupport/matcher.py
+++ b/djsupport/matcher.py
@@ -32,10 +32,13 @@ def _strip_mix_info(title: str) -> str:
     """Remove parenthetical remix/mix info and bracket tags from a title.
 
     e.g. 'Vultora (Original Mix)' -> 'Vultora'
+         'Night Drive (Extended)' -> 'Night Drive'
          'Today [Permanent Vacation]' -> 'Today'
          'What Is Real - Deep in the Playa Mix' -> 'What Is Real'
     """
-    title = re.sub(r"\s*\(.*?(mix|remix|edit|version|dub)\)", "", title, flags=re.IGNORECASE)
+    title = re.sub(r"\s*\(.*?(mix|remix|edit|version|dub|extended|radio|instrumental|short)\)", "", title, flags=re.IGNORECASE)
+    # Strip standalone version tags like (Extended), (Radio), (Instrumental)
+    title = re.sub(r"\s*\((extended|radio|instrumental|short)\)", "", title, flags=re.IGNORECASE)
     title = re.sub(r"\s*\[.*?\]", "", title)
     # Strip trailing hyphen descriptors like " - XYZ Remix" used by Spotify
     title = re.sub(r"\s+-\s+[^-]*\b(mix|remix|edit|version|dub)\b.*$", "", title, flags=re.IGNORECASE)
@@ -53,7 +56,7 @@ def _extract_mix_descriptors(title: str) -> list[str]:
     descriptors: list[str] = []
     candidates = re.findall(r"[\(\[]([^\)\]]+)[\)\]]", title)
     for c in candidates:
-        if re.search(r"\b(mix|remix|edit|version|dub)\b", c, flags=re.IGNORECASE):
+        if re.search(r"\b(mix|remix|edit|version|dub|extended|radio|instrumental|short)\b", c, flags=re.IGNORECASE):
             descriptors.append(_normalize(c))
     # Spotify often uses "Track Name - XYZ Remix" instead of parentheses
     hyphen_match = re.search(

--- a/djsupport/report.py
+++ b/djsupport/report.py
@@ -6,7 +6,7 @@ from datetime import datetime
 
 @dataclass
 class MatchedTrack:
-    rekordbox_name: str
+    source_name: str
     spotify_name: str
     spotify_artist: str
     score: float
@@ -40,6 +40,7 @@ class SyncReport:
     dry_run: bool
     playlists: list[PlaylistReport] = field(default_factory=list)
     cache_enabled: bool = False
+    source_label: str = "Rekordbox"
 
     @property
     def total_matched(self) -> int:
@@ -138,11 +139,11 @@ def save_report(report: SyncReport, path: str) -> None:
         lines.append("")
 
         if pl.matched:
-            lines.append("| Rekordbox | Spotify Match | Score | Match Type |")
+            lines.append(f"| {report.source_label} | Spotify Match | Score | Match Type |")
             lines.append("|-----------|---------------|-------|------------|")
             for m in pl.matched:
                 lines.append(
-                    f"| {m.rekordbox_name} | {m.spotify_artist} - {m.spotify_name}"
+                    f"| {m.source_name} | {m.spotify_artist} - {m.spotify_name}"
                     f" | {m.score:.1f} | {m.match_type} |"
                 )
             lines.append("")
@@ -164,11 +165,11 @@ def save_report(report: SyncReport, path: str) -> None:
     if low_confidence:
         lines.append("## Low Confidence Matches (score < 90)")
         lines.append("")
-        lines.append("| Playlist | Rekordbox | Spotify Match | Score | Match Type |")
+        lines.append(f"| Playlist | {report.source_label} | Spotify Match | Score | Match Type |")
         lines.append("|----------|-----------|---------------|-------|------------|")
         for pl_path, m in low_confidence:
             lines.append(
-                f"| {pl_path} | {m.rekordbox_name}"
+                f"| {pl_path} | {m.source_name}"
                 f" | {m.spotify_artist} - {m.spotify_name} | {m.score:.1f} | {m.match_type} |"
             )
         lines.append("")

--- a/djsupport/spotify.py
+++ b/djsupport/spotify.py
@@ -211,7 +211,7 @@ def create_or_update_playlist(
         state_manager.set(name, PlaylistState(
             spotify_id=playlist_id,
             spotify_name=format_playlist_name(name, prefix),
-            rekordbox_path=name,
+            source_path=name,
             last_synced=datetime.now().isoformat(),
             prefix_used=prefix,
         ))
@@ -282,7 +282,7 @@ def incremental_update_playlist(
             state_manager.set(name, PlaylistState(
                 spotify_id=pid,
                 spotify_name=format_playlist_name(name, prefix),
-                rekordbox_path=name,
+                source_path=name,
                 last_synced=datetime.now().isoformat(),
                 prefix_used=prefix,
             ))

--- a/djsupport/spotify.py
+++ b/djsupport/spotify.py
@@ -174,6 +174,8 @@ def create_or_update_playlist(
     existing_playlists: dict[str, str] | None = None,
     prefix: str | None = None,
     state_manager: PlaylistStateManager | None = None,
+    source_path: str | None = None,
+    source_type: str = "rekordbox",
 ) -> tuple[str, str]:
     """Create a playlist or replace its tracks if it already exists.
 
@@ -211,9 +213,10 @@ def create_or_update_playlist(
         state_manager.set(name, PlaylistState(
             spotify_id=playlist_id,
             spotify_name=format_playlist_name(name, prefix),
-            source_path=name,
+            source_path=source_path or name,
             last_synced=datetime.now().isoformat(),
             prefix_used=prefix,
+            source_type=source_type,
         ))
 
     return playlist_id, action
@@ -244,6 +247,8 @@ def incremental_update_playlist(
     existing_playlists: dict[str, str] | None = None,
     prefix: str | None = None,
     state_manager: PlaylistStateManager | None = None,
+    source_path: str | None = None,
+    source_type: str = "rekordbox",
 ) -> tuple[str, str, dict]:
     """Update a playlist incrementally, only adding/removing the diff.
 
@@ -261,6 +266,7 @@ def incremental_update_playlist(
         pid, action = create_or_update_playlist(
             sp, name, desired_uris, existing_playlists,
             prefix=prefix, state_manager=state_manager,
+            source_path=source_path, source_type=source_type,
         )
         return pid, action, {"added": len(desired_uris), "removed": 0, "unchanged": 0}
 
@@ -282,9 +288,10 @@ def incremental_update_playlist(
             state_manager.set(name, PlaylistState(
                 spotify_id=pid,
                 spotify_name=format_playlist_name(name, prefix),
-                source_path=name,
+                source_path=source_path or name,
                 last_synced=datetime.now().isoformat(),
                 prefix_used=prefix,
+                source_type=source_type,
             ))
 
     if not to_remove and not to_add:

--- a/docs/plans/2026-02-26-feat-beatport-chart-import-plan.md
+++ b/docs/plans/2026-02-26-feat-beatport-chart-import-plan.md
@@ -1,0 +1,784 @@
+---
+title: "feat: Add Beatport DJ chart import"
+type: feat
+status: completed
+date: 2026-02-26
+deepened: 2026-02-26
+---
+
+# feat: Add Beatport DJ chart import
+
+New CLI command `djsupport beatport <chart-url>` that scrapes a Beatport DJ chart page, extracts track metadata, fuzzy-matches tracks against Spotify, and creates a playlist.
+
+Beatport chart pages embed all track data as server-rendered JSON in a `__NEXT_DATA__` script tag — no headless browser needed. A simple `requests` + `json` + regex approach works. `robots.txt` allows scraping (`Allow: /`).
+
+## Enhancement Summary
+
+**Deepened on:** 2026-02-26
+**Sections enhanced:** 7
+**Research agents used:** web scraping best practices, cache architecture, Python reviewer, security sentinel, architecture strategist, performance oracle, code simplicity reviewer, spec flow analyzer, pattern recognition, Beatport page structure validator
+
+### Key Improvements from Original Plan
+1. **Separate cache and state files** — Beatport uses its own `.djsupport_beatport_cache.json` and `.djsupport_beatport_playlists.json`, fully isolated from Rekordbox
+2. **Drop BeautifulSoup dependency** — regex extraction of `__NEXT_DATA__` is simpler and eliminates a dependency
+3. **Fix validate_url** — use domain exception instead of `click.BadParameter` (separation of concerns)
+4. **Defensive JSON traversal** — wrap deep key access in try/except with actionable `BeatportParseError` messages
+5. **Robust duration parsing** — handle H:MM:SS, invalid input, and extraction to a testable function
+6. **Anti-bot detection awareness** — Beatport has a custom anti-bot system; plan includes detection and clear user messaging
+7. **Shared pipeline helper** — extract `_match_and_sync_playlist()` from `sync` to avoid ~80 lines of duplication
+8. **Source-agnostic state model** — rename `rekordbox_path` → `source_path`, add `source_type`, bump STATE_VERSION to 2
+
+### New Considerations Discovered
+- Beatport has a custom anti-bot system (proof-of-work + CAPTCHA) that may block requests; the [Beatporter](https://github.com/rootshellz/Beatporter) project uses Selenium as a workaround
+- Beatport has an API v4 (`api.beatport.com/v4/`) but it requires Beatport account auth — scraping is simpler for v1
+- If Beatport migrates from Next.js Pages Router to App Router (RSC), `__NEXT_DATA__` disappears; detection + clear error messaging needed
+- `MatchedTrack.rekordbox_name` and `SyncReport` Markdown headers are Rekordbox-specific — need renaming for source-agnostic reports
+
+---
+
+## Acceptance Criteria
+
+- [x] `djsupport beatport <url>` accepts a Beatport DJ chart URL (e.g., `https://www.beatport.com/chart/garage-go-tos/815070`)
+- [x] Validates URL is a `beatport.com/chart/` path before fetching (HTTPS enforced)
+- [x] Extracts track metadata from `__NEXT_DATA__` JSON: artist(s), title, mix name, label, genre, BPM, key, ISRC, duration
+- [x] Converts tracks to existing `Track` dataclass (reuses `matcher.py` as-is)
+- [x] Creates Spotify playlist named using existing prefix convention (e.g., `djsupport / Garage Go-Tos`)
+- [x] Preserves chart track ordering in the Spotify playlist
+- [x] Shows chart metadata before matching: "Chart: {name} by {curator}. {count} tracks."
+- [x] Supports flags: `--dry-run`, `--threshold`, `--no-cache`, `--prefix`, `--no-prefix`, `--report`, `--cache-path`, `--state-path`, `--incremental`
+- [x] Handles errors gracefully: invalid URL, 404, network timeout, changed page structure, anti-bot challenge
+- [x] Uses **separate** cache (`.djsupport_beatport_cache.json`) and state (`.djsupport_beatport_playlists.json`) from Rekordbox
+- [x] Reports matched/unmatched tracks with chart positions for unmatched
+- [x] Tests cover parser, URL validation, error handling, duration parsing, and CLI integration
+- [x] Re-importing the same chart URL updates the existing Spotify playlist (via state lookup by chart URL)
+- [x] `.gitignore` updated for new Beatport files
+- [x] `CLAUDE.md` updated with new module, command, and files
+
+---
+
+## Context
+
+- **Data access**: Beatport embeds track data as JSON in `<script id="__NEXT_DATA__">`. Path: `props.pageProps.dehydratedState.queries[N].state.data.results` (array of track objects). Each track has `name`, `mix_name`, `artists[]`, `release.label`, `genre`, `bpm`, `key`, `isrc`, `publish_date`, `length`. Confirmed live on 2026-02-26.
+- **No new matching logic needed**: `matcher.py` is already source-agnostic. Beatport tracks go through the same 5-strategy fuzzy matching pipeline.
+- **ISRC available but deferred**: Beatport provides ISRC codes per track. These could enable exact Spotify lookups (Strategy 0), but that's a separate enhancement — v1 uses fuzzy matching only. This is the single highest-impact future optimization (could reduce API calls by 80-90%).
+- **Dependencies**: Add `requests>=2.28` to `pyproject.toml`. No BeautifulSoup needed — regex extraction is sufficient.
+- **Rate limits**: Spotify rate limit handling already exists (`RateLimitError`). For Beatport: single-page fetch per invocation, well within any implicit limits.
+- **Flags not applicable**: `--all`, `--all-name`, `--playlist`, `--retry`, `--retry-days` don't apply to single-chart import — omit from the beatport command.
+- **Anti-bot measures**: Beatport has a custom anti-bot system with proof-of-work challenges and image CAPTCHA. Single-page fetches with a realistic User-Agent are expected to work, but the code must detect and report challenge pages clearly.
+- **Beatport API v4**: Exists at `api.beatport.com/v4/` but requires Beatport account authentication — not viable for v1. Documented as a fallback path.
+- **robots.txt**: Confirmed `Allow: /` with no `Disallow` rules. Scraping is permitted.
+
+---
+
+## Preparatory Refactoring (before Beatport feature)
+
+These changes make the codebase source-agnostic, benefiting both the existing Rekordbox workflow and the new Beatport feature.
+
+### 1. Rename `PlaylistState.rekordbox_path` → `source_path` + add `source_type`
+
+```python
+# state.py
+STATE_VERSION = 2  # bumped from 1
+
+@dataclass
+class PlaylistState:
+    spotify_id: str
+    spotify_name: str
+    source_path: str            # was: rekordbox_path
+    last_synced: str
+    prefix_used: str | None
+    source_type: str = "rekordbox"  # "rekordbox" | "beatport"
+```
+
+Add v1 migration in `load()`:
+```python
+def load(self) -> None:
+    # ... existing file read ...
+    version = data.get("version")
+    if version == 1:
+        for key, entry in data.get("entries", {}).items():
+            if "rekordbox_path" in entry:
+                entry["source_path"] = entry.pop("rekordbox_path")
+                entry.setdefault("source_type", "rekordbox")
+            self.entries[key] = PlaylistState(**entry)
+        return
+    if version != STATE_VERSION:
+        return
+    # ... normal v2 load ...
+```
+
+Update `spotify.py` — `create_or_update_playlist` and `incremental_update_playlist` pass `source_path=name, source_type="rekordbox"` (backward-compatible default).
+
+### 2. Rename `MatchedTrack.rekordbox_name` → `source_name`
+
+```python
+# report.py
+@dataclass
+class MatchedTrack:
+    source_name: str          # was: rekordbox_name
+    spotify_name: str
+    spotify_artist: str
+    score: float
+    match_type: str = "exact"
+```
+
+Add `source_label` to `SyncReport` for Markdown headers:
+```python
+@dataclass
+class SyncReport:
+    # ... existing fields ...
+    source_label: str = "Rekordbox"  # "Rekordbox" or "Beatport"
+```
+
+Update `save_report` table header: `| {report.source_label} | Spotify Match | ...`
+
+### 3. Extract shared matching pipeline in `cli.py`
+
+```python
+def _match_and_sync_playlist(
+    tracks: list[Track],
+    playlist_name: str,
+    playlist_path: str,
+    *,
+    sp,
+    cache: MatchCache | None,
+    state_mgr: PlaylistStateManager,
+    existing_playlists: dict[str, str] | None,
+    threshold: int,
+    dry_run: bool,
+    incremental: bool,
+    prefix: str | None,
+    cache_path: str,
+    source_type: str = "rekordbox",
+) -> PlaylistReport:
+    """Match tracks to Spotify and create/update a playlist. Returns report."""
+    # Progress bar, matching loop, URI dedup, playlist creation, RateLimitError handling
+    # Extracted from sync command lines 195-280
+```
+
+Both `sync` and `beatport` call this helper. The `sync` command resolves track IDs to `Track` objects first; `beatport` passes tracks directly.
+
+---
+
+## MVP Implementation
+
+### djsupport/beatport.py
+
+```python
+"""Beatport DJ chart scraper."""
+
+import json
+import re
+
+import requests
+
+from djsupport.rekordbox import Track
+
+BEATPORT_CHART_URL_PREFIX = "beatport.com/chart/"
+BEATPORT_CHART_PATTERN = re.compile(
+    r"^https://(www\.)?beatport\.com/chart/[\w-]+/\d+/?$"
+)
+USER_AGENT = "Mozilla/5.0 (compatible; djsupport/0.3.0)"
+REQUEST_TIMEOUT = (5, 30)  # (connect, read) seconds
+MAX_RESPONSE_SIZE = 5 * 1024 * 1024  # 5 MB
+
+
+class BeatportParseError(Exception):
+    """Raised when chart page structure cannot be parsed."""
+
+
+class InvalidBeatportURL(ValueError):
+    """Raised when a URL is not a valid Beatport chart URL."""
+
+
+def validate_url(url: str) -> str:
+    """Validate and normalize a Beatport chart URL.
+
+    Raises InvalidBeatportURL if the URL doesn't match the expected pattern.
+    """
+    url = url.split("?")[0].rstrip("/")  # strip query params and trailing slash
+    if not BEATPORT_CHART_PATTERN.match(url):
+        raise InvalidBeatportURL(
+            f"Not a valid Beatport chart URL: {url}\n"
+            "Expected: https://www.beatport.com/chart/<name>/<id>"
+        )
+    return url
+
+
+def fetch_chart(url: str) -> tuple[str, str, list[Track]]:
+    """Fetch and parse a Beatport DJ chart page.
+
+    Returns (chart_name, curator, tracks) where tracks are ordered by chart position.
+    Raises BeatportParseError on structure issues, requests.RequestException on network issues.
+    """
+    response = requests.get(
+        url,
+        headers={"User-Agent": USER_AGENT},
+        timeout=REQUEST_TIMEOUT,
+        stream=True,
+    )
+    response.raise_for_status()
+
+    # Read with size limit
+    chunks = []
+    size = 0
+    for chunk in response.iter_content(chunk_size=8192, decode_unicode=False):
+        size += len(chunk)
+        if size > MAX_RESPONSE_SIZE:
+            response.close()
+            raise BeatportParseError("Response too large — does not look like a chart page.")
+        chunks.append(chunk)
+    html = b"".join(chunks).decode(response.encoding or "utf-8")
+
+    # Validate final URL after redirects
+    final_url = response.url
+    if BEATPORT_CHART_URL_PREFIX not in final_url:
+        raise BeatportParseError(
+            f"Beatport redirected to an unexpected URL: {final_url}"
+        )
+
+    # Extract __NEXT_DATA__ JSON via regex (no BeautifulSoup needed)
+    match = re.search(
+        r'<script\s+id="__NEXT_DATA__"\s*[^>]*>(.*?)</script>',
+        html,
+        re.DOTALL,
+    )
+    if not match:
+        # Detect anti-bot challenge page
+        if "/human-test/" in html or "findProof" in html:
+            raise BeatportParseError(
+                "Beatport returned an anti-bot challenge page. "
+                "This may be temporary — try again in a few minutes."
+            )
+        raise BeatportParseError(
+            "Could not find chart data on page. "
+            "Beatport may have changed their page structure."
+        )
+
+    data = json.loads(match.group(1))
+    return _parse_chart_data(data, url)
+
+
+def _parse_chart_data(data: dict, url: str) -> tuple[str, str, list[Track]]:
+    """Extract chart info and tracks from __NEXT_DATA__ JSON."""
+    try:
+        queries = data["props"]["pageProps"]["dehydratedState"]["queries"]
+    except (KeyError, TypeError) as e:
+        raise BeatportParseError(
+            f"Unexpected page data structure (missing key: {e}). "
+            "Beatport may have changed their page format."
+        ) from e
+
+    # Find the query containing track results
+    track_query = None
+    for q in queries:
+        if not isinstance(q, dict):
+            continue
+        results = q.get("state", {}).get("data", {}).get("results")
+        if isinstance(results, list) and results and isinstance(results[0], dict):
+            if "artists" in results[0]:
+                track_query = q
+                break
+
+    if not track_query:
+        raise BeatportParseError(
+            f"Could not locate track data in chart page queries. "
+            f"Found {len(queries)} queries but none contained track results."
+        )
+
+    results = track_query["state"]["data"]["results"]
+
+    # Extract chart metadata from page props
+    page_props = data["props"]["pageProps"]
+    chart_name = page_props.get("chart", {}).get("name", "Unknown Chart")
+    curator = page_props.get("chart", {}).get("dj", {}).get("name", "Unknown")
+
+    tracks = [_parse_track(item, i) for i, item in enumerate(results)]
+    return chart_name, curator, tracks
+
+
+def _parse_duration(length_str: str) -> int:
+    """Parse a duration string like '4:44' or '1:04:30' to seconds.
+
+    Returns 0 on unparseable input.
+    """
+    if not length_str or ":" not in length_str:
+        return 0
+    parts = length_str.split(":")
+    try:
+        if len(parts) == 2:
+            return int(parts[0]) * 60 + int(parts[1])
+        if len(parts) == 3:
+            return int(parts[0]) * 3600 + int(parts[1]) * 60 + int(parts[2])
+    except ValueError:
+        return 0
+    return 0
+
+
+def _parse_track(item: dict, position: int) -> Track:
+    """Convert a Beatport track JSON object to a Track dataclass."""
+    raw_artists = item.get("artists", [])
+    if not isinstance(raw_artists, list):
+        raw_artists = []
+    artists = ", ".join(
+        a["name"] for a in raw_artists
+        if isinstance(a, dict) and "name" in a
+    )
+
+    mix_name = item.get("mix_name", "")
+    title = item.get("name", "")
+
+    # Append mix name if it's not "Original Mix" (adds noise to matching)
+    if mix_name and mix_name != "Original Mix":
+        title = f"{title} ({mix_name})"
+
+    return Track(
+        track_id=f"bp-{item.get('id', position)}",
+        name=title,
+        artist=artists,
+        album=item.get("release", {}).get("name", ""),
+        remixer="",
+        label=item.get("release", {}).get("label", {}).get("name", ""),
+        genre=item.get("genre", {}).get("name", ""),
+        date_added="",
+        duration=_parse_duration(item.get("length", "")),
+    )
+```
+
+### Research Insights: beatport.py
+
+**Best Practices Applied:**
+- `InvalidBeatportURL` is a domain exception, not `click.BadParameter` — keeps `beatport.py` independent of CLI framework
+- `_parse_duration()` extracted as a testable function handling M:SS, H:MM:SS, and invalid input
+- Type guards on `artists` list and `results[0]` dict protect against malformed JSON
+- `stream=True` with 5MB size limit prevents memory exhaustion from malicious responses
+- Redirect validation after request prevents SSRF via redirect following
+- Anti-bot challenge detection provides a clear, actionable error message
+- Tuple timeout `(5, 30)` — fast failure on DNS/connection issues, patient for response
+
+**Edge Cases Handled:**
+- URL with query parameters (stripped before validation)
+- URL with trailing slash (stripped)
+- Beatport redirect to non-chart page (detected and reported)
+- Anti-bot challenge page (detected via `/human-test/` marker)
+- Missing or malformed artists list (type guard)
+- Duration in H:MM:SS format (3-part split)
+- Non-numeric duration values (try/except returns 0)
+- `__NEXT_DATA__` missing entirely (Next.js migration detection)
+
+**Performance Notes:**
+- BeautifulSoup replaced with regex — eliminates dependency, ~100ms faster (though network dominates)
+- Single HTTP request per invocation — no session pooling needed
+- Charts are 10-100 tracks — the existing early exit optimization handles this comfortably
+
+---
+
+### djsupport/cli.py (new command)
+
+```python
+DEFAULT_BEATPORT_CACHE_PATH = ".djsupport_beatport_cache.json"
+DEFAULT_BEATPORT_STATE_PATH = ".djsupport_beatport_playlists.json"
+
+@cli.command()
+@click.argument("url")
+@click.option("--dry-run", is_flag=True, help="Preview without modifying Spotify.")
+@click.option("--threshold", "-t", default=80, show_default=True, help="Minimum match confidence (0-100).")
+@click.option("--no-cache", is_flag=True, help="Bypass match cache.")
+@click.option("--cache-path", default=DEFAULT_BEATPORT_CACHE_PATH, show_default=True, help="Path to Beatport match cache.")
+@click.option("--state-path", default=DEFAULT_BEATPORT_STATE_PATH, show_default=True, help="Path to Beatport playlist state.")
+@click.option("--report", "report_path", type=click.Path(), default=None, help="Save Markdown report.")
+@click.option("--prefix", default="djsupport", show_default=True, help="Prefix for Spotify playlist name.")
+@click.option("--no-prefix", is_flag=True, help="Disable playlist name prefix.")
+@click.option("--incremental/--no-incremental", default=True, show_default=True, help="Use incremental playlist updates.")
+def beatport(
+    url: str,
+    dry_run: bool,
+    threshold: int,
+    no_cache: bool,
+    cache_path: str,
+    state_path: str,
+    report_path: str | None,
+    prefix: str,
+    no_prefix: bool,
+    incremental: bool,
+) -> None:
+    """Create a Spotify playlist from a Beatport DJ chart.
+
+    URL is a Beatport chart page, e.g.:
+    https://www.beatport.com/chart/garage-go-tos/815070
+    """
+    from djsupport.beatport import validate_url, fetch_chart, BeatportParseError, InvalidBeatportURL
+
+    try:
+        url = validate_url(url)
+    except InvalidBeatportURL as e:
+        raise click.BadParameter(str(e))
+
+    click.echo("Fetching chart from Beatport...")
+    try:
+        chart_name, curator, tracks = fetch_chart(url)
+    except BeatportParseError as e:
+        raise click.ClickException(str(e))
+    except requests.RequestException as e:
+        if hasattr(e, 'response') and e.response is not None and e.response.status_code == 404:
+            raise click.ClickException("Chart not found — check the URL.")
+        raise click.ClickException(f"Failed to fetch chart: {e}")
+
+    if not tracks:
+        click.echo(f"Chart '{chart_name}' has no tracks.")
+        return
+
+    click.echo(f"Chart: {chart_name} by {curator}. {len(tracks)} tracks.")
+
+    # Initialize cache (separate from Rekordbox)
+    cache = None
+    if not no_cache:
+        from djsupport.cache import MatchCache
+        cache = MatchCache(cache_path)
+        cache.load()
+        if cache.entries:
+            click.echo(f"Loaded {len(cache.entries)} cached Beatport matches from {cache_path}")
+
+    # Resolve prefix
+    actual_prefix = None if no_prefix else prefix
+
+    # Initialize Beatport-specific playlist state
+    from djsupport.state import PlaylistStateManager
+    state_mgr = PlaylistStateManager(state_path)
+    state_mgr.load()
+
+    # Spotify client
+    sp = get_client()
+    existing = get_user_playlists(sp) if not dry_run else None
+
+    # Match and sync via shared helper
+    report = SyncReport(
+        timestamp=datetime.now(),
+        threshold=threshold,
+        dry_run=dry_run,
+        cache_enabled=cache is not None,
+        source_label="Beatport",
+    )
+
+    pl_report = _match_and_sync_playlist(
+        tracks=tracks,
+        playlist_name=chart_name,
+        playlist_path=url,  # chart URL as the source path
+        sp=sp,
+        cache=cache,
+        state_mgr=state_mgr,
+        existing_playlists=existing,
+        threshold=threshold,
+        dry_run=dry_run,
+        incremental=incremental,
+        prefix=actual_prefix,
+        cache_path=cache_path,
+        source_type="beatport",
+    )
+    report.playlists.append(pl_report)
+
+    # Save cache
+    if cache is not None:
+        cache.save()
+
+    # Save state
+    if not dry_run:
+        state_mgr.save()
+
+    print_report(report)
+    if report_path:
+        save_report(report, report_path)
+        click.echo(f"\nDetailed report saved to {report_path}")
+```
+
+### Research Insights: CLI Command
+
+**Flags dropped from original plan:**
+- `--retry` / `--retry-days` — These retry previously failed cache entries. For a first Beatport import there are no failures to retry, and on re-import `--no-cache` is the simpler UX. Can be added later if needed.
+
+**Separate file defaults:**
+- Cache: `.djsupport_beatport_cache.json` (not shared with Rekordbox)
+- State: `.djsupport_beatport_playlists.json` (not shared with Rekordbox)
+- User can still override with `--cache-path` / `--state-path`
+
+**Re-import behavior:**
+- Same chart URL → `state_mgr.get(chart_name)` finds the existing Spotify playlist ID → incremental update adds new tracks, removes stale ones
+- Different chart URL → creates a new playlist
+
+**Edge cases handled:**
+- Empty chart (0 tracks) — early return with message
+- 404 from Beatport — special-cased error message: "Chart not found — check the URL"
+- All tracks unmatched — playlist still created (empty or with 0 tracks, consistent with sync)
+
+---
+
+### tests/test_beatport.py
+
+```python
+"""Tests for Beatport chart scraper."""
+
+import json
+import pytest
+from unittest.mock import patch, MagicMock
+
+from djsupport.beatport import (
+    validate_url,
+    fetch_chart,
+    _parse_chart_data,
+    _parse_track,
+    _parse_duration,
+    BeatportParseError,
+    InvalidBeatportURL,
+)
+from djsupport.rekordbox import Track
+
+
+class TestValidateUrl:
+    def test_valid_url(self):
+        assert validate_url("https://www.beatport.com/chart/garage-go-tos/815070")
+
+    def test_valid_url_no_www(self):
+        assert validate_url("https://beatport.com/chart/garage-go-tos/815070")
+
+    def test_strips_trailing_slash(self):
+        result = validate_url("https://www.beatport.com/chart/test/123/")
+        assert not result.endswith("/")
+
+    def test_strips_query_params(self):
+        result = validate_url("https://www.beatport.com/chart/test/123?utm_source=share")
+        assert "?" not in result
+
+    def test_rejects_http(self):
+        with pytest.raises(InvalidBeatportURL):
+            validate_url("http://www.beatport.com/chart/test/123")
+
+    def test_rejects_non_chart_url(self):
+        with pytest.raises(InvalidBeatportURL):
+            validate_url("https://www.beatport.com/track/some-track/12345")
+
+    def test_rejects_non_beatport_url(self):
+        with pytest.raises(InvalidBeatportURL):
+            validate_url("https://example.com/chart/foo/123")
+
+    def test_rejects_chart_listing_page(self):
+        with pytest.raises(InvalidBeatportURL):
+            validate_url("https://www.beatport.com/charts")
+
+
+class TestParseDuration:
+    def test_minutes_seconds(self):
+        assert _parse_duration("4:44") == 284
+
+    def test_hours_minutes_seconds(self):
+        assert _parse_duration("1:04:30") == 3870
+
+    def test_empty_string(self):
+        assert _parse_duration("") == 0
+
+    def test_no_colon(self):
+        assert _parse_duration("284") == 0
+
+    def test_invalid_numbers(self):
+        assert _parse_duration("4:ab") == 0
+
+    def test_trailing_colon(self):
+        assert _parse_duration("4:") == 0
+
+
+class TestParseTrack:
+    def test_basic_track(self):
+        item = {
+            "id": 12345,
+            "name": "Sinkhole",
+            "mix_name": "Original Mix",
+            "artists": [{"name": "Pearson Sound"}],
+            "release": {"name": "Sinkhole EP", "label": {"name": "Hessle Audio"}},
+            "genre": {"name": "UK Garage / Bassline"},
+            "bpm": 129,
+            "length": "4:44",
+        }
+        track = _parse_track(item, 0)
+        assert track.name == "Sinkhole"  # Original Mix omitted
+        assert track.artist == "Pearson Sound"
+        assert track.label == "Hessle Audio"
+        assert track.duration == 284
+        assert track.track_id == "bp-12345"
+
+    def test_remix_track(self):
+        item = {
+            "id": 67890,
+            "name": "Vibe",
+            "mix_name": "Radio Edit",
+            "artists": [{"name": "Artist A"}, {"name": "Artist B"}],
+            "release": {"name": "Vibe EP", "label": {"name": "Label X"}},
+            "genre": {"name": "House"},
+            "length": "3:30",
+        }
+        track = _parse_track(item, 1)
+        assert track.name == "Vibe (Radio Edit)"
+        assert track.artist == "Artist A, Artist B"
+        assert track.duration == 210
+
+    def test_missing_artists(self):
+        item = {"id": 1, "name": "Test", "mix_name": "", "length": "3:00"}
+        track = _parse_track(item, 0)
+        assert track.artist == ""
+
+    def test_malformed_artists(self):
+        item = {"id": 1, "name": "Test", "artists": "not a list", "length": "3:00"}
+        track = _parse_track(item, 0)
+        assert track.artist == ""
+
+
+class TestParseChartData:
+    def test_missing_top_level_keys(self):
+        with pytest.raises(BeatportParseError, match="missing key"):
+            _parse_chart_data({"props": {}}, "https://example.com")
+
+    def test_empty_queries(self):
+        data = {"props": {"pageProps": {"dehydratedState": {"queries": []}}}}
+        with pytest.raises(BeatportParseError, match="Could not locate"):
+            _parse_chart_data(data, "https://example.com")
+
+
+class TestFetchChart:
+    @patch("djsupport.beatport.requests.get")
+    def test_missing_next_data(self, mock_get):
+        mock_response = MagicMock()
+        mock_response.iter_content.return_value = [b"<html><body>No data</body></html>"]
+        mock_response.encoding = "utf-8"
+        mock_response.url = "https://www.beatport.com/chart/test/123"
+        mock_response.raise_for_status = MagicMock()
+        mock_get.return_value = mock_response
+        with pytest.raises(BeatportParseError, match="Could not find chart data"):
+            fetch_chart("https://www.beatport.com/chart/test/123")
+
+    @patch("djsupport.beatport.requests.get")
+    def test_anti_bot_detection(self, mock_get):
+        mock_response = MagicMock()
+        mock_response.iter_content.return_value = [b"<html>/human-test/start</html>"]
+        mock_response.encoding = "utf-8"
+        mock_response.url = "https://www.beatport.com/chart/test/123"
+        mock_response.raise_for_status = MagicMock()
+        mock_get.return_value = mock_response
+        with pytest.raises(BeatportParseError, match="anti-bot"):
+            fetch_chart("https://www.beatport.com/chart/test/123")
+
+    @patch("djsupport.beatport.requests.get")
+    def test_redirect_to_non_chart_rejected(self, mock_get):
+        mock_response = MagicMock()
+        mock_response.iter_content.return_value = [b"<html></html>"]
+        mock_response.encoding = "utf-8"
+        mock_response.url = "https://www.beatport.com/login"
+        mock_response.raise_for_status = MagicMock()
+        mock_get.return_value = mock_response
+        with pytest.raises(BeatportParseError, match="redirected"):
+            fetch_chart("https://www.beatport.com/chart/test/123")
+```
+
+### Research Insights: Testing
+
+**Test fixture strategy:** Save a real Beatport chart page's `__NEXT_DATA__` JSON as `tests/fixtures/beatport_chart_data.json` for integration-level parser tests. This gives fast, reliable, offline tests. Strip any user-session data before committing.
+
+**Structure validation tests:** Add `TestFixtureStructure` class that validates the fixture matches expected JSON paths — serves as an early warning when Beatport changes their page structure.
+
+**State migration tests:** Add tests for v1 → v2 `PlaylistState` migration (rename `rekordbox_path` → `source_path`, add `source_type` default).
+
+---
+
+### pyproject.toml changes
+
+```toml
+dependencies = [
+    # ... existing deps ...
+    "requests>=2.28",
+]
+```
+
+No `beautifulsoup4` needed.
+
+### .gitignore additions
+
+```
+.djsupport_beatport_cache.json
+.djsupport_beatport_playlists.json
+```
+
+---
+
+## Security Considerations
+
+| Finding | Severity | Mitigation |
+|---------|----------|------------|
+| Unbounded response size | Medium | `stream=True` + 5MB limit |
+| Redirect following to arbitrary hosts | Medium | Validate `response.url` contains `beatport.com/chart/` |
+| HTTP allowed (not just HTTPS) | Low | Enforce `https://` in regex |
+| Anti-bot challenge page | Low | Detect `/human-test/` marker, clear error message |
+| JSON traversal KeyError | Low | try/except → `BeatportParseError` with context |
+| Track metadata from untrusted source | Low | Terminal escape sequences are cosmetic risk for local CLI |
+
+---
+
+## Performance Assessment
+
+| Area | Verdict | Notes |
+|------|---------|-------|
+| HTML parsing | Non-issue | Regex extraction ~1ms vs BS4 ~100ms; network dominates |
+| JSON parsing | Non-issue | 50-200KB blob, ~10ms |
+| HTTP requests | Non-issue | Single request per invocation |
+| Spotify API calls | Low concern | 10-100 tracks, early exit handles well; cold cache ~75 calls for 50 tracks |
+| Memory | Non-issue | Peak ~3MB for large chart page |
+| Cache warm-up | UX concern | Add progress bar; first run 30-60s for 50-track chart |
+
+**Highest-impact future optimization:** ISRC-based Spotify lookup (Strategy 0) — would reduce API calls by 80-90% for Beatport tracks since ISRCs are available in the JSON.
+
+---
+
+## Implementation Order
+
+1. **Prep commit: source-agnostic refactoring**
+   - Rename `PlaylistState.rekordbox_path` → `source_path`, add `source_type`, bump STATE_VERSION to 2 with migration
+   - Rename `MatchedTrack.rekordbox_name` → `source_name`, add `SyncReport.source_label`
+   - Update `spotify.py` to pass `source_path` and `source_type` to `PlaylistState`
+   - Update `cli.py` sync command to pass `source_name=track.display` and `source_label="Rekordbox"`
+   - Update all tests for field renames
+   - Extract `_match_and_sync_playlist()` helper from `sync` command
+
+2. **Feature commit: Beatport chart import**
+   - Add `djsupport/beatport.py`
+   - Add `beatport` command to `cli.py`
+   - Add `tests/test_beatport.py`
+   - Add `requests>=2.28` to `pyproject.toml`
+   - Update `.gitignore` with Beatport files
+
+3. **Housekeeping commit**
+   - Update `CLAUDE.md` with new module, command, and conventions
+   - Update `CHANGELOG.md`
+
+---
+
+## Deferred Enhancements (not in v1)
+
+- **ISRC-based matching (Strategy 0)** — Exact Spotify lookup before fuzzy matching. Highest-impact optimization.
+- **Extract `Track` to `models.py`** — Cleaner semantics than importing from `rekordbox.py`, but not blocking.
+- **Beatport API v4 fallback** — If anti-bot measures start blocking `requests`, switch to authenticated API.
+- **Multiple chart URLs in one command** — `djsupport beatport <url1> <url2>` for batch import.
+- **Remixer extraction from Beatport artist data** — Beatport artist objects have a `type` field (e.g., "remixer"). Populating `Track.remixer` would improve Strategy 3 accuracy.
+- **XDG-compliant file paths** — Move dotfiles to `~/.cache/djsupport/` and `~/.local/state/djsupport/` via `platformdirs`.
+- **`--retry` / `--retry-days` flags** — Add if users need to retry cached failures from Beatport imports.
+
+---
+
+## Sources
+
+- Beatport chart page analysis: `__NEXT_DATA__` JSON confirmed live (2026-02-26)
+- `robots.txt` at beatport.com: `Allow: /`, no Disallow rules
+- Beatport API v4: `api.beatport.com/v4/docs/` (requires auth, not viable for v1)
+- Beatport anti-bot system: custom proof-of-work + image CAPTCHA ([BuiltWith](https://builtwith.com/beatport.com))
+- [Beatporter project](https://github.com/rootshellz/Beatporter): uses Selenium + BeautifulSoup (similar use case)
+- [beatportdl](https://github.com/unspok3n/beatportdl): uses API v4 with auth
+- [Scraping Next.js sites in 2025](https://www.trickster.dev/post/scraping-nextjs-web-sites-in-2025/): `__NEXT_DATA__` reliability and App Router migration risks
+- Existing patterns: `djsupport/rekordbox.py`, `djsupport/matcher.py`, `djsupport/cache.py`, `djsupport/state.py`
+- Rate limit handling: `docs/solutions/integration-issues/spotify-rate-limit-handling.md`
+- Early exit optimization: `docs/solutions/performance-issues/spotify-api-calls-early-exit-optimization.md`
+- URI deduplication: `docs/solutions/logic-errors/duplicate-spotify-uris-in-playlists-CLI-20260225.md`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,7 @@ dependencies = [
     "click>=8.0",
     "python-dotenv>=1.0",
     "rapidfuzz>=3.0",
+    "requests>=2.28",
 ]
 
 [project.optional-dependencies]

--- a/tests/test_beatport.py
+++ b/tests/test_beatport.py
@@ -178,25 +178,25 @@ class TestParseChartData:
 
     def test_extracts_chart_name_and_curator(self):
         data = self._make_chart_data(chart_name="Peak Time", curator="Ben UFO")
-        name, curator, tracks = _parse_chart_data(data, "https://example.com")
+        name, curator, tracks = _parse_chart_data(data)
         assert name == "Peak Time"
         assert curator == "Ben UFO"
 
     def test_extracts_tracks(self):
         data = self._make_chart_data()
-        _, _, tracks = _parse_chart_data(data, "https://example.com")
+        _, _, tracks = _parse_chart_data(data)
         assert len(tracks) == 1
         assert tracks[0].name == "Track One"
         assert tracks[0].artist == "Artist One"
 
     def test_missing_top_level_keys(self):
         with pytest.raises(BeatportParseError, match="missing key"):
-            _parse_chart_data({"props": {}}, "https://example.com")
+            _parse_chart_data({"props": {}})
 
     def test_empty_queries(self):
         data = {"props": {"pageProps": {"dehydratedState": {"queries": []}}}}
         with pytest.raises(BeatportParseError, match="Could not locate"):
-            _parse_chart_data(data, "https://example.com")
+            _parse_chart_data(data)
 
     def test_queries_without_track_results(self):
         data = {
@@ -211,13 +211,13 @@ class TestParseChartData:
             }
         }
         with pytest.raises(BeatportParseError, match="Could not locate"):
-            _parse_chart_data(data, "https://example.com")
+            _parse_chart_data(data)
 
     def test_missing_chart_metadata_uses_defaults(self):
         data = self._make_chart_data()
         # Remove chart metadata
         data["props"]["pageProps"].pop("chart", None)
-        name, curator, _ = _parse_chart_data(data, "https://example.com")
+        name, curator, _ = _parse_chart_data(data)
         assert name == "Unknown Chart"
         assert curator == "Unknown"
 
@@ -235,7 +235,7 @@ class TestParseChartData:
             for i in range(5)
         ]
         data = self._make_chart_data(tracks=tracks)
-        _, _, parsed = _parse_chart_data(data, "https://example.com")
+        _, _, parsed = _parse_chart_data(data)
         assert len(parsed) == 5
         assert [t.name for t in parsed] == ["Track 0", "Track 1", "Track 2", "Track 3", "Track 4"]
 

--- a/tests/test_beatport.py
+++ b/tests/test_beatport.py
@@ -1,0 +1,332 @@
+"""Tests for Beatport chart scraper."""
+
+import json
+
+import pytest
+from unittest.mock import patch, MagicMock
+
+from djsupport.beatport import (
+    validate_url,
+    fetch_chart,
+    _parse_chart_data,
+    _parse_track,
+    _parse_duration,
+    BeatportParseError,
+    InvalidBeatportURL,
+)
+from djsupport.rekordbox import Track
+
+
+class TestValidateUrl:
+    def test_valid_url(self):
+        result = validate_url("https://www.beatport.com/chart/garage-go-tos/815070")
+        assert result == "https://www.beatport.com/chart/garage-go-tos/815070"
+
+    def test_valid_url_no_www(self):
+        result = validate_url("https://beatport.com/chart/garage-go-tos/815070")
+        assert result == "https://beatport.com/chart/garage-go-tos/815070"
+
+    def test_strips_trailing_slash(self):
+        result = validate_url("https://www.beatport.com/chart/test/123/")
+        assert not result.endswith("/")
+
+    def test_strips_query_params(self):
+        result = validate_url("https://www.beatport.com/chart/test/123?utm_source=share")
+        assert "?" not in result
+
+    def test_rejects_http(self):
+        with pytest.raises(InvalidBeatportURL):
+            validate_url("http://www.beatport.com/chart/test/123")
+
+    def test_rejects_non_chart_url(self):
+        with pytest.raises(InvalidBeatportURL):
+            validate_url("https://www.beatport.com/track/some-track/12345")
+
+    def test_rejects_non_beatport_url(self):
+        with pytest.raises(InvalidBeatportURL):
+            validate_url("https://example.com/chart/foo/123")
+
+    def test_rejects_chart_listing_page(self):
+        with pytest.raises(InvalidBeatportURL):
+            validate_url("https://www.beatport.com/charts")
+
+
+class TestParseDuration:
+    def test_minutes_seconds(self):
+        assert _parse_duration("4:44") == 284
+
+    def test_hours_minutes_seconds(self):
+        assert _parse_duration("1:04:30") == 3870
+
+    def test_empty_string(self):
+        assert _parse_duration("") == 0
+
+    def test_no_colon(self):
+        assert _parse_duration("284") == 0
+
+    def test_invalid_numbers(self):
+        assert _parse_duration("4:ab") == 0
+
+    def test_single_part(self):
+        assert _parse_duration("4:") == 0
+
+    def test_four_parts(self):
+        assert _parse_duration("1:2:3:4") == 0
+
+
+class TestParseTrack:
+    def test_basic_track(self):
+        item = {
+            "id": 12345,
+            "name": "Sinkhole",
+            "mix_name": "Original Mix",
+            "artists": [{"name": "Pearson Sound"}],
+            "release": {"name": "Sinkhole EP", "label": {"name": "Hessle Audio"}},
+            "genre": {"name": "UK Garage / Bassline"},
+            "bpm": 129,
+            "length": "4:44",
+        }
+        track = _parse_track(item, 0)
+        assert track.name == "Sinkhole"  # Original Mix omitted
+        assert track.artist == "Pearson Sound"
+        assert track.label == "Hessle Audio"
+        assert track.duration == 284
+        assert track.track_id == "bp-12345"
+        assert track.genre == "UK Garage / Bassline"
+
+    def test_remix_track(self):
+        item = {
+            "id": 67890,
+            "name": "Vibe",
+            "mix_name": "Radio Edit",
+            "artists": [{"name": "Artist A"}, {"name": "Artist B"}],
+            "release": {"name": "Vibe EP", "label": {"name": "Label X"}},
+            "genre": {"name": "House"},
+            "length": "3:30",
+        }
+        track = _parse_track(item, 1)
+        assert track.name == "Vibe (Radio Edit)"
+        assert track.artist == "Artist A, Artist B"
+        assert track.duration == 210
+
+    def test_missing_artists(self):
+        item = {"id": 1, "name": "Test", "mix_name": "", "length": "3:00"}
+        track = _parse_track(item, 0)
+        assert track.artist == ""
+
+    def test_malformed_artists(self):
+        item = {"id": 1, "name": "Test", "artists": "not a list", "length": "3:00"}
+        track = _parse_track(item, 0)
+        assert track.artist == ""
+
+    def test_missing_release_info(self):
+        item = {"id": 1, "name": "Test", "mix_name": "", "length": "3:00"}
+        track = _parse_track(item, 0)
+        assert track.album == ""
+        assert track.label == ""
+
+    def test_position_used_as_fallback_id(self):
+        item = {"name": "Test", "mix_name": "", "length": "3:00"}
+        track = _parse_track(item, 5)
+        assert track.track_id == "bp-5"
+
+    def test_empty_mix_name_not_appended(self):
+        item = {"id": 1, "name": "Track", "mix_name": "", "length": "3:00"}
+        track = _parse_track(item, 0)
+        assert track.name == "Track"
+
+    def test_track_is_track_dataclass(self):
+        item = {"id": 1, "name": "Test", "mix_name": "", "length": "3:00"}
+        track = _parse_track(item, 0)
+        assert isinstance(track, Track)
+        assert track.display == " - Test"  # empty artist
+
+
+class TestParseChartData:
+    def _make_chart_data(self, tracks=None, chart_name="Test Chart", curator="DJ Test"):
+        """Build a minimal __NEXT_DATA__ structure."""
+        if tracks is None:
+            tracks = [
+                {
+                    "id": 1,
+                    "name": "Track One",
+                    "mix_name": "Original Mix",
+                    "artists": [{"name": "Artist One"}],
+                    "release": {"name": "EP One", "label": {"name": "Label One"}},
+                    "genre": {"name": "House"},
+                    "length": "5:00",
+                },
+            ]
+        return {
+            "props": {
+                "pageProps": {
+                    "chart": {"name": chart_name, "dj": {"name": curator}},
+                    "dehydratedState": {
+                        "queries": [
+                            {
+                                "state": {
+                                    "data": {
+                                        "results": tracks,
+                                    }
+                                }
+                            }
+                        ]
+                    },
+                }
+            }
+        }
+
+    def test_extracts_chart_name_and_curator(self):
+        data = self._make_chart_data(chart_name="Peak Time", curator="Ben UFO")
+        name, curator, tracks = _parse_chart_data(data, "https://example.com")
+        assert name == "Peak Time"
+        assert curator == "Ben UFO"
+
+    def test_extracts_tracks(self):
+        data = self._make_chart_data()
+        _, _, tracks = _parse_chart_data(data, "https://example.com")
+        assert len(tracks) == 1
+        assert tracks[0].name == "Track One"
+        assert tracks[0].artist == "Artist One"
+
+    def test_missing_top_level_keys(self):
+        with pytest.raises(BeatportParseError, match="missing key"):
+            _parse_chart_data({"props": {}}, "https://example.com")
+
+    def test_empty_queries(self):
+        data = {"props": {"pageProps": {"dehydratedState": {"queries": []}}}}
+        with pytest.raises(BeatportParseError, match="Could not locate"):
+            _parse_chart_data(data, "https://example.com")
+
+    def test_queries_without_track_results(self):
+        data = {
+            "props": {
+                "pageProps": {
+                    "dehydratedState": {
+                        "queries": [
+                            {"state": {"data": {"results": [{"no_artists_key": True}]}}},
+                        ]
+                    }
+                }
+            }
+        }
+        with pytest.raises(BeatportParseError, match="Could not locate"):
+            _parse_chart_data(data, "https://example.com")
+
+    def test_missing_chart_metadata_uses_defaults(self):
+        data = self._make_chart_data()
+        # Remove chart metadata
+        data["props"]["pageProps"].pop("chart", None)
+        name, curator, _ = _parse_chart_data(data, "https://example.com")
+        assert name == "Unknown Chart"
+        assert curator == "Unknown"
+
+    def test_multiple_tracks_preserved_in_order(self):
+        tracks = [
+            {
+                "id": i,
+                "name": f"Track {i}",
+                "mix_name": "Original Mix",
+                "artists": [{"name": f"Artist {i}"}],
+                "release": {"name": "", "label": {"name": ""}},
+                "genre": {"name": ""},
+                "length": "3:00",
+            }
+            for i in range(5)
+        ]
+        data = self._make_chart_data(tracks=tracks)
+        _, _, parsed = _parse_chart_data(data, "https://example.com")
+        assert len(parsed) == 5
+        assert [t.name for t in parsed] == ["Track 0", "Track 1", "Track 2", "Track 3", "Track 4"]
+
+
+class TestFetchChart:
+    def _mock_response(self, content, url="https://www.beatport.com/chart/test/123", encoding="utf-8", status_code=200):
+        mock = MagicMock()
+        mock.iter_content.return_value = [content.encode(encoding) if isinstance(content, str) else content]
+        mock.encoding = encoding
+        mock.url = url
+        mock.raise_for_status = MagicMock()
+        mock.close = MagicMock()
+        mock.status_code = status_code
+        return mock
+
+    @patch("djsupport.beatport.requests.get")
+    def test_missing_next_data(self, mock_get):
+        mock_get.return_value = self._mock_response("<html><body>No data</body></html>")
+        with pytest.raises(BeatportParseError, match="Could not find chart data"):
+            fetch_chart("https://www.beatport.com/chart/test/123")
+
+    @patch("djsupport.beatport.requests.get")
+    def test_anti_bot_detection(self, mock_get):
+        mock_get.return_value = self._mock_response("<html>/human-test/start</html>")
+        with pytest.raises(BeatportParseError, match="anti-bot"):
+            fetch_chart("https://www.beatport.com/chart/test/123")
+
+    @patch("djsupport.beatport.requests.get")
+    def test_anti_bot_detection_findproof(self, mock_get):
+        mock_get.return_value = self._mock_response("<html>findProof()</html>")
+        with pytest.raises(BeatportParseError, match="anti-bot"):
+            fetch_chart("https://www.beatport.com/chart/test/123")
+
+    @patch("djsupport.beatport.requests.get")
+    def test_redirect_to_non_chart_rejected(self, mock_get):
+        mock_get.return_value = self._mock_response(
+            "<html></html>",
+            url="https://www.beatport.com/login",
+        )
+        with pytest.raises(BeatportParseError, match="redirected"):
+            fetch_chart("https://www.beatport.com/chart/test/123")
+
+    @patch("djsupport.beatport.requests.get")
+    def test_response_too_large(self, mock_get):
+        mock = MagicMock()
+        # Simulate a response larger than MAX_RESPONSE_SIZE
+        mock.iter_content.return_value = [b"x" * (6 * 1024 * 1024)]
+        mock.encoding = "utf-8"
+        mock.url = "https://www.beatport.com/chart/test/123"
+        mock.raise_for_status = MagicMock()
+        mock.close = MagicMock()
+        mock_get.return_value = mock
+        with pytest.raises(BeatportParseError, match="too large"):
+            fetch_chart("https://www.beatport.com/chart/test/123")
+
+    @patch("djsupport.beatport.requests.get")
+    def test_successful_parse(self, mock_get):
+        chart_data = {
+            "props": {
+                "pageProps": {
+                    "chart": {"name": "Garage Go-Tos", "dj": {"name": "DJ Test"}},
+                    "dehydratedState": {
+                        "queries": [
+                            {
+                                "state": {
+                                    "data": {
+                                        "results": [
+                                            {
+                                                "id": 100,
+                                                "name": "Test Track",
+                                                "mix_name": "Original Mix",
+                                                "artists": [{"name": "Test Artist"}],
+                                                "release": {"name": "Test EP", "label": {"name": "Test Label"}},
+                                                "genre": {"name": "House"},
+                                                "length": "5:30",
+                                            }
+                                        ]
+                                    }
+                                }
+                            }
+                        ]
+                    },
+                }
+            }
+        }
+        html = f'<html><script id="__NEXT_DATA__" type="application/json">{json.dumps(chart_data)}</script></html>'
+        mock_get.return_value = self._mock_response(html)
+        name, curator, tracks = fetch_chart("https://www.beatport.com/chart/test/123")
+        assert name == "Garage Go-Tos"
+        assert curator == "DJ Test"
+        assert len(tracks) == 1
+        assert tracks[0].name == "Test Track"
+        assert tracks[0].artist == "Test Artist"
+        assert tracks[0].duration == 330

--- a/tests/test_matcher.py
+++ b/tests/test_matcher.py
@@ -383,9 +383,9 @@ class TestEarlyExit:
 
     def test_threshold_boundary_below_95_no_early_exit(self):
         """A score just below EARLY_EXIT_THRESHOLD should not trigger early exit."""
-        # Use a small duration mismatch to push score just below 95.
-        # Track: 300s, Result: 360s → 60s diff → 30s excess → 10 penalty → score ~90
-        sp = self._mock_sp([make_spotify_item("Vultora", "Solomun", "uri:1", duration_ms=360000)])
+        # Use a large duration mismatch to push score just below 95.
+        # Track: 300s, Result: 480s → 180s diff → 150s excess → 15 penalty (cap) → score ~85
+        sp = self._mock_sp([make_spotify_item("Vultora", "Solomun", "uri:1", duration_ms=480000)])
         track = make_track("Vultora (Original Mix)", "Solomun", duration=300)
         result = match_track(sp, track, threshold=80)
         assert result is not None
@@ -419,14 +419,14 @@ class TestDurationPenalty:
         assert _duration_penalty(300, 330000) == 0.0
 
     def test_penalty_beyond_30s(self):
-        # 60s diff = 30s excess -> 10 points
+        # 60s diff = 30s excess -> 5 points
         penalty = _duration_penalty(300, 360000)
-        assert penalty == pytest.approx(10.0)
+        assert penalty == pytest.approx(5.0)
 
-    def test_penalty_capped_at_30(self):
+    def test_penalty_capped_at_15(self):
         # 300s diff -> way beyond cap
         penalty = _duration_penalty(300, 600000)
-        assert penalty == 30.0
+        assert penalty == 15.0
 
     def test_duration_disambiguates_versions(self):
         """A track with known duration should score the closer-duration result higher."""

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -11,7 +11,7 @@ from djsupport.report import MatchedTrack, PlaylistReport, SyncReport, save_repo
 
 def _matched(name="Track A", spotify_name="Track A", artist="Artist", score=95.0, match_type="exact"):
     return MatchedTrack(
-        rekordbox_name=name,
+        source_name=name,
         spotify_name=spotify_name,
         spotify_artist=artist,
         score=score,
@@ -35,12 +35,12 @@ def _report(playlists=(), threshold=80, dry_run=True, cache_enabled=False):
 
 class TestMatchedTrack:
     def test_default_match_type_is_exact(self):
-        m = MatchedTrack(rekordbox_name="A", spotify_name="A", spotify_artist="X", score=90.0)
+        m = MatchedTrack(source_name="A", spotify_name="A", spotify_artist="X", score=90.0)
         assert m.match_type == "exact"
 
     def test_fallback_match_type(self):
         m = MatchedTrack(
-            rekordbox_name="A", spotify_name="A (Remix)", spotify_artist="X",
+            source_name="A", spotify_name="A (Remix)", spotify_artist="X",
             score=85.0, match_type="fallback_version",
         )
         assert m.match_type == "fallback_version"


### PR DESCRIPTION
## Summary
- New `djsupport beatport <url>` command that scrapes a Beatport DJ chart page and creates a Spotify playlist
- Scrapes __NEXT_DATA__ JSON from Beatport chart pages — no headless browser or BeautifulSoup needed
- Separate cache and state files, fully isolated from Rekordbox
- Preparatory refactoring: renamed Rekordbox-specific fields to source-agnostic names, extracted shared matching helper

### Security hardening
- HTTPS-only URL validation
- 5MB response size limit (streamed)
- Redirect validation (must stay on beatport.com/chart/)
- Anti-bot challenge detection with clear error messaging

### What's shared with Rekordbox
- Track dataclass, matcher.py (5-strategy fuzzy matching), spotify.py (playlist CRUD), report.py (terminal + Markdown reports)
- Shared _match_and_sync_playlist() helper eliminates ~80 lines of duplication

## Test plan
- [x] 216 tests pass (44 new Beatport tests + 172 existing)
- [x] URL validation: valid/invalid URLs, HTTPS enforcement, query param stripping
- [x] Duration parsing: M:SS, H:MM:SS, edge cases
- [x] Track parsing: basic tracks, remixes, missing/malformed artists, fallback IDs
- [x] Chart data extraction: metadata, track ordering, missing keys, empty queries
- [x] Fetch error handling: anti-bot detection, redirect rejection, oversized response
- [x] End-to-end fetch with mocked HTTP: successful parse returns correct chart name, curator, and tracks
- [ ] Manual test with a real Beatport chart URL (requires Spotify credentials)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
