### PR TITLE
feat: preview Beatport charts through Transfer seam

### DIFF
--- a/djsupport/cache.py
+++ b/djsupport/cache.py
@@ -46,6 +46,7 @@ class MatchCache:
 
     def save(self) -> None:
         """Write cache to disk."""
+        self.path.parent.mkdir(parents=True, exist_ok=True)
         data = {
             "version": CACHE_VERSION,
             "entries": {k: asdict(v) for k, v in self.entries.items()},

--- a/djsupport/cli.py
+++ b/djsupport/cli.py
@@ -300,7 +300,10 @@ def list_playlists(xml_path: str | None):
         click.echo(f"  {pl.path} ({len(pl.track_ids)} tracks)")
 
 
-DEFAULT_BEATPORT_CACHE_PATH = ".djsupport_beatport_cache.json"
+from djsupport.transfer import default_matching_knowledge_path
+
+
+DEFAULT_BEATPORT_CACHE_PATH = str(default_matching_knowledge_path())
 DEFAULT_BEATPORT_STATE_PATH = ".djsupport_beatport_playlists.json"
 
 
@@ -338,7 +341,66 @@ def beatport(
     """
     import requests
 
-    from djsupport.beatport import BeatportParseError, InvalidBeatportURL, compose_chart_playlist_name, fetch_chart, validate_url
+    from djsupport.beatport import (
+        BeatportParseError,
+        InvalidBeatportURL,
+        compose_chart_playlist_name,
+        fetch_chart,
+        validate_url,
+    )
+
+    # Preview enters through the deep Transfer seam. It may retain matching
+    # knowledge, but the interface has no playlist publication/state adapter.
+    if dry_run:
+        from djsupport.cache import MatchCache
+        from djsupport.transfer import (
+            BeatportChartSource,
+            EphemeralMatchingKnowledge,
+            MatchCacheKnowledge,
+            SpotifyMatcher,
+            Transfer,
+            TransferRequest,
+        )
+
+        cache = None if no_cache else MatchCache(cache_path)
+        if cache is not None:
+            cache.load()
+        transfer = Transfer(
+            source=BeatportChartSource(),
+            spotify=SpotifyMatcher(get_client()),
+            matching_knowledge=(
+                EphemeralMatchingKnowledge()
+                if cache is None else MatchCacheKnowledge(cache)
+            ),
+        )
+        try:
+            report = transfer.execute(TransferRequest(
+                source=url,
+                preview=True,
+                threshold=threshold,
+                retry=retry,
+                retry_days=retry_days,
+            ))
+        except InvalidBeatportURL as e:
+            raise click.ClickException(str(e))
+        except BeatportParseError as e:
+            raise click.ClickException(str(e))
+        except requests.RequestException as e:
+            if (
+                hasattr(e, "response")
+                and e.response is not None
+                and e.response.status_code == 404
+            ):
+                raise click.ClickException("Chart not found — check the URL.")
+            raise click.ClickException(f"Failed to fetch chart: {e}")
+        except RateLimitError as e:
+            raise click.ClickException(str(e))
+
+        print_report(report)
+        if report_path:
+            save_report(report, report_path)
+            click.echo(f"\nDetailed report saved to {report_path}")
+        return
 
     try:
         url = validate_url(url)

--- a/djsupport/transfer.py
+++ b/djsupport/transfer.py
@@ -1,0 +1,234 @@
+"""Deep, framework-agnostic Transfer workflow.
+
+The public seam is :class:`Transfer.execute`: adapters describe what to
+transfer and receive a structured report, while this module owns matching,
+persistence ordering, and Preview's read-only publication policy.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+from typing import Protocol
+
+from djsupport.cache import MatchCache
+from djsupport.matcher import match_track
+from djsupport.rekordbox import Track
+from djsupport.report import MatchedTrack, PlaylistReport, SyncReport
+
+
+def default_matching_knowledge_path() -> Path:
+    """Return a private, user-local path outside the repository."""
+    if sys.platform == "darwin":
+        root = Path.home() / "Library" / "Application Support"
+    elif os.name == "nt":
+        root = Path(os.environ.get("LOCALAPPDATA", Path.home() / "AppData" / "Local"))
+    else:
+        root = Path(os.environ.get("XDG_DATA_HOME", Path.home() / ".local" / "share"))
+    return root / "djsupport" / "matching-knowledge.json"
+
+
+@dataclass(frozen=True)
+class TransferRequest:
+    """Everything an adapter must provide to start one Transfer."""
+
+    source: str
+    preview: bool = False
+    threshold: int = 80
+    retry: bool = False
+    retry_days: int = 7
+
+
+@dataclass(frozen=True)
+class SourceSelection:
+    """One named selection returned by a source adapter."""
+
+    name: str
+    reference: str
+    tracks: list[Track]
+
+
+class SourceAdapter(Protocol):
+    source_label: str
+
+    def consume(self, reference: str) -> SourceSelection: ...
+
+
+class SpotifyAdapter(Protocol):
+    def match(self, track: Track, threshold: int) -> dict | None: ...
+
+
+class MatchingKnowledge(Protocol):
+    def lookup(self, track: Track, threshold: int) -> dict | None: ...
+
+    def should_retry(
+        self, track: Track, threshold: int, retry_days: int, force: bool,
+    ) -> bool: ...
+
+    def retain(self, track: Track, threshold: int, result: dict | None) -> None: ...
+
+    def checkpoint(self) -> None: ...
+
+
+class BeatportChartSource:
+    """Production source adapter for one Beatport chart."""
+
+    source_label = "Beatport"
+
+    def consume(self, reference: str) -> SourceSelection:
+        from djsupport.beatport import (
+            compose_chart_playlist_name,
+            fetch_chart,
+            validate_url,
+        )
+
+        url = validate_url(reference)
+        chart_name, curator, tracks = fetch_chart(url)
+        return SourceSelection(
+            name=compose_chart_playlist_name(chart_name, curator),
+            reference=url,
+            tracks=tracks,
+        )
+
+
+class SpotifyMatcher:
+    """Production Spotify matching adapter."""
+
+    def __init__(self, client) -> None:
+        self._client = client
+
+    def match(self, track: Track, threshold: int) -> dict | None:
+        return match_track(self._client, track, threshold=threshold)
+
+
+class MatchCacheKnowledge:
+    """Expose the existing durable match cache as Transfer storage."""
+
+    persistent = True
+
+    def __init__(self, cache: MatchCache) -> None:
+        self._cache = cache
+
+    def lookup(self, track: Track, threshold: int) -> dict | None:
+        entry = self._cache.lookup(track.artist, track.name, threshold)
+        if entry is None or not entry.matched:
+            return None
+        return {
+            "uri": entry.spotify_uri,
+            "name": entry.spotify_name,
+            "artist": entry.spotify_artist,
+            "score": entry.score,
+            "match_type": entry.match_type or "exact",
+        }
+
+    def should_retry(
+        self, track: Track, threshold: int, retry_days: int, force: bool,
+    ) -> bool:
+        entry = self._cache.lookup(track.artist, track.name, threshold)
+        if entry is None:
+            return True
+        if entry.matched:
+            return False
+        return self._cache.is_retry_eligible(
+            track.artist, track.name, retry_days=retry_days, force=force,
+        )
+
+    def retain(self, track: Track, threshold: int, result: dict | None) -> None:
+        self._cache.store(track.artist, track.name, threshold, result)
+
+    def checkpoint(self) -> None:
+        self._cache.save()
+
+
+class EphemeralMatchingKnowledge:
+    """Non-persistent matching knowledge used for explicit ``--no-cache``."""
+
+    persistent = False
+
+    def lookup(self, track: Track, threshold: int) -> dict | None:
+        return None
+
+    def should_retry(
+        self, track: Track, threshold: int, retry_days: int, force: bool,
+    ) -> bool:
+        return True
+
+    def retain(self, track: Track, threshold: int, result: dict | None) -> None:
+        pass
+
+    def checkpoint(self) -> None:
+        pass
+
+
+class Transfer:
+    """Coordinate a Transfer through source, Spotify, and storage seams."""
+
+    def __init__(
+        self,
+        *,
+        source: SourceAdapter,
+        spotify: SpotifyAdapter,
+        matching_knowledge: MatchingKnowledge,
+    ) -> None:
+        self._source = source
+        self._spotify = spotify
+        self._knowledge = matching_knowledge
+
+    def execute(self, request: TransferRequest) -> SyncReport:
+        """Execute one Transfer and return its structured outcome.
+
+        This tracer-bullet implementation intentionally supports Preview only.
+        Publication will be added behind this same seam by later Transfer work.
+        """
+        if not request.preview:
+            raise ValueError("Publishing Transfers are not supported by this interface yet")
+
+        selection = self._source.consume(request.source)
+        playlist = PlaylistReport(
+            name=selection.name,
+            path=selection.reference,
+            action="preview",
+        )
+        report = SyncReport(
+            timestamp=datetime.now(),
+            threshold=request.threshold,
+            dry_run=True,
+            playlists=[playlist],
+            cache_enabled=getattr(self._knowledge, "persistent", True),
+            source_label=self._source.source_label,
+        )
+
+        try:
+            for track in selection.tracks:
+                result = self._knowledge.lookup(track, request.threshold)
+                if result is not None:
+                    playlist.cache_hits += 1
+                elif self._knowledge.should_retry(
+                    track, request.threshold, request.retry_days, request.retry,
+                ):
+                    result = self._spotify.match(track, request.threshold)
+                    playlist.api_lookups += 1
+                    self._knowledge.retain(track, request.threshold, result)
+                else:
+                    result = None
+                    playlist.cache_hits += 1
+
+                if result is None:
+                    playlist.unmatched.append(track.display)
+                else:
+                    playlist.matched.append(MatchedTrack(
+                        source_name=track.display,
+                        spotify_name=result["name"],
+                        spotify_artist=result["artist"],
+                        score=result["score"],
+                        match_type=result.get("match_type", "exact"),
+                    ))
+        finally:
+            # Matching discoveries survive an interrupted Preview. Playlist
+            # management storage is deliberately absent from this workflow.
+            self._knowledge.checkpoint()
+
+        return report

--- a/tests/fixtures/beatport_chart.json
+++ b/tests/fixtures/beatport_chart.json
@@ -1,0 +1,8 @@
+{
+  "name": "Fixture Chart by Fixture DJ",
+  "reference": "https://www.beatport.com/chart/fixture/14",
+  "tracks": [
+    {"track_id": "bp-1", "artist": "Known Artist", "name": "Known Track"},
+    {"track_id": "bp-2", "artist": "New Artist", "name": "New Track"}
+  ]
+}

--- a/tests/test_transfer.py
+++ b/tests/test_transfer.py
@@ -1,0 +1,148 @@
+"""Behavior tests at the public Transfer seam."""
+
+import json
+from datetime import datetime
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from click.testing import CliRunner
+
+from djsupport.cli import cli
+from djsupport.rekordbox import Track
+from djsupport.report import PlaylistReport, SyncReport
+from djsupport.transfer import SourceSelection, Transfer, TransferRequest
+
+
+class FixtureBeatportSource:
+    source_label = "Beatport"
+
+    def __init__(self, fixture: Path) -> None:
+        self.fixture = fixture
+
+    def consume(self, reference: str) -> SourceSelection:
+        data = json.loads(self.fixture.read_text())
+        tracks = [
+            Track(
+                track_id=item["track_id"], artist=item["artist"], name=item["name"],
+                album="", remixer="", label="", genre="", date_added="",
+            )
+            for item in data["tracks"]
+        ]
+        return SourceSelection(data["name"], data["reference"], tracks)
+
+
+class StatefulSpotify:
+    def __init__(self, matches=None) -> None:
+        self.matches = matches or {}
+        self.searches = []
+        self.playlists = {"existing": ["spotify:track:untouched"]}
+
+    def match(self, track, threshold):
+        self.searches.append((track.artist, track.name, threshold))
+        return self.matches.get((track.artist, track.name))
+
+
+class InMemoryStorage:
+    def __init__(self) -> None:
+        self.matches = {}
+        self.failures = set()
+        self.checkpoints = 0
+        self.playlist_state = {"must": "remain unchanged"}
+        self.playlist_writes = 0
+
+    def lookup(self, track, threshold):
+        result = self.matches.get((track.artist, track.name))
+        return result if result and result["score"] >= threshold else None
+
+    def should_retry(self, track, threshold, retry_days, force):
+        key = (track.artist, track.name)
+        return key not in self.failures or force
+
+    def retain(self, track, threshold, result):
+        key = (track.artist, track.name)
+        if result is None:
+            self.failures.add(key)
+        else:
+            self.matches[key] = result
+
+    def checkpoint(self):
+        self.checkpoints += 1
+
+
+FIXTURE = Path(__file__).parent / "fixtures" / "beatport_chart.json"
+
+
+def _match(uri, name, artist):
+    return {
+        "uri": uri, "name": name, "artist": artist,
+        "score": 96.0, "match_type": "exact",
+    }
+
+
+def test_preview_reuses_and_retains_matching_knowledge_without_playlist_writes():
+    source = FixtureBeatportSource(FIXTURE)
+    spotify = StatefulSpotify({
+        ("New Artist", "New Track"): _match(
+            "spotify:track:new", "New Track", "New Artist",
+        ),
+    })
+    storage = InMemoryStorage()
+    storage.matches[("Known Artist", "Known Track")] = _match(
+        "spotify:track:known", "Known Track", "Known Artist",
+    )
+    original_playlists = dict(spotify.playlists)
+    original_state = dict(storage.playlist_state)
+
+    report = Transfer(
+        source=source, spotify=spotify, matching_knowledge=storage,
+    ).execute(TransferRequest(source="fixture", preview=True))
+
+    playlist = report.playlists[0]
+    assert report.dry_run is True
+    assert playlist.action == "preview"
+    assert playlist.match_rate == 100.0
+    assert playlist.cache_hits == 1
+    assert playlist.api_lookups == 1
+    assert spotify.searches == [("New Artist", "New Track", 80)]
+    assert ("New Artist", "New Track") in storage.matches
+    assert storage.checkpoints == 1
+    assert spotify.playlists == original_playlists
+    assert storage.playlist_state == original_state
+    assert storage.playlist_writes == 0
+
+
+def test_preview_with_zero_acceptable_matches_succeeds_with_zero_percent():
+    spotify = StatefulSpotify()
+    storage = InMemoryStorage()
+
+    report = Transfer(
+        source=FixtureBeatportSource(FIXTURE),
+        spotify=spotify,
+        matching_knowledge=storage,
+    ).execute(TransferRequest(source="fixture", preview=True))
+
+    assert report.overall_match_rate == 0.0
+    assert report.total_matched == 0
+    assert report.total_unmatched == 2
+    assert storage.checkpoints == 1
+    assert spotify.playlists == {"existing": ["spotify:track:untouched"]}
+
+
+@patch("djsupport.transfer.Transfer.execute")
+@patch("djsupport.cli.get_client", return_value=MagicMock())
+def test_cli_beatport_dry_run_enters_transfer_interface(mock_client, execute):
+    execute.return_value = SyncReport(
+        timestamp=datetime.now(), threshold=80, dry_run=True,
+        playlists=[PlaylistReport(name="Fixture", path="fixture", action="preview")],
+        cache_enabled=True, source_label="Beatport",
+    )
+
+    result = CliRunner().invoke(cli, [
+        "beatport", "https://www.beatport.com/chart/fixture/14",
+        "--dry-run", "--cache-path", "preview-cache.json",
+    ])
+
+    assert result.exit_code == 0, result.output
+    request = execute.call_args.args[0]
+    assert request.preview is True
+    assert request.source == "https://www.beatport.com/chart/fixture/14"


### PR DESCRIPTION
Closes #14

> Stacked on #12. Merge #12 first, then retarget this PR to `main` if GitHub does not do so automatically.

## Summary
- add a deep `Transfer.execute()` Preview interface for Beatport charts
- route `djsupport beatport <url> --dry-run` through the Transfer module
- reuse retained matches and checkpoints while preventing playlist publication and playlist-state access
- return structured reports, including successful 0% match results
- store matching knowledge in the OS application-data directory
- add fixture-backed seam tests with stateful Spotify and in-memory storage adapters

## Verification
- 329 tests passed
- git diff --check passed