### PR TITLE
Publish distinct provisional Beatport snapshots

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -79,7 +79,7 @@ djsupport beatport <url> --no-cache                  # Bypass Beatport match cac
 djsupport beatport <url> --retry                     # Retry previously failed matches
 djsupport beatport <url> --retry-days 3              # Auto-retry failures older than N days (default 7)
 djsupport beatport <url> --cache-path my.json        # Custom Beatport cache file
-djsupport beatport <url> --state-path my.json        # Custom Beatport state file
+djsupport beatport <url> --state-path my.json        # Custom publication manifest file
 djsupport beatport <url> --prefix "dj"               # Prefix for playlist name
 djsupport beatport <url> --no-prefix                 # No prefix
 djsupport beatport <url> --report report.md          # Save Markdown report

--- a/djsupport/cli.py
+++ b/djsupport/cli.py
@@ -300,11 +300,14 @@ def list_playlists(xml_path: str | None):
         click.echo(f"  {pl.path} ({len(pl.track_ids)} tracks)")
 
 
-from djsupport.transfer import default_matching_knowledge_path
+from djsupport.transfer import (
+    default_matching_knowledge_path,
+    default_publication_manifest_path,
+)
 
 
 DEFAULT_BEATPORT_CACHE_PATH = str(default_matching_knowledge_path())
-DEFAULT_BEATPORT_STATE_PATH = ".djsupport_beatport_playlists.json"
+DEFAULT_BEATPORT_STATE_PATH = str(default_publication_manifest_path())
 
 
 @cli.command()
@@ -315,7 +318,10 @@ DEFAULT_BEATPORT_STATE_PATH = ".djsupport_beatport_playlists.json"
 @click.option("--retry", is_flag=True, help="Force retry all previously failed matches.")
 @click.option("--retry-days", default=7, show_default=True, help="Auto-retry failures older than N days.")
 @click.option("--cache-path", default=DEFAULT_BEATPORT_CACHE_PATH, show_default=True, help="Path to Beatport match cache.")
-@click.option("--state-path", default=DEFAULT_BEATPORT_STATE_PATH, show_default=True, help="Path to Beatport playlist state.")
+@click.option(
+    "--state-path", default=DEFAULT_BEATPORT_STATE_PATH, show_default=True,
+    help="Path to durable Beatport publication manifests.",
+)
 @click.option("--report", "report_path", type=click.Path(), default=None, help="Save Markdown report.")
 @click.option("--prefix", default="djsupport", show_default=True, help="Prefix for Spotify playlist name.")
 @click.option("--no-prefix", is_flag=True, help="Disable playlist name prefix.")
@@ -344,152 +350,56 @@ def beatport(
     from djsupport.beatport import (
         BeatportParseError,
         InvalidBeatportURL,
-        compose_chart_playlist_name,
-        fetch_chart,
-        validate_url,
     )
 
-    # Preview enters through the deep Transfer seam. It may retain matching
-    # knowledge, but the interface has no playlist publication/state adapter.
-    if dry_run:
-        from djsupport.cache import MatchCache
-        from djsupport.transfer import (
-            BeatportChartSource,
-            EphemeralMatchingKnowledge,
-            MatchCacheKnowledge,
-            SpotifyMatcher,
-            Transfer,
-            TransferRequest,
-        )
+    from djsupport.cache import MatchCache
+    from djsupport.transfer import (
+        BeatportChartSource,
+        EphemeralMatchingKnowledge,
+        FilePublicationStorage,
+        MatchCacheKnowledge,
+        SpotifyMatcher,
+        Transfer,
+        TransferRequest,
+    )
 
-        cache = None if no_cache else MatchCache(cache_path)
-        if cache is not None:
-            cache.load()
-        transfer = Transfer(
-            source=BeatportChartSource(),
-            spotify=SpotifyMatcher(get_client()),
-            matching_knowledge=(
-                EphemeralMatchingKnowledge()
-                if cache is None else MatchCacheKnowledge(cache)
-            ),
-        )
-        try:
-            report = transfer.execute(TransferRequest(
-                source=url,
-                preview=True,
-                threshold=threshold,
-                retry=retry,
-                retry_days=retry_days,
-            ))
-        except InvalidBeatportURL as e:
-            raise click.ClickException(str(e))
-        except BeatportParseError as e:
-            raise click.ClickException(str(e))
-        except requests.RequestException as e:
-            if (
-                hasattr(e, "response")
-                and e.response is not None
-                and e.response.status_code == 404
-            ):
-                raise click.ClickException("Chart not found — check the URL.")
-            raise click.ClickException(f"Failed to fetch chart: {e}")
-        except RateLimitError as e:
-            raise click.ClickException(str(e))
-
-        print_report(report)
-        if report_path:
-            save_report(report, report_path)
-            click.echo(f"\nDetailed report saved to {report_path}")
-        return
-
+    cache = None if no_cache else MatchCache(cache_path)
+    if cache is not None:
+        cache.load()
+    transfer = Transfer(
+        source=BeatportChartSource(),
+        spotify=SpotifyMatcher(get_client()),
+        matching_knowledge=(
+            EphemeralMatchingKnowledge()
+            if cache is None else MatchCacheKnowledge(cache)
+        ),
+        publication_storage=(
+            None if dry_run else FilePublicationStorage(state_path)
+        ),
+    )
     try:
-        url = validate_url(url)
+        report = transfer.execute(TransferRequest(
+            source=url,
+            preview=dry_run,
+            threshold=threshold,
+            retry=retry,
+            retry_days=retry_days,
+            playlist_prefix=None if no_prefix else prefix,
+        ))
     except InvalidBeatportURL as e:
         raise click.ClickException(str(e))
-
-    click.echo("Fetching chart from Beatport...")
-    try:
-        chart_name, curator, tracks = fetch_chart(url)
     except BeatportParseError as e:
         raise click.ClickException(str(e))
     except requests.RequestException as e:
-        if hasattr(e, "response") and e.response is not None and e.response.status_code == 404:
+        if (
+            hasattr(e, "response")
+            and e.response is not None
+            and e.response.status_code == 404
+        ):
             raise click.ClickException("Chart not found — check the URL.")
         raise click.ClickException(f"Failed to fetch chart: {e}")
-
-    if not tracks:
-        click.echo(f"Chart '{chart_name}' has no tracks.")
-        return
-
-    playlist_name = compose_chart_playlist_name(chart_name, curator)
-    click.echo(f"Chart: {chart_name} by {curator}. {len(tracks)} tracks.")
-
-    # Initialize cache (separate from Rekordbox)
-    cache = None
-    if not no_cache:
-        from djsupport.cache import MatchCache
-        cache = MatchCache(cache_path)
-        cache.load()
-        if cache.entries:
-            click.echo(f"Loaded {len(cache.entries)} cached Beatport matches from {cache_path}")
-
-    # Resolve prefix
-    actual_prefix = None if no_prefix else prefix
-
-    # Initialize Beatport-specific playlist state
-    from djsupport.state import PlaylistStateManager
-    state_mgr = PlaylistStateManager(state_path)
-    state_mgr.load()
-
-    # Spotify client
-    sp = get_client()
-    existing = get_user_playlists(sp) if not dry_run else None
-
-    # Match and sync via shared helper
-    report = SyncReport(
-        timestamp=datetime.now(),
-        threshold=threshold,
-        dry_run=dry_run,
-        cache_enabled=cache is not None,
-        source_label="Beatport",
-    )
-
-    try:
-        pl_report = _cli_match_and_sync(
-            tracks,
-            playlist_name,
-            url,
-            sp=sp,
-            cache=cache,
-            state_mgr=state_mgr,
-            existing_playlists=existing,
-            threshold=threshold,
-            dry_run=dry_run,
-            incremental=incremental,
-            prefix=actual_prefix,
-            retry_days=retry_days,
-            retry=retry,
-            source_type="beatport",
-        )
     except RateLimitError as e:
-        click.echo(f"\n{e}", err=True)
-        if cache is not None:
-            cache.save()
-            click.echo(f"Cache saved to {cache_path} ({len(cache.entries)} entries).", err=True)
-        print_report(report)
-        if report_path:
-            save_report(report, report_path)
-        sys.exit(1)
-
-    report.playlists.append(pl_report)
-
-    # Save cache
-    if cache is not None:
-        cache.save()
-
-    # Save state
-    if not dry_run:
-        state_mgr.save()
+        raise click.ClickException(str(e))
 
     print_report(report)
     if report_path:

--- a/djsupport/report.py
+++ b/djsupport/report.py
@@ -1,7 +1,13 @@
 """Post-sync report generation for terminal and Markdown output."""
 
+from __future__ import annotations
+
 from dataclasses import dataclass, field
 from datetime import datetime
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from djsupport.transfer import PublicationManifest
 
 
 @dataclass
@@ -21,6 +27,7 @@ class PlaylistReport:
     unmatched: list[str] = field(default_factory=list)
     action: str = "dry-run"  # "created", "updated", "unchanged", or "dry-run"
     spotify_playlist_id: str | None = None
+    publication_manifest: PublicationManifest | None = None
     cache_hits: int = 0
     api_lookups: int = 0
     retried: int = 0

--- a/djsupport/transfer.py
+++ b/djsupport/transfer.py
@@ -2,22 +2,27 @@
 
 The public seam is :class:`Transfer.execute`: adapters describe what to
 transfer and receive a structured report, while this module owns matching,
-persistence ordering, and Preview's read-only publication policy.
+persistence ordering, Preview policy, and Provisional Snapshot publication.
 """
 
 from __future__ import annotations
 
+import json
 import os
 import sys
-from dataclasses import dataclass
+from dataclasses import asdict, dataclass
 from datetime import datetime
 from pathlib import Path
 from typing import Protocol
+from uuid import uuid4
 
 from djsupport.cache import MatchCache
 from djsupport.matcher import match_track
 from djsupport.rekordbox import Track
 from djsupport.report import MatchedTrack, PlaylistReport, SyncReport
+
+
+PUBLICATION_MANIFEST_VERSION = 1
 
 
 def default_matching_knowledge_path() -> Path:
@@ -40,6 +45,7 @@ class TransferRequest:
     threshold: int = 80
     retry: bool = False
     retry_days: int = 7
+    playlist_prefix: str | None = "djsupport"
 
 
 @dataclass(frozen=True)
@@ -51,6 +57,33 @@ class SourceSelection:
     tracks: list[Track]
 
 
+@dataclass(frozen=True)
+class PublicationItem:
+    """One exact source-to-Spotify proposal published for review."""
+
+    source_track_id: str
+    source_name: str
+    source_artist: str
+    source_title: str
+    spotify_uri: str
+    spotify_name: str
+    spotify_artist: str
+    score: float
+    match_type: str
+
+
+@dataclass(frozen=True)
+class PublicationManifest:
+    """The durable facts needed to review one Provisional Playlist."""
+
+    spotify_playlist_id: str
+    spotify_playlist_name: str
+    source_label: str
+    source_reference: str
+    created_at: datetime
+    items: tuple[PublicationItem, ...]
+
+
 class SourceAdapter(Protocol):
     source_label: str
 
@@ -59,6 +92,53 @@ class SourceAdapter(Protocol):
 
 class SpotifyAdapter(Protocol):
     def match(self, track: Track, threshold: int) -> dict | None: ...
+
+    def publish_provisional_snapshot(
+        self, name: str, track_uris: list[str], description: str,
+    ) -> str: ...
+
+    def delete_provisional_snapshot(self, playlist_id: str) -> None: ...
+
+
+class PublicationStorage(Protocol):
+    def retain_publication(self, manifest: PublicationManifest) -> None: ...
+
+
+class FilePublicationStorage:
+    """Versioned, durable publication manifests for later review."""
+
+    def __init__(self, path: str | Path) -> None:
+        self.path = Path(path)
+        self.manifests: list[dict] = []
+        self.load()
+
+    def load(self) -> None:
+        if not self.path.exists():
+            return
+        try:
+            data = json.loads(self.path.read_text())
+        except (json.JSONDecodeError, OSError):
+            return
+        if data.get("version") != PUBLICATION_MANIFEST_VERSION:
+            return
+        self.manifests = data.get("manifests", [])
+
+    def retain_publication(self, manifest: PublicationManifest) -> None:
+        stored = asdict(manifest)
+        stored["created_at"] = manifest.created_at.isoformat()
+        next_manifests = [*self.manifests, stored]
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        temporary = self.path.with_suffix(f"{self.path.suffix}.tmp")
+        temporary.write_text(json.dumps({
+            "version": PUBLICATION_MANIFEST_VERSION,
+            "manifests": next_manifests,
+        }, indent=2))
+        os.replace(temporary, self.path)
+        self.manifests = next_manifests
+
+
+def default_publication_manifest_path() -> Path:
+    return default_matching_knowledge_path().with_name("publication-manifests.json")
 
 
 class MatchingKnowledge(Protocol):
@@ -95,13 +175,38 @@ class BeatportChartSource:
 
 
 class SpotifyMatcher:
-    """Production Spotify matching adapter."""
+    """Production Spotify matching and Snapshot publication adapter."""
 
     def __init__(self, client) -> None:
         self._client = client
 
     def match(self, track: Track, threshold: int) -> dict | None:
         return match_track(self._client, track, threshold=threshold)
+
+    def publish_provisional_snapshot(
+        self, name: str, track_uris: list[str], description: str,
+    ) -> str:
+        user_id = self._client.current_user()["id"]
+        playlist = self._client.user_playlist_create(
+            user_id, name, public=False, description=description,
+        )
+        playlist_id = playlist["id"]
+        try:
+            if track_uris:
+                self._client.playlist_replace_items(playlist_id, track_uris[:100])
+                for offset in range(100, len(track_uris), 100):
+                    self._client.playlist_add_items(
+                        playlist_id, track_uris[offset:offset + 100],
+                    )
+            else:
+                self._client.playlist_replace_items(playlist_id, [])
+        except Exception:
+            self.delete_provisional_snapshot(playlist_id)
+            raise
+        return playlist_id
+
+    def delete_provisional_snapshot(self, playlist_id: str) -> None:
+        self._client.current_user_unfollow_playlist(playlist_id)
 
 
 class MatchCacheKnowledge:
@@ -172,34 +277,38 @@ class Transfer:
         source: SourceAdapter,
         spotify: SpotifyAdapter,
         matching_knowledge: MatchingKnowledge,
+        publication_storage: PublicationStorage | None = None,
     ) -> None:
         self._source = source
         self._spotify = spotify
         self._knowledge = matching_knowledge
+        self._publication_storage = publication_storage
 
     def execute(self, request: TransferRequest) -> SyncReport:
         """Execute one Transfer and return its structured outcome.
 
-        This tracer-bullet implementation intentionally supports Preview only.
-        Publication will be added behind this same seam by later Transfer work.
+        Beatport publication creates a distinct Provisional Snapshot after the
+        complete selection has matched safely.
         """
-        if not request.preview:
-            raise ValueError("Publishing Transfers are not supported by this interface yet")
+        if not request.preview and self._publication_storage is None:
+            raise ValueError("Publishing Transfers require publication storage")
 
         selection = self._source.consume(request.source)
+        created_at = datetime.now()
         playlist = PlaylistReport(
             name=selection.name,
             path=selection.reference,
-            action="preview",
+            action="preview" if request.preview else "pending publication",
         )
         report = SyncReport(
-            timestamp=datetime.now(),
+            timestamp=created_at,
             threshold=request.threshold,
-            dry_run=True,
+            dry_run=request.preview,
             playlists=[playlist],
             cache_enabled=getattr(self._knowledge, "persistent", True),
             source_label=self._source.source_label,
         )
+        publication_items: list[PublicationItem] = []
 
         try:
             for track in selection.tracks:
@@ -219,16 +328,66 @@ class Transfer:
                 if result is None:
                     playlist.unmatched.append(track.display)
                 else:
-                    playlist.matched.append(MatchedTrack(
+                    matched_track = MatchedTrack(
                         source_name=track.display,
                         spotify_name=result["name"],
                         spotify_artist=result["artist"],
                         score=result["score"],
                         match_type=result.get("match_type", "exact"),
+                    )
+                    playlist.matched.append(matched_track)
+                    publication_items.append(PublicationItem(
+                        source_track_id=track.track_id,
+                        source_name=track.display,
+                        source_artist=track.artist,
+                        source_title=track.name,
+                        spotify_uri=result["uri"],
+                        spotify_name=matched_track.spotify_name,
+                        spotify_artist=matched_track.spotify_artist,
+                        score=matched_track.score,
+                        match_type=matched_track.match_type,
                     ))
+
+            if not request.preview and not selection.tracks:
+                playlist.action = "not published: empty source"
+            elif not request.preview and playlist.unmatched:
+                playlist.action = "not published: incomplete matching"
+            elif not request.preview:
+                discriminator = (
+                    f"{created_at:%Y-%m-%d %H%M%S} {uuid4().hex[:8]}"
+                )
+                snapshot_name = f"{selection.name} — {discriminator}"
+                if request.playlist_prefix:
+                    snapshot_name = f"{request.playlist_prefix} / {snapshot_name}"
+                description = (
+                    f"Provisional Snapshot from {self._source.source_label}: "
+                    f"{selection.reference}. Created {created_at.isoformat()}."
+                )
+                playlist_id = self._spotify.publish_provisional_snapshot(
+                    snapshot_name,
+                    [item.spotify_uri for item in publication_items],
+                    description,
+                )
+                manifest = PublicationManifest(
+                    spotify_playlist_id=playlist_id,
+                    spotify_playlist_name=snapshot_name,
+                    source_label=self._source.source_label,
+                    source_reference=selection.reference,
+                    created_at=created_at,
+                    items=tuple(publication_items),
+                )
+                assert self._publication_storage is not None
+                try:
+                    self._publication_storage.retain_publication(manifest)
+                except Exception:
+                    self._spotify.delete_provisional_snapshot(playlist_id)
+                    raise
+                playlist.name = snapshot_name
+                playlist.spotify_playlist_id = playlist_id
+                playlist.publication_manifest = manifest
+                playlist.action = "provisional snapshot created"
         finally:
-            # Matching discoveries survive an interrupted Preview. Playlist
-            # management storage is deliberately absent from this workflow.
+            # Matching discoveries survive interrupted matching or publication.
             self._knowledge.checkpoint()
 
         return report

--- a/tests/test_transfer.py
+++ b/tests/test_transfer.py
@@ -5,12 +5,19 @@ from datetime import datetime
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
+import pytest
+
 from click.testing import CliRunner
 
 from djsupport.cli import cli
 from djsupport.rekordbox import Track
 from djsupport.report import PlaylistReport, SyncReport
-from djsupport.transfer import SourceSelection, Transfer, TransferRequest
+from djsupport.transfer import (
+    FilePublicationStorage,
+    SourceSelection,
+    Transfer,
+    TransferRequest,
+)
 
 
 class FixtureBeatportSource:
@@ -37,6 +44,18 @@ class StatefulSpotify:
         self.searches = []
         self.playlists = {"existing": ["spotify:track:untouched"]}
 
+    def publish_provisional_snapshot(self, name, track_uris, description):
+        playlist_id = f"snapshot-{len(self.playlists)}"
+        self.playlists[playlist_id] = {
+            "name": name,
+            "tracks": list(track_uris),
+            "description": description,
+        }
+        return playlist_id
+
+    def delete_provisional_snapshot(self, playlist_id):
+        del self.playlists[playlist_id]
+
     def match(self, track, threshold):
         self.searches.append((track.artist, track.name, threshold))
         return self.matches.get((track.artist, track.name))
@@ -49,6 +68,7 @@ class InMemoryStorage:
         self.checkpoints = 0
         self.playlist_state = {"must": "remain unchanged"}
         self.playlist_writes = 0
+        self.publications = []
 
     def lookup(self, track, threshold):
         result = self.matches.get((track.artist, track.name))
@@ -67,6 +87,10 @@ class InMemoryStorage:
 
     def checkpoint(self):
         self.checkpoints += 1
+
+    def retain_publication(self, manifest):
+        self.publications.append(manifest)
+        self.playlist_writes += 1
 
 
 FIXTURE = Path(__file__).parent / "fixtures" / "beatport_chart.json"
@@ -128,21 +152,229 @@ def test_preview_with_zero_acceptable_matches_succeeds_with_zero_percent():
     assert spotify.playlists == {"existing": ["spotify:track:untouched"]}
 
 
-@patch("djsupport.transfer.Transfer.execute")
-@patch("djsupport.cli.get_client", return_value=MagicMock())
-def test_cli_beatport_dry_run_enters_transfer_interface(mock_client, execute):
-    execute.return_value = SyncReport(
-        timestamp=datetime.now(), threshold=80, dry_run=True,
-        playlists=[PlaylistReport(name="Fixture", path="fixture", action="preview")],
-        cache_enabled=True, source_label="Beatport",
-    )
+class TestSnapshotPublication:
 
-    result = CliRunner().invoke(cli, [
-        "beatport", "https://www.beatport.com/chart/fixture/14",
-        "--dry-run", "--cache-path", "preview-cache.json",
-    ])
+    def test_publish_creates_provisional_snapshot_and_exact_manifest_after_matching(self):
+        spotify = StatefulSpotify({
+            ("Known Artist", "Known Track"): _match(
+                "spotify:track:known", "Known Track", "Known Artist",
+            ),
+            ("New Artist", "New Track"): _match(
+                "spotify:track:new", "New Track", "New Artist",
+            ),
+        })
+        storage = InMemoryStorage()
 
-    assert result.exit_code == 0, result.output
-    request = execute.call_args.args[0]
-    assert request.preview is True
-    assert request.source == "https://www.beatport.com/chart/fixture/14"
+        report = Transfer(
+            source=FixtureBeatportSource(FIXTURE),
+            spotify=spotify,
+            matching_knowledge=storage,
+            publication_storage=storage,
+        ).execute(TransferRequest(source="fixture"))
+
+        playlist = report.playlists[0]
+        assert playlist.action == "provisional snapshot created"
+        assert playlist.spotify_playlist_id == "snapshot-1"
+        published = spotify.playlists["snapshot-1"]
+        assert published["tracks"] == ["spotify:track:known", "spotify:track:new"]
+        assert "Beatport" in published["description"]
+        assert "https://www.beatport.com/chart/fixture/14" in published["description"]
+        assert len(storage.publications) == 1
+        manifest = storage.publications[0]
+        assert manifest.spotify_playlist_id == "snapshot-1"
+        assert playlist.publication_manifest is manifest
+        assert manifest.source_label == "Beatport"
+        assert manifest.source_reference == "https://www.beatport.com/chart/fixture/14"
+        assert [item.spotify_uri for item in manifest.items] == [
+            "spotify:track:known", "spotify:track:new",
+        ]
+        assert [item.source_track_id for item in manifest.items] == ["bp-1", "bp-2"]
+        assert storage.checkpoints == 1
+
+
+    def test_repeated_snapshot_is_distinct_and_never_updates_previous_snapshot(self):
+        matches = {
+            ("Known Artist", "Known Track"): _match(
+                "spotify:track:known", "Known Track", "Known Artist",
+            ),
+            ("New Artist", "New Track"): _match(
+                "spotify:track:new", "New Track", "New Artist",
+            ),
+        }
+        spotify = StatefulSpotify(matches)
+        storage = InMemoryStorage()
+        transfer = Transfer(
+            source=FixtureBeatportSource(FIXTURE), spotify=spotify,
+            matching_knowledge=storage, publication_storage=storage,
+        )
+
+        first = transfer.execute(TransferRequest(source="fixture"))
+        first_id = first.playlists[0].spotify_playlist_id
+        first_snapshot = dict(spotify.playlists[first_id])
+        second = transfer.execute(TransferRequest(source="fixture"))
+        second_id = second.playlists[0].spotify_playlist_id
+
+        assert second_id != first_id
+        assert second.playlists[0].name != first.playlists[0].name
+        assert spotify.playlists[first_id] == first_snapshot
+        assert len(storage.publications) == 2
+
+
+    def test_matching_failure_checkpoints_knowledge_without_partial_publication(self):
+        class InterruptedSpotify(StatefulSpotify):
+            def match(self, track, threshold):
+                if track.track_id == "bp-2":
+                    raise RuntimeError("matching interrupted")
+                return _match("spotify:track:known", "Known Track", "Known Artist")
+
+        spotify = InterruptedSpotify()
+        storage = InMemoryStorage()
+
+        with pytest.raises(RuntimeError, match="matching interrupted"):
+            Transfer(
+                source=FixtureBeatportSource(FIXTURE), spotify=spotify,
+                matching_knowledge=storage, publication_storage=storage,
+            ).execute(TransferRequest(source="fixture"))
+
+        assert spotify.playlists == {"existing": ["spotify:track:untouched"]}
+        assert storage.publications == []
+        assert storage.checkpoints == 1
+
+
+    def test_incomplete_matching_does_not_publish_snapshot(self):
+        spotify = StatefulSpotify({
+            ("Known Artist", "Known Track"): _match(
+                "spotify:track:known", "Known Track", "Known Artist",
+            ),
+        })
+        storage = InMemoryStorage()
+
+        report = Transfer(
+            source=FixtureBeatportSource(FIXTURE), spotify=spotify,
+            matching_knowledge=storage, publication_storage=storage,
+        ).execute(TransferRequest(source="fixture"))
+
+        assert report.playlists[0].action == "not published: incomplete matching"
+        assert spotify.playlists == {"existing": ["spotify:track:untouched"]}
+        assert storage.publications == []
+
+    def test_empty_chart_does_not_publish_snapshot(self):
+        class EmptySource:
+            source_label = "Beatport"
+
+            def consume(self, reference):
+                return SourceSelection("Empty Chart", reference, [])
+
+        spotify = StatefulSpotify()
+        storage = InMemoryStorage()
+
+        report = Transfer(
+            source=EmptySource(), spotify=spotify,
+            matching_knowledge=storage, publication_storage=storage,
+        ).execute(TransferRequest(source="empty"))
+
+        assert report.playlists[0].action == "not published: empty source"
+        assert spotify.playlists == {"existing": ["spotify:track:untouched"]}
+        assert storage.publications == []
+
+
+    def test_publication_storage_failure_removes_provisional_playlist(self):
+        class FailingPublicationStorage(InMemoryStorage):
+            def retain_publication(self, manifest):
+                raise OSError("disk full")
+
+        matches = {
+            ("Known Artist", "Known Track"): _match(
+                "spotify:track:known", "Known Track", "Known Artist",
+            ),
+            ("New Artist", "New Track"): _match(
+                "spotify:track:new", "New Track", "New Artist",
+            ),
+        }
+        spotify = StatefulSpotify(matches)
+
+        with pytest.raises(OSError, match="disk full"):
+            Transfer(
+                source=FixtureBeatportSource(FIXTURE), spotify=spotify,
+                matching_knowledge=InMemoryStorage(),
+                publication_storage=FailingPublicationStorage(),
+            ).execute(TransferRequest(source="fixture"))
+
+        assert spotify.playlists == {"existing": ["spotify:track:untouched"]}
+
+
+    def test_file_publication_manifest_survives_reload_through_transfer(self, tmp_path):
+        matches = {
+            ("Known Artist", "Known Track"): _match(
+                "spotify:track:known", "Known Track", "Known Artist",
+            ),
+            ("New Artist", "New Track"): _match(
+                "spotify:track:new", "New Track", "New Artist",
+            ),
+        }
+        path = tmp_path / "publication-manifests.json"
+        storage = FilePublicationStorage(path)
+
+        report = Transfer(
+            source=FixtureBeatportSource(FIXTURE), spotify=StatefulSpotify(matches),
+            matching_knowledge=InMemoryStorage(), publication_storage=storage,
+        ).execute(TransferRequest(source="fixture"))
+
+        reloaded = FilePublicationStorage(path)
+        assert reloaded.manifests[0]["spotify_playlist_id"] == (
+            report.playlists[0].spotify_playlist_id
+        )
+        assert [item["source_track_id"] for item in reloaded.manifests[0]["items"]] == [
+            "bp-1", "bp-2",
+        ]
+
+
+
+class TestBeatportCliTransfer:
+
+    @patch("djsupport.transfer.Transfer.execute")
+    @patch("djsupport.cli.get_client", return_value=MagicMock())
+    def test_cli_beatport_dry_run_enters_transfer_interface(
+        self, mock_client, execute,
+    ):
+        execute.return_value = SyncReport(
+            timestamp=datetime.now(), threshold=80, dry_run=True,
+            playlists=[PlaylistReport(name="Fixture", path="fixture", action="preview")],
+            cache_enabled=True, source_label="Beatport",
+        )
+
+        result = CliRunner().invoke(cli, [
+            "beatport", "https://www.beatport.com/chart/fixture/14",
+            "--dry-run", "--cache-path", "preview-cache.json",
+        ])
+
+        assert result.exit_code == 0, result.output
+        request = execute.call_args.args[0]
+        assert request.preview is True
+        assert request.source == "https://www.beatport.com/chart/fixture/14"
+
+
+    @patch("djsupport.transfer.Transfer.execute")
+    @patch("djsupport.cli.get_client", return_value=MagicMock())
+    def test_cli_beatport_publish_enters_transfer_interface(
+        self, mock_client, execute, tmp_path,
+    ):
+        execute.return_value = SyncReport(
+            timestamp=datetime.now(), threshold=80, dry_run=False,
+            playlists=[PlaylistReport(
+                name="Fixture — unique", path="fixture",
+                action="provisional snapshot created",
+                spotify_playlist_id="snapshot-1",
+            )],
+            cache_enabled=False, source_label="Beatport",
+        )
+
+        result = CliRunner().invoke(cli, [
+            "beatport", "https://www.beatport.com/chart/fixture/14",
+            "--no-cache", "--state-path", str(tmp_path / "publications.json"),
+        ])
+
+        assert result.exit_code == 0, result.output
+        request = execute.call_args.args[0]
+        assert request.preview is False
+        assert request.source == "https://www.beatport.com/chart/fixture/14"


### PR DESCRIPTION
## Summary
- route live Beatport publication through the Transfer seam
- publish only fully matched charts as uniquely named Provisional Snapshots
- persist exact versioned publication manifests with source and creation metadata
- compensate failed publication/manifest writes without updating prior Snapshots

## Testing
- python3 -m compileall -q djsupport tests
- pytest (337 passed)

Closes #15