### PR TITLE
fix: match co-credited remix artists

### DIFF
--- a/djsupport/matcher.py
+++ b/djsupport/matcher.py
@@ -83,11 +83,53 @@ def _is_named_variant(mix_descriptor: str | None) -> bool:
     return "original" not in mix_descriptor
 
 
+def _extract_remixer_identity(track: Track) -> str | None:
+    """Return a remixer named by source metadata or the title descriptor."""
+    if track.remixer:
+        return _normalize(track.remixer)
+
+    descriptor = _extract_mix_descriptor(track.name)
+    if not descriptor:
+        return None
+
+    remixer = re.sub(r"\s+(remix|edit)\b.*$", "", descriptor).strip()
+    generic_descriptors = {
+        "club", "extended", "instrumental", "original", "radio", "short",
+    }
+    if remixer in generic_descriptors:
+        return None
+    return remixer or None
+
+
+def _contains_artist_identity(artist_credits: str, identity: str) -> bool:
+    """Return whether normalized credits contain a complete artist identity."""
+    return bool(re.search(rf"(?<!\w){re.escape(identity)}(?!\w)", artist_credits))
+
+
+def _artist_score(track: Track, result: dict) -> tuple[float, str]:
+    """Score artist identity, recognizing an explicitly named co-credited remixer."""
+    source_artist = _normalize(track.artist)
+    result_artist = _normalize(result["artist"])
+    score = fuzz.token_sort_ratio(source_artist, result_artist)
+    remixer = _extract_remixer_identity(track)
+
+    if (
+        source_artist
+        and remixer
+        and _contains_artist_identity(result_artist, source_artist)
+        and _contains_artist_identity(result_artist, remixer)
+    ):
+        credited_artists = _normalize(f"{track.artist}, {remixer}")
+        boosted_score = fuzz.token_sort_ratio(credited_artists, result_artist)
+        if boosted_score > score:
+            return boosted_score, "original artist and named remixer co-credited"
+
+    return score, "source artist similarity"
+
+
 def _score_components(track: Track, result: dict) -> dict[str, float]:
     """Return matching score components for a Rekordbox/Spotify pair."""
-    artist_score = fuzz.token_sort_ratio(
-        _normalize(track.artist), _normalize(result["artist"])
-    )
+    artist_score, _artist_score_reason = _artist_score(track, result)
     norm_title = _normalize(track.name)
     norm_result = _normalize(result["name"])
     raw_title_score = fuzz.token_sort_ratio(norm_title, norm_result)
@@ -210,9 +252,15 @@ def _select_best(track: Track, results: list[dict], threshold: int) -> dict | No
     exact_candidates = [s for s in scored if s[4] == "exact"]
     exact_candidates.sort(key=lambda x: x[1], reverse=True)
     if exact_candidates:
-        best, best_score, _base_score, _components, _match_type = exact_candidates[0]
+        best, best_score, _base_score, components, _match_type = exact_candidates[0]
         if best_score >= threshold:
-            return {**best, "score": best_score, "match_type": "exact"}
+            _artist_score_value, artist_score_reason = _artist_score(track, best)
+            return {
+                **best,
+                "score": best_score,
+                "match_type": "exact",
+                "score_reasons": [artist_score_reason],
+            }
 
     # Second pass: fallback to a different version if the base track is strong.
     # This preserves the user's track intent in reporting while avoiding silent
@@ -226,7 +274,16 @@ def _select_best(track: Track, results: list[dict], threshold: int) -> dict | No
             and components["stripped_title_score"] >= 90
             and components["artist_score"] >= 70
         ):
-            return {**best, "score": base_score, "match_type": "fallback_version"}
+            _artist_score_value, artist_score_reason = _artist_score(track, best)
+            return {
+                **best,
+                "score": base_score,
+                "match_type": "fallback_version",
+                "score_reasons": [
+                    artist_score_reason,
+                    "fallback version",
+                ],
+            }
 
     return None
 

--- a/djsupport/report.py
+++ b/djsupport/report.py
@@ -11,6 +11,7 @@ class MatchedTrack:
     spotify_artist: str
     score: float
     match_type: str = "exact"
+    score_reasons: tuple[str, ...] = ()
 
 
 @dataclass
@@ -140,12 +141,13 @@ def save_report(report: SyncReport, path: str) -> None:
         lines.append("")
 
         if pl.matched:
-            lines.append(f"| {report.source_label} | Spotify Match | Score | Match Type |")
-            lines.append("|-----------|---------------|-------|------------|")
+            lines.append(f"| {report.source_label} | Spotify Match | Score | Match Type | Score Reasons |")
+            lines.append("|-----------|---------------|-------|------------|---------------|")
             for m in pl.matched:
+                reasons = "; ".join(m.score_reasons)
                 lines.append(
                     f"| {m.source_name} | {m.spotify_artist} - {m.spotify_name}"
-                    f" | {m.score:.1f} | {m.match_type} |"
+                    f" | {m.score:.1f} | {m.match_type} | {reasons} |"
                 )
             lines.append("")
 

--- a/djsupport/service.py
+++ b/djsupport/service.py
@@ -102,6 +102,7 @@ def match_and_sync_playlist(
                 spotify_artist=result["artist"],
                 score=result["score"],
                 match_type=result.get("match_type", "exact"),
+                score_reasons=tuple(result.get("score_reasons", ())),
             ))
         else:
             pl_report.unmatched.append(track.display)

--- a/tests/test_matcher.py
+++ b/tests/test_matcher.py
@@ -239,6 +239,95 @@ class TestMatchTrack:
         assert result["score"] >= 80
         assert result["match_type"] == "exact"
 
+    def test_matches_remix_when_spotify_co_credits_named_remixer(self):
+        sp = self._mock_sp([
+            make_spotify_item(
+                "The Hours - Allies for Everyone Remix",
+                "Balad, Allies for Everyone",
+                "spotify:track:remix",
+            )
+        ])
+        track = make_track("The Hours (Allies for Everyone Remix)", "Balad")
+
+        result = match_track(sp, track, threshold=80)
+
+        assert result is not None
+        assert result["uri"] == "spotify:track:remix"
+        assert result["score"] >= 80
+        assert result["match_type"] == "exact"
+        assert "original artist and named remixer co-credited" in result["score_reasons"]
+
+    def test_does_not_boost_unrelated_spotify_co_artists(self):
+        sp = self._mock_sp([
+            make_spotify_item(
+                "The Hours - Allies for Everyone Remix",
+                "Balad, Unrelated Singer, Random Ensemble",
+                "spotify:track:unrelated",
+            )
+        ])
+        track = make_track("The Hours (Allies for Everyone Remix)", "Balad")
+
+        assert match_track(sp, track, threshold=80) is None
+
+    def test_matches_co_credit_from_explicit_remixer_metadata(self):
+        sp = self._mock_sp([
+            make_spotify_item(
+                "Track - Club Remix",
+                "Original Artist, Known Remixer",
+                "spotify:track:metadata-remixer",
+            )
+        ])
+        track = make_track(
+            "Track (Club Remix)", "Original Artist", remixer="Known Remixer",
+        )
+
+        result = match_track(sp, track, threshold=80)
+
+        assert result is not None
+        assert result["uri"] == "spotify:track:metadata-remixer"
+        assert "original artist and named remixer co-credited" in result["score_reasons"]
+
+    def test_matches_co_credit_from_named_edit_descriptor(self):
+        sp = self._mock_sp([
+            make_spotify_item(
+                "Track - Known Artist Edit",
+                "Original Artist, Known Artist",
+                "spotify:track:named-edit",
+            )
+        ])
+        track = make_track("Track (Known Artist Edit)", "Original Artist")
+
+        result = match_track(sp, track, threshold=80)
+
+        assert result is not None
+        assert result["uri"] == "spotify:track:named-edit"
+        assert "original artist and named remixer co-credited" in result["score_reasons"]
+
+    @pytest.mark.parametrize("descriptor", ["Club Remix", "Extended Remix", "Radio Remix"])
+    def test_does_not_treat_generic_version_descriptor_as_remixer(self, descriptor):
+        sp = self._mock_sp([
+            make_spotify_item(
+                f"Track - {descriptor}",
+                f"Original Artist, {descriptor.removesuffix(' Remix')}",
+                "spotify:track:generic",
+            )
+        ])
+        track = make_track(f"Track ({descriptor})", "Original Artist")
+
+        assert match_track(sp, track, threshold=95) is None
+
+    def test_does_not_match_partial_artist_or_remixer_names(self):
+        sp = self._mock_sp([
+            make_spotify_item(
+                "Track - DJ Annex Remix",
+                "Joanne, DJ Annexed",
+                "spotify:track:partial-names",
+            )
+        ])
+        track = make_track("Track (DJ Annex Remix)", "Ann")
+
+        assert match_track(sp, track, threshold=80) is None
+
     def test_returns_none_when_no_results(self):
         sp = self._mock_sp([])
         track = make_track("Vultora", "Solomun")

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -9,13 +9,17 @@ import pytest
 from djsupport.report import MatchedTrack, PlaylistReport, SyncReport, save_report
 
 
-def _matched(name="Track A", spotify_name="Track A", artist="Artist", score=95.0, match_type="exact"):
+def _matched(
+    name="Track A", spotify_name="Track A", artist="Artist", score=95.0,
+    match_type="exact", score_reasons=(),
+):
     return MatchedTrack(
         source_name=name,
         spotify_name=spotify_name,
         spotify_artist=artist,
         score=score,
         match_type=match_type,
+        score_reasons=score_reasons,
     )
 
 
@@ -147,6 +151,20 @@ class TestSaveReport:
         save_report(r, path)
         content = (tmp_path / "report.md").read_text()
         assert "Obscure Track" in content
+
+    def test_file_explains_named_remixer_co_credit(self, tmp_path):
+        path = str(tmp_path / "report.md")
+        match = _matched(
+            name="Balad - The Hours (Allies for Everyone Remix)",
+            artist="Balad, Allies for Everyone",
+            score_reasons=("original artist and named remixer co-credited",),
+        )
+
+        save_report(_report(playlists=[_playlist(matched=[match])]), path)
+
+        assert "original artist and named remixer co-credited" in (
+            tmp_path / "report.md"
+        ).read_text()
 
     def test_dry_run_mode_label(self, tmp_path):
         path = str(tmp_path / "report.md")


### PR DESCRIPTION
Closes #30

## Summary
- recognize remixers credited alongside the primary artist
- expose matcher score reasons in reports
- add regression coverage for co-credited remix artists

## Verification
- 331 tests passed
- git diff --check passed