### PR TITLE
feat: prepend Beatport chart curator to Spotify playlist names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Added
+
+- Beatport chart playlists now include the curator/DJ name — e.g. `"Adam Beyer - Tech House Vibes"` instead of just `"Tech House Vibes"`
+- `compose_chart_playlist_name()` helper in `beatport.py` for chart name composition (curator omitted when `"Unknown"`, empty, or `None`)
+
 ### Changed
 
 - FastAPI and uvicorn are now optional dependencies — install with `pip install djsupport[web]`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,7 +23,7 @@ djsupport/
   web.py        # FastAPI web backend (OAuth, sync endpoints, SSE progress)
   service.py    # Framework-agnostic sync orchestration (shared by CLI + web)
   rekordbox.py  # XML parser — Track and Playlist dataclasses
-  beatport.py   # Beatport chart scraper — __NEXT_DATA__ extraction
+  beatport.py   # Beatport chart scraper — __NEXT_DATA__ extraction, curator name composition
   label.py      # Beatport label scraper — paginated track fetching + label search
   matcher.py    # Fuzzy matching logic against Spotify search
   spotify.py    # Spotify client wrapper (spotipy + OAuth)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,9 @@
 # CLAUDE.md
 
+## Scope Guard
+- This repo is for djsupport only. Do NOT build Claude Code skills, slash commands, hooks, or other extensions here.
+- If the user asks to build something that is not djsupport-specific, STOP and redirect them to their dedicated Claude Code extensions workspace.
+
 ## Project overview
 
 djsupport syncs Rekordbox playlists, Beatport DJ charts, and Beatport record labels to Spotify. It parses a Rekordbox XML export, scrapes a Beatport chart or label page, fuzzy-matches tracks against Spotify's catalog, and creates/updates Spotify playlists.

--- a/djsupport/beatport.py
+++ b/djsupport/beatport.py
@@ -24,6 +24,13 @@ class InvalidBeatportURL(ValueError):
     """Raised when a URL is not a valid Beatport chart URL."""
 
 
+def compose_chart_playlist_name(chart_name: str, curator: str) -> str:
+    """Compose playlist name from chart name and curator."""
+    if curator and curator != "Unknown":
+        return f"{curator} - {chart_name}"
+    return chart_name
+
+
 def validate_url(url: str) -> str:
     """Validate and normalize a Beatport chart URL.
 

--- a/djsupport/beatport.py
+++ b/djsupport/beatport.py
@@ -24,7 +24,7 @@ class InvalidBeatportURL(ValueError):
     """Raised when a URL is not a valid Beatport chart URL."""
 
 
-def compose_chart_playlist_name(chart_name: str, curator: str) -> str:
+def compose_chart_playlist_name(chart_name: str, curator: str | None) -> str:
     """Compose playlist name from chart name and curator."""
     if curator and curator != "Unknown":
         return f"{curator} - {chart_name}"

--- a/djsupport/cli.py
+++ b/djsupport/cli.py
@@ -338,7 +338,7 @@ def beatport(
     """
     import requests
 
-    from djsupport.beatport import BeatportParseError, InvalidBeatportURL, fetch_chart, validate_url
+    from djsupport.beatport import BeatportParseError, InvalidBeatportURL, compose_chart_playlist_name, fetch_chart, validate_url
 
     try:
         url = validate_url(url)
@@ -359,6 +359,7 @@ def beatport(
         click.echo(f"Chart '{chart_name}' has no tracks.")
         return
 
+    playlist_name = compose_chart_playlist_name(chart_name, curator)
     click.echo(f"Chart: {chart_name} by {curator}. {len(tracks)} tracks.")
 
     # Initialize cache (separate from Rekordbox)
@@ -394,7 +395,7 @@ def beatport(
     try:
         pl_report = _cli_match_and_sync(
             tracks,
-            chart_name,
+            playlist_name,
             url,
             sp=sp,
             cache=cache,

--- a/djsupport/service.py
+++ b/djsupport/service.py
@@ -174,7 +174,7 @@ def sync_beatport_chart(
 
     Returns a SyncReport.  Raises RateLimitError on excessive rate limiting.
     """
-    from djsupport.beatport import fetch_chart, validate_url
+    from djsupport.beatport import compose_chart_playlist_name, fetch_chart, validate_url
 
     if on_progress:
         on_progress(ProgressEvent(phase="fetching", detail="Validating URL..."))
@@ -182,7 +182,8 @@ def sync_beatport_chart(
 
     if on_progress:
         on_progress(ProgressEvent(phase="fetching", detail="Fetching chart from Beatport..."))
-    chart_name, _curator, tracks = fetch_chart(url)
+    chart_name, curator, tracks = fetch_chart(url)
+    playlist_name = compose_chart_playlist_name(chart_name, curator)
 
     if not tracks:
         report = SyncReport(
@@ -190,7 +191,7 @@ def sync_beatport_chart(
             dry_run=dry_run, cache_enabled=cache is not None,
             source_label="Beatport",
         )
-        report.playlists.append(PlaylistReport(name=chart_name, path=url))
+        report.playlists.append(PlaylistReport(name=playlist_name, path=url))
         return report
 
     existing = get_user_playlists(sp) if not dry_run else None
@@ -202,7 +203,7 @@ def sync_beatport_chart(
     )
 
     pl_report = match_and_sync_playlist(
-        tracks, chart_name, url,
+        tracks, playlist_name, url,
         sp=sp, cache=cache, state_mgr=state_mgr,
         existing_playlists=existing, threshold=threshold,
         dry_run=dry_run, incremental=incremental,

--- a/docs/plans/2026-03-14-feat-beatport-chart-curator-in-playlist-name-plan.md
+++ b/docs/plans/2026-03-14-feat-beatport-chart-curator-in-playlist-name-plan.md
@@ -1,0 +1,117 @@
+---
+title: "feat: Prepend Beatport chart curator to Spotify playlist names"
+type: feat
+status: completed
+date: 2026-03-14
+---
+
+# feat: Prepend Beatport chart curator to Spotify playlist names
+
+## Overview
+
+Beatport chart playlists synced to Spotify are currently named only by chart name (e.g. "Tech House Vibes"). The curator/DJ who created the chart is already extracted from Beatport's `__NEXT_DATA__` JSON but explicitly discarded in both `cli.py` and `service.py`. This feature prepends the curator name so the Spotify playlist becomes `"Adam Beyer - Tech House Vibes"` (with prefix: `"djsupport / Adam Beyer - Tech House Vibes"`).
+
+**Scope:** Beatport charts only — label imports are not affected.
+
+## Problem Statement / Motivation
+
+When browsing Spotify playlists synced from Beatport, there's no way to tell who curated the chart. For DJs who follow specific artists' chart picks, the curator name is essential context. The data is already available — it's just being thrown away.
+
+## Proposed Solution
+
+1. Add a `compose_chart_playlist_name(chart_name, curator)` helper in `beatport.py`
+2. Use it in both `cli.py` and `service.py` call sites
+
+No state migration needed — existing Beatport playlists won't be re-synced. New syncs will use the curator-prefixed name going forward.
+
+### Name composition rules
+
+| Curator value | Result |
+|---|---|
+| `"Adam Beyer"` | `"Adam Beyer - Tech House Vibes"` |
+| `"Unknown"` | `"Tech House Vibes"` (omit curator) |
+| `""` or `None` | `"Tech House Vibes"` (omit curator) |
+
+## Technical Considerations
+
+### Cache keys — not affected
+
+Cache keys are based on `artist||title` of individual tracks (cache.py line 57), not playlist names. No impact.
+
+### State — no migration
+
+Existing Beatport chart state entries remain keyed under the old name. Re-syncing the same chart URL would create a new playlist under the curator-prefixed name. This is acceptable — no re-sync of existing charts is planned.
+
+## Acceptance Criteria
+
+- [x] Beatport chart playlists include curator in name: `"Curator - Chart Name"`
+- [x] Curator omitted when value is `"Unknown"`, empty, or `None`
+- [x] `--dry-run` shows the new name format
+- [x] Web UI sync produces the same curator-prefixed names
+- [x] Label imports are unaffected
+- [x] All existing tests pass; new tests cover name composition
+
+## Implementation
+
+### `djsupport/beatport.py` — add helper
+
+```python
+def compose_chart_playlist_name(chart_name: str, curator: str) -> str:
+    """Compose playlist name from chart name and curator."""
+    if curator and curator != "Unknown":
+        return f"{curator} - {chart_name}"
+    return chart_name
+```
+
+### `djsupport/service.py` — stop discarding curator (~line 185)
+
+```python
+# Before:
+chart_name, _curator, tracks = fetch_chart(url)
+
+# After:
+chart_name, curator, tracks = fetch_chart(url)
+playlist_name = compose_chart_playlist_name(chart_name, curator)
+```
+
+Pass `playlist_name` (instead of `chart_name`) to `match_and_sync_playlist()`.
+
+### `djsupport/cli.py` — compose name in CLI flow (~line 395)
+
+```python
+# Already has: chart_name, curator, tracks = fetch_chart(url)
+playlist_name = compose_chart_playlist_name(chart_name, curator)
+```
+
+Pass `playlist_name` to `_cli_match_and_sync()`. The display message at line 362 already shows `f"Chart: {chart_name} by {curator}"` — no change needed there.
+
+### Tests — `tests/test_beatport.py`
+
+```python
+def test_compose_chart_playlist_name_with_curator():
+    assert compose_chart_playlist_name("Vibes", "Adam Beyer") == "Adam Beyer - Vibes"
+
+def test_compose_chart_playlist_name_unknown_curator():
+    assert compose_chart_playlist_name("Vibes", "Unknown") == "Vibes"
+
+def test_compose_chart_playlist_name_empty_curator():
+    assert compose_chart_playlist_name("Vibes", "") == "Vibes"
+```
+
+## Files Changed
+
+| File | Change |
+|---|---|
+| `djsupport/beatport.py` | Add `compose_chart_playlist_name()` |
+| `djsupport/service.py` | Use curator in playlist name |
+| `djsupport/cli.py` | Use curator in playlist name |
+| `tests/test_beatport.py` | Tests for name composition |
+| `CLAUDE.md` | Document new naming convention |
+| `CHANGELOG.md` | Add entry under Unreleased |
+
+## Sources
+
+- Beatport `__NEXT_DATA__` curator extraction: `djsupport/beatport.py:127`
+- Curator discarded in service: `djsupport/service.py:185`
+- Curator displayed but unused in CLI: `djsupport/cli.py:350-362`
+- Playlist name formatting: `djsupport/spotify.py:130-134`

--- a/tests/test_beatport.py
+++ b/tests/test_beatport.py
@@ -6,6 +6,7 @@ import pytest
 from unittest.mock import patch, MagicMock
 
 from djsupport.beatport import (
+    compose_chart_playlist_name,
     validate_url,
     fetch_chart,
     _parse_chart_data,
@@ -15,6 +16,20 @@ from djsupport.beatport import (
     InvalidBeatportURL,
 )
 from djsupport.rekordbox import Track
+
+
+class TestComposeChartPlaylistName:
+    def test_with_curator(self):
+        assert compose_chart_playlist_name("Tech House Vibes", "Adam Beyer") == "Adam Beyer - Tech House Vibes"
+
+    def test_unknown_curator(self):
+        assert compose_chart_playlist_name("Vibes", "Unknown") == "Vibes"
+
+    def test_empty_curator(self):
+        assert compose_chart_playlist_name("Vibes", "") == "Vibes"
+
+    def test_none_curator(self):
+        assert compose_chart_playlist_name("Vibes", None) == "Vibes"
 
 
 class TestValidateUrl:


### PR DESCRIPTION
## Summary
- Beatport chart playlists now include the curator/DJ name in the Spotify playlist name (e.g. `"Adam Beyer - Tech House Vibes"` instead of just `"Tech House Vibes"`)
- Added `compose_chart_playlist_name()` helper in `beatport.py` — curator omitted when `"Unknown"`, empty, or `None`
- Both CLI (`cli.py`) and web UI (`service.py`) use the new composed name

## Testing
- 4 new tests for `compose_chart_playlist_name()` covering curator present, unknown, empty, and None cases
- All 326 existing tests pass — no regressions

## Post-Deploy Monitoring & Validation
- `No additional operational monitoring required: ` name composition is a pure string operation with no external dependencies or runtime risk

---

[![Compound Engineered](https://img.shields.io/badge/Compound-Engineered-6366f1)](https://github.com/EveryInc/compound-engineering-plugin) 🤖 Generated with [Claude Code](https://claude.com/claude-code)