### PR TITLE
Pause and resume one durable Transfer

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -84,6 +84,8 @@ djsupport beatport <url> --prefix "dj"               # Prefix for playlist name
 djsupport beatport <url> --no-prefix                 # No prefix
 djsupport beatport <url> --report report.md          # Save Markdown report
 djsupport beatport <url> --incremental               # Incremental updates (default)
+djsupport beatport <url> --resume <transfer-id>      # Resume a paused Transfer
+djsupport beatport <url> --abandon <transfer-id>     # Explicitly abandon a Transfer
 
 # Label flags
 djsupport label <url>                                # Import by Beatport label URL

--- a/djsupport/cli.py
+++ b/djsupport/cli.py
@@ -357,6 +357,7 @@ def beatport(
         BeatportChartSource,
         EphemeralMatchingKnowledge,
         FilePublicationStorage,
+        FileTransferStorage,
         MatchCacheKnowledge,
         SpotifyMatcher,
         Transfer,
@@ -375,6 +376,9 @@ def beatport(
         ),
         publication_storage=(
             None if dry_run else FilePublicationStorage(state_path)
+        ),
+        transfer_storage=FileTransferStorage(
+            str(Path(state_path).with_suffix(".transfers.json"))
         ),
     )
     try:

--- a/djsupport/cli.py
+++ b/djsupport/cli.py
@@ -6,6 +6,7 @@ import sys
 from datetime import datetime
 from pathlib import Path
 from typing import TYPE_CHECKING
+from uuid import uuid4
 
 import click
 
@@ -326,6 +327,8 @@ DEFAULT_BEATPORT_STATE_PATH = str(default_publication_manifest_path())
 @click.option("--prefix", default="djsupport", show_default=True, help="Prefix for Spotify playlist name.")
 @click.option("--no-prefix", is_flag=True, help="Disable playlist name prefix.")
 @click.option("--incremental/--no-incremental", default=True, show_default=True, help="Use incremental playlist updates.")
+@click.option("--resume", "resume_id", default=None, help="Resume a durable Transfer ID.")
+@click.option("--abandon", "abandon_id", default=None, help="Explicitly abandon a durable Transfer ID.")
 def beatport(
     url: str,
     dry_run: bool,
@@ -339,6 +342,8 @@ def beatport(
     prefix: str,
     no_prefix: bool,
     incremental: bool,
+    resume_id: str | None,
+    abandon_id: str | None,
 ) -> None:
     """Create a Spotify playlist from a Beatport DJ chart.
 
@@ -367,6 +372,11 @@ def beatport(
     cache = None if no_cache else MatchCache(cache_path)
     if cache is not None:
         cache.load()
+    if resume_id and abandon_id:
+        raise click.UsageError("Use either --resume or --abandon, not both.")
+    transfer_storage = FileTransferStorage(
+        str(Path(state_path).with_suffix(".transfers.json"))
+    )
     transfer = Transfer(
         source=BeatportChartSource(),
         spotify=SpotifyMatcher(get_client()),
@@ -377,10 +387,16 @@ def beatport(
         publication_storage=(
             None if dry_run else FilePublicationStorage(state_path)
         ),
-        transfer_storage=FileTransferStorage(
-            str(Path(state_path).with_suffix(".transfers.json"))
-        ),
+        transfer_storage=transfer_storage,
     )
+    if abandon_id:
+        transfer.abandon(abandon_id)
+        click.echo(f"Transfer {abandon_id} abandoned.")
+        return
+    if resume_id and transfer_storage.load_transfer(resume_id) is None:
+        raise click.ClickException(f"Unknown Transfer: {resume_id}")
+    transfer_id = resume_id or uuid4().hex
+    click.echo(f"Transfer ID: {transfer_id}")
     try:
         report = transfer.execute(TransferRequest(
             source=url,
@@ -389,6 +405,7 @@ def beatport(
             retry=retry,
             retry_days=retry_days,
             playlist_prefix=None if no_prefix else prefix,
+            transfer_id=transfer_id,
         ))
     except InvalidBeatportURL as e:
         raise click.ClickException(str(e))

--- a/djsupport/report.py
+++ b/djsupport/report.py
@@ -49,6 +49,8 @@ class SyncReport:
     playlists: list[PlaylistReport] = field(default_factory=list)
     cache_enabled: bool = False
     source_label: str = "Rekordbox"
+    transfer_id: str | None = None
+    status: str = "completed"
 
     @property
     def total_matched(self) -> int:

--- a/djsupport/report.py
+++ b/djsupport/report.py
@@ -77,6 +77,8 @@ def print_report(report: SyncReport) -> None:
     click.echo("\u2550" * 42)
     click.echo(f"  Sync Report  {ts}")
     click.echo(f"  Mode: {mode}  |  Threshold: {report.threshold}")
+    if report.transfer_id:
+        click.echo(f"  Transfer: {report.transfer_id}  |  Status: {report.status}")
     click.echo("\u2550" * 42)
 
     for pl in report.playlists:
@@ -128,6 +130,8 @@ def save_report(report: SyncReport, path: str) -> None:
     lines.append(f"# Sync Report — {ts}")
     lines.append("")
     lines.append(f"**Mode:** {mode}  |  **Threshold:** {report.threshold}")
+    if report.transfer_id:
+        lines.append(f"**Transfer:** {report.transfer_id}  |  **Status:** {report.status}")
     lines.append("")
 
     for pl in report.playlists:

--- a/djsupport/transfer.py
+++ b/djsupport/transfer.py
@@ -12,6 +12,7 @@ import os
 import sys
 from dataclasses import asdict, dataclass
 from datetime import datetime
+from enum import Enum
 from pathlib import Path
 from typing import Protocol
 from uuid import uuid4
@@ -48,6 +49,38 @@ class TransferRequest:
     retry_days: int = 7
     playlist_prefix: str | None = "djsupport"
     transfer_id: str | None = None
+
+
+class TransferStatus(str, Enum):
+    MATCHING = "matching"
+    PAUSED = "paused"
+    RETAINING_PUBLICATION = "retaining publication"
+    COMPLETED = "completed"
+    ABANDONED = "abandoned"
+
+
+@dataclass
+class TransferState:
+    """Mutable, versioned checkpoint for one durable Transfer."""
+
+    status: TransferStatus
+    source: str
+    account_id: str
+    request: dict
+    selection: dict
+    created_at: str
+    next_track_index: int
+    matched: list[dict]
+    unmatched: list[str]
+    publication_items: list[dict]
+    spotify_playlist_id: str | None = None
+    spotify_playlist_name: str | None = None
+    publication_manifest: dict | None = None
+    outcome: str | None = None
+
+    @classmethod
+    def from_dict(cls, value: dict) -> TransferState:
+        return cls(**{**value, "status": TransferStatus(value["status"])})
 
 
 @dataclass(frozen=True)
@@ -93,10 +126,13 @@ class SourceAdapter(Protocol):
 
 
 class SpotifyAdapter(Protocol):
+    def account_id(self) -> str: ...
+
     def match(self, track: Track, threshold: int) -> dict | None: ...
 
     def publish_provisional_snapshot(
         self, name: str, track_uris: list[str], description: str,
+        publication_key: str,
     ) -> str: ...
 
     def delete_provisional_snapshot(self, playlist_id: str) -> None: ...
@@ -128,7 +164,11 @@ class FilePublicationStorage:
     def retain_publication(self, manifest: PublicationManifest) -> None:
         stored = asdict(manifest)
         stored["created_at"] = manifest.created_at.isoformat()
-        next_manifests = [*self.manifests, stored]
+        next_manifests = [
+            item for item in self.manifests
+            if item.get("spotify_playlist_id") != manifest.spotify_playlist_id
+        ]
+        next_manifests.append(stored)
         self.path.parent.mkdir(parents=True, exist_ok=True)
         temporary = self.path.with_suffix(f"{self.path.suffix}.tmp")
         temporary.write_text(json.dumps({
@@ -140,9 +180,9 @@ class FilePublicationStorage:
 
 
 class TransferStorage(Protocol):
-    def load_transfer(self, transfer_id: str) -> dict | None: ...
+    def load_transfer(self, transfer_id: str) -> TransferState | None: ...
 
-    def save_transfer(self, transfer_id: str, state: dict) -> None: ...
+    def save_transfer(self, transfer_id: str, state: TransferState) -> None: ...
 
 
 class FileTransferStorage:
@@ -150,7 +190,7 @@ class FileTransferStorage:
 
     def __init__(self, path: str | Path) -> None:
         self.path = Path(path)
-        self.transfers: dict[str, dict] = {}
+        self.transfers: dict[str, TransferState] = {}
         self._load()
 
     def _load(self) -> None:
@@ -161,19 +201,24 @@ class FileTransferStorage:
         except (json.JSONDecodeError, OSError):
             return
         if data.get("version") == TRANSFER_STATE_VERSION:
-            self.transfers = data.get("transfers", {})
+            for transfer_id, state in data.get("transfers", {}).items():
+                try:
+                    self.transfers[transfer_id] = TransferState.from_dict(state)
+                except (KeyError, TypeError, ValueError):
+                    continue
 
-    def load_transfer(self, transfer_id: str) -> dict | None:
-        state = self.transfers.get(transfer_id)
-        return None if state is None else dict(state)
+    def load_transfer(self, transfer_id: str) -> TransferState | None:
+        return self.transfers.get(transfer_id)
 
-    def save_transfer(self, transfer_id: str, state: dict) -> None:
+    def save_transfer(self, transfer_id: str, state: TransferState) -> None:
         next_transfers = {**self.transfers, transfer_id: state}
         self.path.parent.mkdir(parents=True, exist_ok=True)
         temporary = self.path.with_suffix(f"{self.path.suffix}.tmp")
         temporary.write_text(json.dumps({
             "version": TRANSFER_STATE_VERSION,
-            "transfers": next_transfers,
+            "transfers": {
+                key: asdict(transfer) for key, transfer in next_transfers.items()
+            },
         }, indent=2))
         os.replace(temporary, self.path)
         self.transfers = next_transfers
@@ -222,17 +267,24 @@ class SpotifyMatcher:
     def __init__(self, client) -> None:
         self._client = client
 
+    def account_id(self) -> str:
+        return self._client.current_user()["id"]
+
     def match(self, track: Track, threshold: int) -> dict | None:
         return match_track(self._client, track, threshold=threshold)
 
     def publish_provisional_snapshot(
         self, name: str, track_uris: list[str], description: str,
+        publication_key: str,
     ) -> str:
-        user_id = self._client.current_user()["id"]
-        playlist = self._client.user_playlist_create(
-            user_id, name, public=False, description=description,
-        )
-        playlist_id = playlist["id"]
+        marker = f"djsupport-transfer:{publication_key}"
+        description = f"{description} {marker}"
+        playlist_id = self._find_publication(marker)
+        if playlist_id is None:
+            playlist = self._client.user_playlist_create(
+                self.account_id(), name, public=False, description=description,
+            )
+            playlist_id = playlist["id"]
         try:
             if track_uris:
                 self._client.playlist_replace_items(playlist_id, track_uris[:100])
@@ -246,6 +298,17 @@ class SpotifyMatcher:
             self.delete_provisional_snapshot(playlist_id)
             raise
         return playlist_id
+
+    def _find_publication(self, marker: str) -> str | None:
+        page = self._client.current_user_playlists(limit=50)
+        while page:
+            for playlist in page.get("items", []):
+                if marker in (playlist.get("description") or ""):
+                    return playlist["id"]
+            if not page.get("next"):
+                break
+            page = self._client.next(page)
+        return None
 
     def delete_provisional_snapshot(self, playlist_id: str) -> None:
         self._client.current_user_unfollow_playlist(playlist_id)
@@ -340,9 +403,9 @@ class Transfer:
         state = self._transfer_storage.load_transfer(transfer_id)
         if state is None:
             raise ValueError(f"Unknown Transfer: {transfer_id}")
-        if state["status"] == "completed":
+        if state.status == TransferStatus.COMPLETED:
             raise ValueError("A completed Transfer cannot be abandoned")
-        state["status"] = "abandoned"
+        state.status = TransferStatus.ABANDONED
         self._transfer_storage.save_transfer(transfer_id, state)
 
     def execute(self, request: TransferRequest) -> SyncReport:
@@ -359,16 +422,14 @@ class Transfer:
             self._transfer_storage.load_transfer(transfer_id)
             if self._transfer_storage is not None else None
         )
-        if request.transfer_id and state is None:
-            raise ValueError(f"Unknown Transfer: {transfer_id}")
-
         if state is None:
             selection = self._source.consume(request.source)
             created_at = datetime.now()
-            state = {
-                "status": "matching",
-                "source": request.source,
-                "request": {
+            state = TransferState(
+                status=TransferStatus.MATCHING,
+                source=request.source,
+                account_id=self._spotify.account_id(),
+                request={
                     "source": request.source,
                     "preview": request.preview,
                     "threshold": request.threshold,
@@ -376,32 +437,34 @@ class Transfer:
                     "retry_days": request.retry_days,
                     "playlist_prefix": request.playlist_prefix,
                 },
-                "selection": {
+                selection={
                     "name": selection.name,
                     "reference": selection.reference,
                     "tracks": [asdict(track) for track in selection.tracks],
                 },
-                "created_at": created_at.isoformat(),
-                "next_track_index": 0,
-                "matched": [],
-                "unmatched": [],
-                "publication_items": [],
-            }
+                created_at=created_at.isoformat(),
+                next_track_index=0,
+                matched=[],
+                unmatched=[],
+                publication_items=[],
+            )
             self._save_transfer(transfer_id, state)
         else:
-            if state["status"] == "abandoned":
+            if state.status == TransferStatus.ABANDONED:
                 raise ValueError(f"Transfer {transfer_id} was abandoned")
-            if state["source"] != request.source:
+            if state.source != request.source:
                 raise ValueError("A resumed Transfer must use its original source")
+            if state.account_id != self._spotify.account_id():
+                raise ValueError("A Transfer cannot resume under another Spotify account")
             request = TransferRequest(
-                **state["request"], transfer_id=transfer_id,
+                **state.request, transfer_id=transfer_id,
             )
-            stored_selection = state["selection"]
+            stored_selection = state.selection
             selection = SourceSelection(
                 stored_selection["name"], stored_selection["reference"],
                 [Track(**track) for track in stored_selection["tracks"]],
             )
-            created_at = datetime.fromisoformat(state["created_at"])
+            created_at = datetime.fromisoformat(state.created_at)
 
         playlist = PlaylistReport(
             name=selection.name,
@@ -416,19 +479,33 @@ class Transfer:
             cache_enabled=getattr(self._knowledge, "persistent", True),
             source_label=self._source.source_label,
             transfer_id=transfer_id,
-            status=state["status"],
+            status=state.status.value,
         )
-        playlist.matched = [MatchedTrack(**item) for item in state["matched"]]
-        playlist.unmatched = list(state["unmatched"])
+        playlist.matched = [MatchedTrack(**item) for item in state.matched]
+        playlist.unmatched = list(state.unmatched)
         publication_items = [
-            PublicationItem(**item) for item in state["publication_items"]
+            PublicationItem(**item) for item in state.publication_items
         ]
-        if state["status"] == "completed":
+        if state.status == TransferStatus.COMPLETED:
             report.status = "completed"
-            if state.get("spotify_playlist_id"):
-                playlist.name = state["spotify_playlist_name"]
-                playlist.spotify_playlist_id = state["spotify_playlist_id"]
+            if state.spotify_playlist_id:
+                playlist.name = state.spotify_playlist_name or playlist.name
+                playlist.spotify_playlist_id = state.spotify_playlist_id
                 playlist.action = "provisional snapshot created"
+                stored_manifest = state.publication_manifest
+                if stored_manifest:
+                    playlist.publication_manifest = PublicationManifest(
+                        **{
+                            **stored_manifest,
+                            "created_at": datetime.fromisoformat(
+                                stored_manifest["created_at"]
+                            ),
+                            "items": tuple(
+                                PublicationItem(**item)
+                                for item in stored_manifest["items"]
+                            ),
+                        }
+                    )
             elif not request.preview and not selection.tracks:
                 playlist.action = "not published: empty source"
             elif not request.preview and playlist.unmatched:
@@ -436,7 +513,7 @@ class Transfer:
             return report
 
         try:
-            for index in range(state["next_track_index"], len(selection.tracks)):
+            for index in range(state.next_track_index, len(selection.tracks)):
                 track = selection.tracks[index]
                 result = self._knowledge.lookup(track, request.threshold)
                 if result is not None:
@@ -474,15 +551,15 @@ class Transfer:
                         match_type=matched_track.match_type,
                     ))
 
-                state["next_track_index"] = index + 1
-                state["matched"] = [asdict(item) for item in playlist.matched]
-                state["unmatched"] = list(playlist.unmatched)
-                state["publication_items"] = [
+                state.next_track_index = index + 1
+                state.matched = [asdict(item) for item in playlist.matched]
+                state.unmatched = list(playlist.unmatched)
+                state.publication_items = [
                     asdict(item) for item in publication_items
                 ]
                 self._knowledge.checkpoint()
                 if self._pause_requested:
-                    state["status"] = "paused"
+                    state.status = TransferStatus.PAUSED
                     self._save_transfer(transfer_id, state)
                     self._pause_requested = False
                     playlist.action = "paused"
@@ -495,8 +572,8 @@ class Transfer:
             elif not request.preview and playlist.unmatched:
                 playlist.action = "not published: incomplete matching"
             elif not request.preview:
-                playlist_id = state.get("spotify_playlist_id")
-                snapshot_name = state.get("spotify_playlist_name")
+                playlist_id = state.spotify_playlist_id
+                snapshot_name = state.spotify_playlist_name
                 if playlist_id is None:
                     discriminator = (
                         f"{created_at:%Y-%m-%d %H%M%S} {uuid4().hex[:8]}"
@@ -512,11 +589,21 @@ class Transfer:
                         snapshot_name,
                         [item.spotify_uri for item in publication_items],
                         description,
+                        transfer_id,
                     )
-                    state["spotify_playlist_id"] = playlist_id
-                    state["spotify_playlist_name"] = snapshot_name
-                    state["status"] = "retaining publication"
+                    state.spotify_playlist_id = playlist_id
+                    state.spotify_playlist_name = snapshot_name
+                    state.status = TransferStatus.RETAINING_PUBLICATION
                     self._save_transfer(transfer_id, state)
+                    if self._pause_requested:
+                        self._pause_requested = False
+                        state.status = TransferStatus.PAUSED
+                        self._save_transfer(transfer_id, state)
+                        playlist.name = snapshot_name
+                        playlist.spotify_playlist_id = playlist_id
+                        playlist.action = "paused"
+                        report.status = "paused"
+                        return report
                 assert snapshot_name is not None
                 manifest = PublicationManifest(
                     spotify_playlist_id=playlist_id,
@@ -526,25 +613,30 @@ class Transfer:
                     created_at=created_at,
                     items=tuple(publication_items),
                 )
+                stored_manifest = asdict(manifest)
+                stored_manifest["created_at"] = manifest.created_at.isoformat()
+                state.publication_manifest = stored_manifest
+                self._save_transfer(transfer_id, state)
                 assert self._publication_storage is not None
                 try:
                     self._publication_storage.retain_publication(manifest)
                 except Exception:
                     self._spotify.delete_provisional_snapshot(playlist_id)
-                    state.pop("spotify_playlist_id", None)
-                    state.pop("spotify_playlist_name", None)
-                    state["status"] = "matching"
+                    state.spotify_playlist_id = None
+                    state.spotify_playlist_name = None
+                    state.status = TransferStatus.MATCHING
                     self._save_transfer(transfer_id, state)
                     raise
                 playlist.name = snapshot_name
                 playlist.spotify_playlist_id = playlist_id
                 playlist.publication_manifest = manifest
                 playlist.action = "provisional snapshot created"
-            state["status"] = "completed"
+            state.outcome = playlist.action
+            state.status = TransferStatus.COMPLETED
             self._save_transfer(transfer_id, state)
             report.status = "completed"
         except KeyboardInterrupt:
-            state["status"] = "paused"
+            state.status = TransferStatus.PAUSED
             self._save_transfer(transfer_id, state)
             raise
         finally:
@@ -553,6 +645,6 @@ class Transfer:
 
         return report
 
-    def _save_transfer(self, transfer_id: str, state: dict) -> None:
+    def _save_transfer(self, transfer_id: str, state: TransferState) -> None:
         if self._transfer_storage is not None:
             self._transfer_storage.save_transfer(transfer_id, state)

--- a/djsupport/transfer.py
+++ b/djsupport/transfer.py
@@ -23,6 +23,7 @@ from djsupport.report import MatchedTrack, PlaylistReport, SyncReport
 
 
 PUBLICATION_MANIFEST_VERSION = 1
+TRANSFER_STATE_VERSION = 1
 
 
 def default_matching_knowledge_path() -> Path:
@@ -46,6 +47,7 @@ class TransferRequest:
     retry: bool = False
     retry_days: int = 7
     playlist_prefix: str | None = "djsupport"
+    transfer_id: str | None = None
 
 
 @dataclass(frozen=True)
@@ -135,6 +137,46 @@ class FilePublicationStorage:
         }, indent=2))
         os.replace(temporary, self.path)
         self.manifests = next_manifests
+
+
+class TransferStorage(Protocol):
+    def load_transfer(self, transfer_id: str) -> dict | None: ...
+
+    def save_transfer(self, transfer_id: str, state: dict) -> None: ...
+
+
+class FileTransferStorage:
+    """Atomically persisted, versioned state for resumable Transfers."""
+
+    def __init__(self, path: str | Path) -> None:
+        self.path = Path(path)
+        self.transfers: dict[str, dict] = {}
+        self._load()
+
+    def _load(self) -> None:
+        if not self.path.exists():
+            return
+        try:
+            data = json.loads(self.path.read_text())
+        except (json.JSONDecodeError, OSError):
+            return
+        if data.get("version") == TRANSFER_STATE_VERSION:
+            self.transfers = data.get("transfers", {})
+
+    def load_transfer(self, transfer_id: str) -> dict | None:
+        state = self.transfers.get(transfer_id)
+        return None if state is None else dict(state)
+
+    def save_transfer(self, transfer_id: str, state: dict) -> None:
+        next_transfers = {**self.transfers, transfer_id: state}
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        temporary = self.path.with_suffix(f"{self.path.suffix}.tmp")
+        temporary.write_text(json.dumps({
+            "version": TRANSFER_STATE_VERSION,
+            "transfers": next_transfers,
+        }, indent=2))
+        os.replace(temporary, self.path)
+        self.transfers = next_transfers
 
 
 def default_publication_manifest_path() -> Path:
@@ -278,11 +320,30 @@ class Transfer:
         spotify: SpotifyAdapter,
         matching_knowledge: MatchingKnowledge,
         publication_storage: PublicationStorage | None = None,
+        transfer_storage: TransferStorage | None = None,
     ) -> None:
         self._source = source
         self._spotify = spotify
         self._knowledge = matching_knowledge
         self._publication_storage = publication_storage
+        self._transfer_storage = transfer_storage
+        self._pause_requested = False
+
+    def pause(self) -> None:
+        """Request a pause after the current track reaches a safe checkpoint."""
+        self._pause_requested = True
+
+    def abandon(self, transfer_id: str) -> None:
+        """Explicitly make a persisted, non-completed Transfer terminal."""
+        if self._transfer_storage is None:
+            raise ValueError("Abandonment requires durable Transfer storage")
+        state = self._transfer_storage.load_transfer(transfer_id)
+        if state is None:
+            raise ValueError(f"Unknown Transfer: {transfer_id}")
+        if state["status"] == "completed":
+            raise ValueError("A completed Transfer cannot be abandoned")
+        state["status"] = "abandoned"
+        self._transfer_storage.save_transfer(transfer_id, state)
 
     def execute(self, request: TransferRequest) -> SyncReport:
         """Execute one Transfer and return its structured outcome.
@@ -293,8 +354,55 @@ class Transfer:
         if not request.preview and self._publication_storage is None:
             raise ValueError("Publishing Transfers require publication storage")
 
-        selection = self._source.consume(request.source)
-        created_at = datetime.now()
+        transfer_id = request.transfer_id or uuid4().hex
+        state = (
+            self._transfer_storage.load_transfer(transfer_id)
+            if self._transfer_storage is not None else None
+        )
+        if request.transfer_id and state is None:
+            raise ValueError(f"Unknown Transfer: {transfer_id}")
+
+        if state is None:
+            selection = self._source.consume(request.source)
+            created_at = datetime.now()
+            state = {
+                "status": "matching",
+                "source": request.source,
+                "request": {
+                    "source": request.source,
+                    "preview": request.preview,
+                    "threshold": request.threshold,
+                    "retry": request.retry,
+                    "retry_days": request.retry_days,
+                    "playlist_prefix": request.playlist_prefix,
+                },
+                "selection": {
+                    "name": selection.name,
+                    "reference": selection.reference,
+                    "tracks": [asdict(track) for track in selection.tracks],
+                },
+                "created_at": created_at.isoformat(),
+                "next_track_index": 0,
+                "matched": [],
+                "unmatched": [],
+                "publication_items": [],
+            }
+            self._save_transfer(transfer_id, state)
+        else:
+            if state["status"] == "abandoned":
+                raise ValueError(f"Transfer {transfer_id} was abandoned")
+            if state["source"] != request.source:
+                raise ValueError("A resumed Transfer must use its original source")
+            request = TransferRequest(
+                **state["request"], transfer_id=transfer_id,
+            )
+            stored_selection = state["selection"]
+            selection = SourceSelection(
+                stored_selection["name"], stored_selection["reference"],
+                [Track(**track) for track in stored_selection["tracks"]],
+            )
+            created_at = datetime.fromisoformat(state["created_at"])
+
         playlist = PlaylistReport(
             name=selection.name,
             path=selection.reference,
@@ -307,11 +415,29 @@ class Transfer:
             playlists=[playlist],
             cache_enabled=getattr(self._knowledge, "persistent", True),
             source_label=self._source.source_label,
+            transfer_id=transfer_id,
+            status=state["status"],
         )
-        publication_items: list[PublicationItem] = []
+        playlist.matched = [MatchedTrack(**item) for item in state["matched"]]
+        playlist.unmatched = list(state["unmatched"])
+        publication_items = [
+            PublicationItem(**item) for item in state["publication_items"]
+        ]
+        if state["status"] == "completed":
+            report.status = "completed"
+            if state.get("spotify_playlist_id"):
+                playlist.name = state["spotify_playlist_name"]
+                playlist.spotify_playlist_id = state["spotify_playlist_id"]
+                playlist.action = "provisional snapshot created"
+            elif not request.preview and not selection.tracks:
+                playlist.action = "not published: empty source"
+            elif not request.preview and playlist.unmatched:
+                playlist.action = "not published: incomplete matching"
+            return report
 
         try:
-            for track in selection.tracks:
+            for index in range(state["next_track_index"], len(selection.tracks)):
+                track = selection.tracks[index]
                 result = self._knowledge.lookup(track, request.threshold)
                 if result is not None:
                     playlist.cache_hits += 1
@@ -348,26 +474,50 @@ class Transfer:
                         match_type=matched_track.match_type,
                     ))
 
+                state["next_track_index"] = index + 1
+                state["matched"] = [asdict(item) for item in playlist.matched]
+                state["unmatched"] = list(playlist.unmatched)
+                state["publication_items"] = [
+                    asdict(item) for item in publication_items
+                ]
+                self._knowledge.checkpoint()
+                if self._pause_requested:
+                    state["status"] = "paused"
+                    self._save_transfer(transfer_id, state)
+                    self._pause_requested = False
+                    playlist.action = "paused"
+                    report.status = "paused"
+                    return report
+                self._save_transfer(transfer_id, state)
+
             if not request.preview and not selection.tracks:
                 playlist.action = "not published: empty source"
             elif not request.preview and playlist.unmatched:
                 playlist.action = "not published: incomplete matching"
             elif not request.preview:
-                discriminator = (
-                    f"{created_at:%Y-%m-%d %H%M%S} {uuid4().hex[:8]}"
-                )
-                snapshot_name = f"{selection.name} — {discriminator}"
-                if request.playlist_prefix:
-                    snapshot_name = f"{request.playlist_prefix} / {snapshot_name}"
-                description = (
-                    f"Provisional Snapshot from {self._source.source_label}: "
-                    f"{selection.reference}. Created {created_at.isoformat()}."
-                )
-                playlist_id = self._spotify.publish_provisional_snapshot(
-                    snapshot_name,
-                    [item.spotify_uri for item in publication_items],
-                    description,
-                )
+                playlist_id = state.get("spotify_playlist_id")
+                snapshot_name = state.get("spotify_playlist_name")
+                if playlist_id is None:
+                    discriminator = (
+                        f"{created_at:%Y-%m-%d %H%M%S} {uuid4().hex[:8]}"
+                    )
+                    snapshot_name = f"{selection.name} — {discriminator}"
+                    if request.playlist_prefix:
+                        snapshot_name = f"{request.playlist_prefix} / {snapshot_name}"
+                    description = (
+                        f"Provisional Snapshot from {self._source.source_label}: "
+                        f"{selection.reference}. Created {created_at.isoformat()}."
+                    )
+                    playlist_id = self._spotify.publish_provisional_snapshot(
+                        snapshot_name,
+                        [item.spotify_uri for item in publication_items],
+                        description,
+                    )
+                    state["spotify_playlist_id"] = playlist_id
+                    state["spotify_playlist_name"] = snapshot_name
+                    state["status"] = "retaining publication"
+                    self._save_transfer(transfer_id, state)
+                assert snapshot_name is not None
                 manifest = PublicationManifest(
                     spotify_playlist_id=playlist_id,
                     spotify_playlist_name=snapshot_name,
@@ -381,13 +531,28 @@ class Transfer:
                     self._publication_storage.retain_publication(manifest)
                 except Exception:
                     self._spotify.delete_provisional_snapshot(playlist_id)
+                    state.pop("spotify_playlist_id", None)
+                    state.pop("spotify_playlist_name", None)
+                    state["status"] = "matching"
+                    self._save_transfer(transfer_id, state)
                     raise
                 playlist.name = snapshot_name
                 playlist.spotify_playlist_id = playlist_id
                 playlist.publication_manifest = manifest
                 playlist.action = "provisional snapshot created"
+            state["status"] = "completed"
+            self._save_transfer(transfer_id, state)
+            report.status = "completed"
+        except KeyboardInterrupt:
+            state["status"] = "paused"
+            self._save_transfer(transfer_id, state)
+            raise
         finally:
             # Matching discoveries survive interrupted matching or publication.
             self._knowledge.checkpoint()
 
         return report
+
+    def _save_transfer(self, transfer_id: str, state: dict) -> None:
+        if self._transfer_storage is not None:
+            self._transfer_storage.save_transfer(transfer_id, state)

--- a/tests/test_transfer.py
+++ b/tests/test_transfer.py
@@ -14,6 +14,7 @@ from djsupport.rekordbox import Track
 from djsupport.report import PlaylistReport, SyncReport
 from djsupport.transfer import (
     FilePublicationStorage,
+    FileTransferStorage,
     SourceSelection,
     Transfer,
     TransferRequest,
@@ -129,7 +130,7 @@ def test_preview_reuses_and_retains_matching_knowledge_without_playlist_writes()
     assert playlist.api_lookups == 1
     assert spotify.searches == [("New Artist", "New Track", 80)]
     assert ("New Artist", "New Track") in storage.matches
-    assert storage.checkpoints == 1
+    assert storage.checkpoints >= 1
     assert spotify.playlists == original_playlists
     assert storage.playlist_state == original_state
     assert storage.playlist_writes == 0
@@ -148,11 +149,163 @@ def test_preview_with_zero_acceptable_matches_succeeds_with_zero_percent():
     assert report.overall_match_rate == 0.0
     assert report.total_matched == 0
     assert report.total_unmatched == 2
-    assert storage.checkpoints == 1
+    assert storage.checkpoints >= 1
     assert spotify.playlists == {"existing": ["spotify:track:untouched"]}
 
 
 class TestSnapshotPublication:
+
+    def test_paused_transfer_reloads_and_resumes_without_repeating_work(self, tmp_path):
+        matches = {
+            ("Known Artist", "Known Track"): _match(
+                "spotify:track:known", "Known Track", "Known Artist",
+            ),
+            ("New Artist", "New Track"): _match(
+                "spotify:track:new", "New Track", "New Artist",
+            ),
+        }
+        spotify = StatefulSpotify(matches)
+        knowledge = InMemoryStorage()
+        state_path = tmp_path / "transfers.json"
+        first = Transfer(
+            source=FixtureBeatportSource(FIXTURE), spotify=spotify,
+            matching_knowledge=knowledge, publication_storage=knowledge,
+            transfer_storage=FileTransferStorage(state_path),
+        )
+        first.pause()
+
+        paused = first.execute(TransferRequest(source="fixture"))
+
+        assert paused.status == "paused"
+        assert paused.playlists[0].action == "paused"
+        assert spotify.searches == [("Known Artist", "Known Track", 80)]
+        assert "snapshot-1" not in spotify.playlists
+
+        resumed_knowledge = InMemoryStorage()
+        resumed = Transfer(
+            source=FixtureBeatportSource(FIXTURE), spotify=spotify,
+            matching_knowledge=resumed_knowledge, publication_storage=knowledge,
+            transfer_storage=FileTransferStorage(state_path),
+        ).execute(TransferRequest(source="fixture", transfer_id=paused.transfer_id))
+
+        assert resumed.status == "completed"
+        assert resumed.playlists[0].action == "provisional snapshot created"
+        assert spotify.searches == [
+            ("Known Artist", "Known Track", 80),
+            ("New Artist", "New Track", 80),
+        ]
+        assert len(knowledge.publications) == 1
+        assert list(spotify.playlists).count("snapshot-1") == 1
+
+    def test_user_cancellation_is_persisted_as_paused_by_default(self, tmp_path):
+        class CancellingSpotify(StatefulSpotify):
+            def __init__(self):
+                super().__init__({
+                    ("Known Artist", "Known Track"): _match(
+                        "spotify:track:known", "Known Track", "Known Artist",
+                    ),
+                })
+
+            def match(self, track, threshold):
+                if track.track_id == "bp-2":
+                    raise KeyboardInterrupt
+                return super().match(track, threshold)
+
+        states = FileTransferStorage(tmp_path / "transfers.json")
+        with pytest.raises(KeyboardInterrupt):
+            Transfer(
+                source=FixtureBeatportSource(FIXTURE), spotify=CancellingSpotify(),
+                matching_knowledge=InMemoryStorage(),
+                publication_storage=InMemoryStorage(), transfer_storage=states,
+            ).execute(TransferRequest(source="fixture"))
+
+        persisted = next(iter(FileTransferStorage(states.path).transfers.values()))
+        assert persisted["status"] == "paused"
+        assert persisted["next_track_index"] == 1
+
+    def test_abandonment_is_explicit_persisted_and_cannot_be_resumed(self, tmp_path):
+        spotify = StatefulSpotify({
+            ("Known Artist", "Known Track"): _match(
+                "spotify:track:known", "Known Track", "Known Artist",
+            ),
+        })
+        state_path = tmp_path / "transfers.json"
+        transfer = Transfer(
+            source=FixtureBeatportSource(FIXTURE), spotify=spotify,
+            matching_knowledge=InMemoryStorage(),
+            publication_storage=InMemoryStorage(),
+            transfer_storage=FileTransferStorage(state_path),
+        )
+        transfer.pause()
+        paused = transfer.execute(TransferRequest(source="fixture"))
+
+        transfer.abandon(paused.transfer_id)
+
+        reloaded = FileTransferStorage(state_path)
+        assert reloaded.load_transfer(paused.transfer_id)["status"] == "abandoned"
+        with pytest.raises(ValueError, match="abandoned"):
+            Transfer(
+                source=FixtureBeatportSource(FIXTURE), spotify=spotify,
+                matching_knowledge=InMemoryStorage(),
+                publication_storage=InMemoryStorage(), transfer_storage=reloaded,
+            ).execute(TransferRequest(
+                source="fixture", transfer_id=paused.transfer_id,
+            ))
+        assert "snapshot-1" not in spotify.playlists
+
+    def test_resume_after_publishing_does_not_duplicate_spotify_effect(self, tmp_path):
+        class InterruptedPublicationStorage(InMemoryStorage):
+            def __init__(self):
+                super().__init__()
+                self.interrupt = True
+
+            def retain_publication(self, manifest):
+                if self.interrupt:
+                    self.interrupt = False
+                    raise KeyboardInterrupt
+                super().retain_publication(manifest)
+
+        matches = {
+            ("Known Artist", "Known Track"): _match(
+                "spotify:track:known", "Known Track", "Known Artist",
+            ),
+            ("New Artist", "New Track"): _match(
+                "spotify:track:new", "New Track", "New Artist",
+            ),
+        }
+        spotify = StatefulSpotify(matches)
+        knowledge = InMemoryStorage()
+        publications = InterruptedPublicationStorage()
+        states = FileTransferStorage(tmp_path / "transfers.json")
+        transfer = Transfer(
+            source=FixtureBeatportSource(FIXTURE), spotify=spotify,
+            matching_knowledge=knowledge, publication_storage=publications,
+            transfer_storage=states,
+        )
+
+        with pytest.raises(KeyboardInterrupt):
+            transfer.execute(TransferRequest(source="fixture"))
+        transfer_id = next(iter(states.transfers))
+
+        resumed = Transfer(
+            source=FixtureBeatportSource(FIXTURE), spotify=spotify,
+            matching_knowledge=knowledge, publication_storage=publications,
+            transfer_storage=FileTransferStorage(states.path),
+        ).execute(TransferRequest(source="fixture", transfer_id=transfer_id))
+
+        assert resumed.status == "completed"
+        assert len([key for key in spotify.playlists if key.startswith("snapshot-")]) == 1
+        assert len(publications.publications) == 1
+
+        repeated = Transfer(
+            source=FixtureBeatportSource(FIXTURE), spotify=spotify,
+            matching_knowledge=knowledge, publication_storage=publications,
+            transfer_storage=FileTransferStorage(states.path),
+        ).execute(TransferRequest(source="fixture", transfer_id=transfer_id))
+
+        assert repeated.status == "completed"
+        assert len([key for key in spotify.playlists if key.startswith("snapshot-")]) == 1
+        assert len(publications.publications) == 1
 
     def test_publish_creates_provisional_snapshot_and_exact_manifest_after_matching(self):
         spotify = StatefulSpotify({
@@ -189,7 +342,7 @@ class TestSnapshotPublication:
             "spotify:track:known", "spotify:track:new",
         ]
         assert [item.source_track_id for item in manifest.items] == ["bp-1", "bp-2"]
-        assert storage.checkpoints == 1
+        assert storage.checkpoints >= 1
 
 
     def test_repeated_snapshot_is_distinct_and_never_updates_previous_snapshot(self):
@@ -238,7 +391,7 @@ class TestSnapshotPublication:
 
         assert spotify.playlists == {"existing": ["spotify:track:untouched"]}
         assert storage.publications == []
-        assert storage.checkpoints == 1
+        assert storage.checkpoints >= 1
 
 
     def test_incomplete_matching_does_not_publish_snapshot(self):

--- a/tests/test_transfer.py
+++ b/tests/test_transfer.py
@@ -605,3 +605,39 @@ class TestBeatportCliTransfer:
         request = execute.call_args.args[0]
         assert request.preview is False
         assert request.source == "https://www.beatport.com/chart/fixture/14"
+
+    @patch("djsupport.transfer.FileTransferStorage.load_transfer")
+    @patch("djsupport.transfer.Transfer.execute")
+    @patch("djsupport.cli.get_client", return_value=MagicMock())
+    def test_cli_can_resume_a_visible_transfer_id(
+        self, mock_client, execute, load_transfer, tmp_path,
+    ):
+        load_transfer.return_value = MagicMock()
+        execute.return_value = SyncReport(
+            timestamp=datetime.now(), threshold=80, dry_run=False,
+            playlists=[PlaylistReport(name="Fixture", path="fixture")],
+            transfer_id="resume-me", status="completed",
+        )
+
+        result = CliRunner().invoke(cli, [
+            "beatport", "https://www.beatport.com/chart/fixture/14",
+            "--resume", "resume-me", "--state-path", str(tmp_path / "state.json"),
+        ])
+
+        assert result.exit_code == 0, result.output
+        assert "Transfer ID: resume-me" in result.output
+        assert execute.call_args.args[0].transfer_id == "resume-me"
+
+    @patch("djsupport.transfer.Transfer.abandon")
+    @patch("djsupport.cli.get_client", return_value=MagicMock())
+    def test_cli_can_explicitly_abandon_a_transfer(
+        self, mock_client, abandon, tmp_path,
+    ):
+        result = CliRunner().invoke(cli, [
+            "beatport", "https://www.beatport.com/chart/fixture/14",
+            "--abandon", "stop-me", "--state-path", str(tmp_path / "state.json"),
+        ])
+
+        assert result.exit_code == 0, result.output
+        abandon.assert_called_once_with("stop-me")
+        assert "Transfer stop-me abandoned" in result.output

--- a/tests/test_transfer.py
+++ b/tests/test_transfer.py
@@ -44,14 +44,25 @@ class StatefulSpotify:
         self.matches = matches or {}
         self.searches = []
         self.playlists = {"existing": ["spotify:track:untouched"]}
+        self.publication_keys = {}
 
-    def publish_provisional_snapshot(self, name, track_uris, description):
+    def account_id(self):
+        return "spotify-user-1"
+
+    def publish_provisional_snapshot(
+        self, name, track_uris, description, publication_key,
+    ):
+        if publication_key in self.publication_keys:
+            playlist_id = self.publication_keys[publication_key]
+            self.playlists[playlist_id]["tracks"] = list(track_uris)
+            return playlist_id
         playlist_id = f"snapshot-{len(self.playlists)}"
         self.playlists[playlist_id] = {
             "name": name,
             "tracks": list(track_uris),
             "description": description,
         }
+        self.publication_keys[publication_key] = playlist_id
         return playlist_id
 
     def delete_provisional_snapshot(self, playlist_id):
@@ -220,8 +231,8 @@ class TestSnapshotPublication:
             ).execute(TransferRequest(source="fixture"))
 
         persisted = next(iter(FileTransferStorage(states.path).transfers.values()))
-        assert persisted["status"] == "paused"
-        assert persisted["next_track_index"] == 1
+        assert persisted.status.value == "paused"
+        assert persisted.next_track_index == 1
 
     def test_abandonment_is_explicit_persisted_and_cannot_be_resumed(self, tmp_path):
         spotify = StatefulSpotify({
@@ -242,7 +253,7 @@ class TestSnapshotPublication:
         transfer.abandon(paused.transfer_id)
 
         reloaded = FileTransferStorage(state_path)
-        assert reloaded.load_transfer(paused.transfer_id)["status"] == "abandoned"
+        assert reloaded.load_transfer(paused.transfer_id).status.value == "abandoned"
         with pytest.raises(ValueError, match="abandoned"):
             Transfer(
                 source=FixtureBeatportSource(FIXTURE), spotify=spotify,
@@ -306,6 +317,69 @@ class TestSnapshotPublication:
         assert repeated.status == "completed"
         assert len([key for key in spotify.playlists if key.startswith("snapshot-")]) == 1
         assert len(publications.publications) == 1
+
+    def test_crash_before_publication_checkpoint_reuses_idempotency_key(self, tmp_path):
+        class CrashAfterSpotifyCreate(StatefulSpotify):
+            def __init__(self, matches):
+                super().__init__(matches)
+                self.crash = True
+
+            def publish_provisional_snapshot(self, *args):
+                playlist_id = super().publish_provisional_snapshot(*args)
+                if self.crash:
+                    self.crash = False
+                    raise KeyboardInterrupt
+                return playlist_id
+
+        matches = {
+            ("Known Artist", "Known Track"): _match(
+                "spotify:track:known", "Known Track", "Known Artist",
+            ),
+            ("New Artist", "New Track"): _match(
+                "spotify:track:new", "New Track", "New Artist",
+            ),
+        }
+        spotify = CrashAfterSpotifyCreate(matches)
+        knowledge = InMemoryStorage()
+        publications = InMemoryStorage()
+        states = FileTransferStorage(tmp_path / "transfers.json")
+        transfer_id = "durable-publication"
+
+        with pytest.raises(KeyboardInterrupt):
+            Transfer(
+                source=FixtureBeatportSource(FIXTURE), spotify=spotify,
+                matching_knowledge=knowledge, publication_storage=publications,
+                transfer_storage=states,
+            ).execute(TransferRequest(source="fixture", transfer_id=transfer_id))
+
+        Transfer(
+            source=FixtureBeatportSource(FIXTURE), spotify=spotify,
+            matching_knowledge=knowledge, publication_storage=publications,
+            transfer_storage=FileTransferStorage(states.path),
+        ).execute(TransferRequest(source="fixture", transfer_id=transfer_id))
+
+        assert len([key for key in spotify.playlists if key.startswith("snapshot-")]) == 1
+
+    def test_resume_rejects_a_different_spotify_account(self, tmp_path):
+        spotify = StatefulSpotify()
+        states = FileTransferStorage(tmp_path / "transfers.json")
+        transfer = Transfer(
+            source=FixtureBeatportSource(FIXTURE), spotify=spotify,
+            matching_knowledge=InMemoryStorage(),
+            publication_storage=InMemoryStorage(), transfer_storage=states,
+        )
+        transfer.pause()
+        paused = transfer.execute(TransferRequest(source="fixture"))
+        spotify.account_id = lambda: "spotify-user-2"
+
+        with pytest.raises(ValueError, match="another Spotify account"):
+            Transfer(
+                source=FixtureBeatportSource(FIXTURE), spotify=spotify,
+                matching_knowledge=InMemoryStorage(),
+                publication_storage=InMemoryStorage(), transfer_storage=states,
+            ).execute(TransferRequest(
+                source="fixture", transfer_id=paused.transfer_id,
+            ))
 
     def test_publish_creates_provisional_snapshot_and_exact_manifest_after_matching(self):
         spotify = StatefulSpotify({


### PR DESCRIPTION
Closes #16

## Summary
- persist versioned, account-bound Transfer checkpoints after safe matching and publication transitions
- pause on request or user cancellation, resume by Transfer ID without repeating completed searches or Spotify publication, and support explicit abandonment
- expose resume/abandon controls in the Beatport CLI and restore structured outcomes after reload
- make Spotify snapshot creation idempotent using a durable Transfer publication key

## Validation
- `pytest` — 345 passed
- `python3 -m compileall -q djsupport tests`
- `git diff --check`

## Reviews
- Standards: documented standards pass; one non-blocking low judgment call about nested serialized dictionaries
- Spec: pass with no material findings