### PR TITLE
Protect publishing with account scope and bounded retries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Added
 
+- Account-scoped Provisional Playlist state, per-account publishing serialization,
+  and bounded Spotify retries with safe Transfer checkpointing
 - Beatport chart playlists now include the curator/DJ name — e.g. `"Adam Beyer - Tech House Vibes"` instead of just `"Tech House Vibes"`
 - `compose_chart_playlist_name()` helper in `beatport.py` for chart name composition (curator omitted when `"Unknown"`, empty, or `None`)
 

--- a/djsupport/cli.py
+++ b/djsupport/cli.py
@@ -302,6 +302,7 @@ def list_playlists(xml_path: str | None):
 
 
 from djsupport.transfer import (
+    AccountPublishingGuards,
     default_matching_knowledge_path,
     default_publication_manifest_path,
 )
@@ -380,6 +381,7 @@ def beatport(
     transfer = Transfer(
         source=BeatportChartSource(),
         spotify=SpotifyMatcher(get_client()),
+        publishing_guards=AccountPublishingGuards(),
         matching_knowledge=(
             EphemeralMatchingKnowledge()
             if cache is None else MatchCacheKnowledge(cache)

--- a/djsupport/transfer.py
+++ b/djsupport/transfer.py
@@ -8,23 +8,37 @@ persistence ordering, Preview policy, and Provisional Snapshot publication.
 from __future__ import annotations
 
 import json
+import hashlib
 import os
 import sys
+import tempfile
+import time
+from contextlib import contextmanager
 from dataclasses import asdict, dataclass
 from datetime import datetime
 from enum import Enum
 from pathlib import Path
-from typing import Protocol
+from typing import Callable, Protocol, TypeVar
 from uuid import uuid4
+
+import requests
+import spotipy
+
+if os.name == "nt":
+    import msvcrt
+else:
+    import fcntl
 
 from djsupport.cache import MatchCache
 from djsupport.matcher import match_track
 from djsupport.rekordbox import Track
 from djsupport.report import MatchedTrack, PlaylistReport, SyncReport
+from djsupport.spotify import MAX_RATE_LIMIT_WAIT, RateLimitError, _parse_retry_after
 
 
 PUBLICATION_MANIFEST_VERSION = 1
 TRANSFER_STATE_VERSION = 1
+ResultT = TypeVar("ResultT")
 
 
 def default_matching_knowledge_path() -> Path:
@@ -57,6 +71,91 @@ class TransferStatus(str, Enum):
     RETAINING_PUBLICATION = "retaining publication"
     COMPLETED = "completed"
     ABANDONED = "abandoned"
+
+
+@dataclass(frozen=True)
+class RetryPolicy:
+    """Bound retries for transient Spotify failures and short rate limits."""
+
+    max_attempts: int = 3
+    backoff_seconds: float = 1.0
+    max_rate_limit_wait: int = MAX_RATE_LIMIT_WAIT
+    sleep: Callable[[float], None] = time.sleep
+
+    def run(self, operation: Callable[[], ResultT]) -> ResultT:
+        for attempt in range(1, self.max_attempts + 1):
+            try:
+                return operation()
+            except spotipy.SpotifyException as exc:
+                retryable_error: Exception = exc
+                status = exc.http_status
+                if status == 429:
+                    delay = _parse_retry_after(exc)
+                    if delay > self.max_rate_limit_wait:
+                        raise RateLimitError(delay) from exc
+                elif status is not None and status >= 500:
+                    delay = self.backoff_seconds * (2 ** (attempt - 1))
+                else:
+                    raise
+            except (requests.Timeout, requests.ConnectionError) as exc:
+                retryable_error = exc
+                delay = self.backoff_seconds * (2 ** (attempt - 1))
+            if attempt == self.max_attempts:
+                raise retryable_error
+            self.sleep(delay)
+        raise AssertionError("unreachable")
+
+
+class PublishingTransferConflict(RuntimeError):
+    """Raised when another publishing Transfer owns an account guard."""
+
+
+class AccountPublishingGuards:
+    """Serialize publishing Transfers across processes by Spotify account."""
+
+    def __init__(self, lock_directory: str | Path | None = None) -> None:
+        self.lock_directory = Path(
+            lock_directory
+            or Path(tempfile.gettempdir()) / "djsupport-publishing-locks"
+        )
+
+    @contextmanager
+    def acquire(self, account_id: str):
+        account_key = hashlib.sha256(account_id.encode()).hexdigest()
+        self.lock_directory.mkdir(parents=True, exist_ok=True)
+        lock_file = (self.lock_directory / f"{account_key}.lock").open("a+b")
+        try:
+            self._lock(lock_file)
+        except OSError:
+            lock_file.close()
+            raise PublishingTransferConflict(
+                f"A publishing Transfer is already active for {account_id}"
+            ) from None
+        try:
+            yield
+        finally:
+            self._unlock(lock_file)
+            lock_file.close()
+
+    @staticmethod
+    def _lock(lock_file) -> None:
+        if os.name == "nt":
+            lock_file.seek(0)
+            if not lock_file.read(1):
+                lock_file.write(b"0")
+                lock_file.flush()
+            lock_file.seek(0)
+            msvcrt.locking(lock_file.fileno(), msvcrt.LK_NBLCK, 1)
+        else:
+            fcntl.flock(lock_file.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+
+    @staticmethod
+    def _unlock(lock_file) -> None:
+        if os.name == "nt":
+            lock_file.seek(0)
+            msvcrt.locking(lock_file.fileno(), msvcrt.LK_UNLCK, 1)
+        else:
+            fcntl.flock(lock_file.fileno(), fcntl.LOCK_UN)
 
 
 @dataclass
@@ -111,6 +210,7 @@ class PublicationItem:
 class PublicationManifest:
     """The durable facts needed to review one Provisional Playlist."""
 
+    account_id: str
     spotify_playlist_id: str
     spotify_playlist_name: str
     source_label: str
@@ -166,7 +266,10 @@ class FilePublicationStorage:
         stored["created_at"] = manifest.created_at.isoformat()
         next_manifests = [
             item for item in self.manifests
-            if item.get("spotify_playlist_id") != manifest.spotify_playlist_id
+            if not (
+                item.get("account_id") == manifest.account_id
+                and item.get("spotify_playlist_id") == manifest.spotify_playlist_id
+            )
         ]
         next_manifests.append(stored)
         self.path.parent.mkdir(parents=True, exist_ok=True)
@@ -177,6 +280,13 @@ class FilePublicationStorage:
         }, indent=2))
         os.replace(temporary, self.path)
         self.manifests = next_manifests
+
+    def manifests_for_account(self, account_id: str) -> list[dict]:
+        """Return only playlist-management state owned by one account."""
+        return [
+            manifest for manifest in self.manifests
+            if manifest.get("account_id") == account_id
+        ]
 
 
 class TransferStorage(Protocol):
@@ -342,9 +452,7 @@ class MatchCacheKnowledge:
             return True
         if entry.matched:
             return False
-        return self._cache.is_retry_eligible(
-            track.artist, track.name, retry_days=retry_days, force=force,
-        )
+        return force
 
     def retain(self, track: Track, threshold: int, result: dict | None) -> None:
         self._cache.store(track.artist, track.name, threshold, result)
@@ -382,14 +490,18 @@ class Transfer:
         source: SourceAdapter,
         spotify: SpotifyAdapter,
         matching_knowledge: MatchingKnowledge,
+        publishing_guards: AccountPublishingGuards,
         publication_storage: PublicationStorage | None = None,
         transfer_storage: TransferStorage | None = None,
+        retry_policy: RetryPolicy | None = None,
     ) -> None:
         self._source = source
         self._spotify = spotify
         self._knowledge = matching_knowledge
+        self._publishing_guards = publishing_guards
         self._publication_storage = publication_storage
         self._transfer_storage = transfer_storage
+        self._retry_policy = retry_policy or RetryPolicy()
         self._pause_requested = False
 
     def pause(self) -> None:
@@ -405,10 +517,22 @@ class Transfer:
             raise ValueError(f"Unknown Transfer: {transfer_id}")
         if state.status == TransferStatus.COMPLETED:
             raise ValueError("A completed Transfer cannot be abandoned")
+        if state.account_id != self._spotify.account_id():
+            raise ValueError("A Transfer cannot be abandoned under another Spotify account")
         state.status = TransferStatus.ABANDONED
         self._transfer_storage.save_transfer(transfer_id, state)
 
     def execute(self, request: TransferRequest) -> SyncReport:
+        """Execute at most one publishing Transfer per Spotify account."""
+        if request.preview:
+            return self._execute(request)
+        if self._publication_storage is None:
+            raise ValueError("Publishing Transfers require publication storage")
+        account_id = self._spotify.account_id()
+        with self._publishing_guards.acquire(account_id):
+            return self._execute(request)
+
+    def _execute(self, request: TransferRequest) -> SyncReport:
         """Execute one Transfer and return its structured outcome.
 
         Beatport publication creates a distinct Provisional Snapshot after the
@@ -497,6 +621,9 @@ class Transfer:
                     playlist.publication_manifest = PublicationManifest(
                         **{
                             **stored_manifest,
+                            "account_id": stored_manifest.get(
+                                "account_id", state.account_id,
+                            ),
                             "created_at": datetime.fromisoformat(
                                 stored_manifest["created_at"]
                             ),
@@ -521,7 +648,9 @@ class Transfer:
                 elif self._knowledge.should_retry(
                     track, request.threshold, request.retry_days, request.retry,
                 ):
-                    result = self._spotify.match(track, request.threshold)
+                    result = self._retry_policy.run(
+                        lambda: self._spotify.match(track, request.threshold)
+                    )
                     playlist.api_lookups += 1
                     self._knowledge.retain(track, request.threshold, result)
                 else:
@@ -585,11 +714,13 @@ class Transfer:
                         f"Provisional Snapshot from {self._source.source_label}: "
                         f"{selection.reference}. Created {created_at.isoformat()}."
                     )
-                    playlist_id = self._spotify.publish_provisional_snapshot(
-                        snapshot_name,
-                        [item.spotify_uri for item in publication_items],
-                        description,
-                        transfer_id,
+                    playlist_id = self._retry_policy.run(
+                        lambda: self._spotify.publish_provisional_snapshot(
+                            snapshot_name,
+                            [item.spotify_uri for item in publication_items],
+                            description,
+                            transfer_id,
+                        )
                     )
                     state.spotify_playlist_id = playlist_id
                     state.spotify_playlist_name = snapshot_name
@@ -606,6 +737,7 @@ class Transfer:
                         return report
                 assert snapshot_name is not None
                 manifest = PublicationManifest(
+                    account_id=state.account_id,
                     spotify_playlist_id=playlist_id,
                     spotify_playlist_name=snapshot_name,
                     source_label=self._source.source_label,
@@ -635,6 +767,18 @@ class Transfer:
             state.status = TransferStatus.COMPLETED
             self._save_transfer(transfer_id, state)
             report.status = "completed"
+        except (RateLimitError, requests.Timeout, requests.ConnectionError) as exc:
+            state.status = TransferStatus.PAUSED
+            self._save_transfer(transfer_id, state)
+            raise exc
+        except spotipy.SpotifyException as exc:
+            if exc.http_status not in (401, 403, 429) and (
+                exc.http_status is None or exc.http_status < 500
+            ):
+                raise
+            state.status = TransferStatus.PAUSED
+            self._save_transfer(transfer_id, state)
+            raise
         except KeyboardInterrupt:
             state.status = TransferStatus.PAUSED
             self._save_transfer(transfer_id, state)

--- a/tests/test_transfer.py
+++ b/tests/test_transfer.py
@@ -1,20 +1,30 @@
 """Behavior tests at the public Transfer seam."""
 
 import json
-from datetime import datetime
+import threading
+from concurrent.futures import ThreadPoolExecutor
+from datetime import datetime, timedelta
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
+import requests
+import spotipy
 
 from click.testing import CliRunner
 
 from djsupport.cli import cli
+from djsupport.cache import MatchCache
 from djsupport.rekordbox import Track
 from djsupport.report import PlaylistReport, SyncReport
+from djsupport.spotify import RateLimitError
 from djsupport.transfer import (
+    AccountPublishingGuards,
     FilePublicationStorage,
     FileTransferStorage,
+    MatchCacheKnowledge,
+    PublishingTransferConflict,
+    RetryPolicy,
     SourceSelection,
     Transfer,
     TransferRequest,
@@ -106,6 +116,7 @@ class InMemoryStorage:
 
 
 FIXTURE = Path(__file__).parent / "fixtures" / "beatport_chart.json"
+TEST_PUBLISHING_GUARDS = AccountPublishingGuards()
 
 
 def _match(uri, name, artist):
@@ -113,6 +124,13 @@ def _match(uri, name, artist):
         "uri": uri, "name": name, "artist": artist,
         "score": 96.0, "match_type": "exact",
     }
+
+
+def _spotify_error(status, *, retry_after=None):
+    headers = {} if retry_after is None else {"Retry-After": str(retry_after)}
+    return spotipy.SpotifyException(
+        status, -1, "Spotify failure", headers=headers,
+    )
 
 
 def test_preview_reuses_and_retains_matching_knowledge_without_playlist_writes():
@@ -130,6 +148,7 @@ def test_preview_reuses_and_retains_matching_knowledge_without_playlist_writes()
     original_state = dict(storage.playlist_state)
 
     report = Transfer(
+        publishing_guards=TEST_PUBLISHING_GUARDS,
         source=source, spotify=spotify, matching_knowledge=storage,
     ).execute(TransferRequest(source="fixture", preview=True))
 
@@ -152,6 +171,7 @@ def test_preview_with_zero_acceptable_matches_succeeds_with_zero_percent():
     storage = InMemoryStorage()
 
     report = Transfer(
+        publishing_guards=TEST_PUBLISHING_GUARDS,
         source=FixtureBeatportSource(FIXTURE),
         spotify=spotify,
         matching_knowledge=storage,
@@ -162,6 +182,186 @@ def test_preview_with_zero_acceptable_matches_succeeds_with_zero_percent():
     assert report.total_unmatched == 2
     assert storage.checkpoints >= 1
     assert spotify.playlists == {"existing": ["spotify:track:untouched"]}
+
+
+class TestProtectedTransferBehavior:
+
+    def test_previously_unmatched_tracks_retry_only_when_explicitly_requested(
+        self, tmp_path,
+    ):
+        cache = MatchCache(str(tmp_path / "matching-knowledge.json"))
+        for artist, title in (
+            ("Known Artist", "Known Track"), ("New Artist", "New Track"),
+        ):
+            cache.store(artist, title, 80, None)
+            cache.entries[cache.cache_key(artist, title)].timestamp = (
+                datetime.now() - timedelta(days=30)
+            ).isoformat()
+        spotify = StatefulSpotify({
+            ("Known Artist", "Known Track"): _match(
+                "spotify:track:known", "Known Track", "Known Artist",
+            ),
+            ("New Artist", "New Track"): _match(
+                "spotify:track:new", "New Track", "New Artist",
+            ),
+        })
+        transfer = Transfer(
+            publishing_guards=TEST_PUBLISHING_GUARDS,
+            source=FixtureBeatportSource(FIXTURE), spotify=spotify,
+            matching_knowledge=MatchCacheKnowledge(cache),
+        )
+
+        skipped = transfer.execute(TransferRequest(source="fixture", preview=True))
+        retried = transfer.execute(TransferRequest(
+            source="fixture", preview=True, retry=True,
+        ))
+
+        assert skipped.total_unmatched == 2
+        assert skipped.playlists[0].api_lookups == 0
+        assert retried.total_matched == 2
+        assert retried.playlists[0].api_lookups == 2
+
+
+    def test_transient_timeouts_retry_with_bounded_backoff(self):
+        class TimeoutThenMatch(StatefulSpotify):
+            def __init__(self):
+                super().__init__()
+                self.attempts = 0
+
+            def match(self, track, threshold):
+                self.attempts += 1
+                if self.attempts < 3:
+                    raise requests.Timeout("Spotify timed out")
+                return _match("spotify:track:known", track.name, track.artist)
+
+        spotify = TimeoutThenMatch()
+        sleeps = []
+        report = Transfer(
+            publishing_guards=TEST_PUBLISHING_GUARDS,
+            source=FixtureBeatportSource(FIXTURE), spotify=spotify,
+            matching_knowledge=InMemoryStorage(),
+            retry_policy=RetryPolicy(sleep=sleeps.append),
+        ).execute(TransferRequest(source="fixture", preview=True))
+
+        assert report.total_matched == 2
+        assert spotify.attempts == 4
+        assert sleeps == [1.0, 2.0]
+
+
+    def test_server_failure_retries_are_bounded(self):
+        class UnavailableSpotify(StatefulSpotify):
+            def __init__(self):
+                super().__init__()
+                self.attempts = 0
+
+            def match(self, track, threshold):
+                self.attempts += 1
+                raise _spotify_error(503)
+
+        spotify = UnavailableSpotify()
+        with pytest.raises(spotipy.SpotifyException) as raised:
+            Transfer(
+                publishing_guards=TEST_PUBLISHING_GUARDS,
+                source=FixtureBeatportSource(FIXTURE), spotify=spotify,
+                matching_knowledge=InMemoryStorage(),
+                retry_policy=RetryPolicy(sleep=lambda _delay: None),
+            ).execute(TransferRequest(source="fixture", preview=True))
+
+        assert raised.value.http_status == 503
+        assert spotify.attempts == 3
+
+
+    def test_short_rate_limit_retries_using_retry_after(self):
+        class RateLimitedOnce(StatefulSpotify):
+            def __init__(self):
+                super().__init__()
+                self.rate_limited = False
+
+            def match(self, track, threshold):
+                if not self.rate_limited:
+                    self.rate_limited = True
+                    raise _spotify_error(429, retry_after=4)
+                return _match("spotify:track:match", track.name, track.artist)
+
+        sleeps = []
+        report = Transfer(
+            publishing_guards=TEST_PUBLISHING_GUARDS,
+            source=FixtureBeatportSource(FIXTURE), spotify=RateLimitedOnce(),
+            matching_knowledge=InMemoryStorage(),
+            retry_policy=RetryPolicy(sleep=sleeps.append),
+        ).execute(TransferRequest(source="fixture", preview=True))
+
+        assert report.total_matched == 2
+        assert sleeps == [4]
+
+
+    @pytest.mark.parametrize(
+        ("failure", "expected_exception"),
+        [
+            (_spotify_error(401), spotipy.SpotifyException),
+            (_spotify_error(429, retry_after=2), spotipy.SpotifyException),
+            (_spotify_error(429, retry_after=3600), RateLimitError),
+        ],
+    )
+    def test_shared_spotify_failures_checkpoint_and_stop_safely(
+        self, tmp_path, failure, expected_exception,
+    ):
+        class FailingSpotify(StatefulSpotify):
+            def match(self, track, threshold):
+                raise failure
+
+        state_path = tmp_path / "transfers.json"
+        knowledge = InMemoryStorage()
+        with pytest.raises(expected_exception):
+            Transfer(
+                publishing_guards=TEST_PUBLISHING_GUARDS,
+                source=FixtureBeatportSource(FIXTURE), spotify=FailingSpotify(),
+                matching_knowledge=knowledge,
+                transfer_storage=FileTransferStorage(state_path),
+                retry_policy=RetryPolicy(sleep=lambda _delay: None),
+            ).execute(TransferRequest(source="fixture", preview=True))
+
+        persisted = next(iter(FileTransferStorage(state_path).transfers.values()))
+        assert persisted.status.value == "paused"
+        assert persisted.next_track_index == 0
+        assert knowledge.checkpoints >= 1
+
+
+    def test_second_publishing_transfer_for_same_account_cannot_race_first(self):
+        entered_publication = threading.Event()
+        release_publication = threading.Event()
+
+        class BlockingSpotify(StatefulSpotify):
+            def publish_provisional_snapshot(self, *args):
+                entered_publication.set()
+                assert release_publication.wait(timeout=2)
+                return super().publish_provisional_snapshot(*args)
+
+        matches = {
+            ("Known Artist", "Known Track"): _match(
+                "spotify:track:known", "Known Track", "Known Artist",
+            ),
+            ("New Artist", "New Track"): _match(
+                "spotify:track:new", "New Track", "New Artist",
+            ),
+        }
+        spotify = BlockingSpotify(matches)
+
+        def publish():
+            storage = InMemoryStorage()
+            return Transfer(
+                publishing_guards=AccountPublishingGuards(),
+                source=FixtureBeatportSource(FIXTURE), spotify=spotify,
+                matching_knowledge=storage, publication_storage=storage,
+            ).execute(TransferRequest(source="fixture"))
+
+        with ThreadPoolExecutor(max_workers=2) as executor:
+            first = executor.submit(publish)
+            assert entered_publication.wait(timeout=2)
+            with pytest.raises(PublishingTransferConflict, match="spotify-user-1"):
+                publish()
+            release_publication.set()
+            assert first.result(timeout=2).status == "completed"
 
 
 class TestSnapshotPublication:
@@ -179,6 +379,7 @@ class TestSnapshotPublication:
         knowledge = InMemoryStorage()
         state_path = tmp_path / "transfers.json"
         first = Transfer(
+            publishing_guards=TEST_PUBLISHING_GUARDS,
             source=FixtureBeatportSource(FIXTURE), spotify=spotify,
             matching_knowledge=knowledge, publication_storage=knowledge,
             transfer_storage=FileTransferStorage(state_path),
@@ -194,6 +395,7 @@ class TestSnapshotPublication:
 
         resumed_knowledge = InMemoryStorage()
         resumed = Transfer(
+            publishing_guards=TEST_PUBLISHING_GUARDS,
             source=FixtureBeatportSource(FIXTURE), spotify=spotify,
             matching_knowledge=resumed_knowledge, publication_storage=knowledge,
             transfer_storage=FileTransferStorage(state_path),
@@ -225,6 +427,7 @@ class TestSnapshotPublication:
         states = FileTransferStorage(tmp_path / "transfers.json")
         with pytest.raises(KeyboardInterrupt):
             Transfer(
+                publishing_guards=TEST_PUBLISHING_GUARDS,
                 source=FixtureBeatportSource(FIXTURE), spotify=CancellingSpotify(),
                 matching_knowledge=InMemoryStorage(),
                 publication_storage=InMemoryStorage(), transfer_storage=states,
@@ -242,6 +445,7 @@ class TestSnapshotPublication:
         })
         state_path = tmp_path / "transfers.json"
         transfer = Transfer(
+            publishing_guards=TEST_PUBLISHING_GUARDS,
             source=FixtureBeatportSource(FIXTURE), spotify=spotify,
             matching_knowledge=InMemoryStorage(),
             publication_storage=InMemoryStorage(),
@@ -256,6 +460,7 @@ class TestSnapshotPublication:
         assert reloaded.load_transfer(paused.transfer_id).status.value == "abandoned"
         with pytest.raises(ValueError, match="abandoned"):
             Transfer(
+                publishing_guards=TEST_PUBLISHING_GUARDS,
                 source=FixtureBeatportSource(FIXTURE), spotify=spotify,
                 matching_knowledge=InMemoryStorage(),
                 publication_storage=InMemoryStorage(), transfer_storage=reloaded,
@@ -263,6 +468,24 @@ class TestSnapshotPublication:
                 source="fixture", transfer_id=paused.transfer_id,
             ))
         assert "snapshot-1" not in spotify.playlists
+
+    def test_transfer_cannot_be_abandoned_by_another_spotify_account(self, tmp_path):
+        spotify = StatefulSpotify()
+        states = FileTransferStorage(tmp_path / "transfers.json")
+        transfer = Transfer(
+            publishing_guards=TEST_PUBLISHING_GUARDS,
+            source=FixtureBeatportSource(FIXTURE), spotify=spotify,
+            matching_knowledge=InMemoryStorage(),
+            publication_storage=InMemoryStorage(), transfer_storage=states,
+        )
+        transfer.pause()
+        paused = transfer.execute(TransferRequest(source="fixture"))
+        spotify.account_id = lambda: "spotify-user-2"
+
+        with pytest.raises(ValueError, match="another Spotify account"):
+            transfer.abandon(paused.transfer_id)
+
+        assert states.load_transfer(paused.transfer_id).status.value == "paused"
 
     def test_resume_after_publishing_does_not_duplicate_spotify_effect(self, tmp_path):
         class InterruptedPublicationStorage(InMemoryStorage):
@@ -289,6 +512,7 @@ class TestSnapshotPublication:
         publications = InterruptedPublicationStorage()
         states = FileTransferStorage(tmp_path / "transfers.json")
         transfer = Transfer(
+            publishing_guards=TEST_PUBLISHING_GUARDS,
             source=FixtureBeatportSource(FIXTURE), spotify=spotify,
             matching_knowledge=knowledge, publication_storage=publications,
             transfer_storage=states,
@@ -299,6 +523,7 @@ class TestSnapshotPublication:
         transfer_id = next(iter(states.transfers))
 
         resumed = Transfer(
+            publishing_guards=TEST_PUBLISHING_GUARDS,
             source=FixtureBeatportSource(FIXTURE), spotify=spotify,
             matching_knowledge=knowledge, publication_storage=publications,
             transfer_storage=FileTransferStorage(states.path),
@@ -309,6 +534,7 @@ class TestSnapshotPublication:
         assert len(publications.publications) == 1
 
         repeated = Transfer(
+            publishing_guards=TEST_PUBLISHING_GUARDS,
             source=FixtureBeatportSource(FIXTURE), spotify=spotify,
             matching_knowledge=knowledge, publication_storage=publications,
             transfer_storage=FileTransferStorage(states.path),
@@ -347,12 +573,14 @@ class TestSnapshotPublication:
 
         with pytest.raises(KeyboardInterrupt):
             Transfer(
+                publishing_guards=TEST_PUBLISHING_GUARDS,
                 source=FixtureBeatportSource(FIXTURE), spotify=spotify,
                 matching_knowledge=knowledge, publication_storage=publications,
                 transfer_storage=states,
             ).execute(TransferRequest(source="fixture", transfer_id=transfer_id))
 
         Transfer(
+            publishing_guards=TEST_PUBLISHING_GUARDS,
             source=FixtureBeatportSource(FIXTURE), spotify=spotify,
             matching_knowledge=knowledge, publication_storage=publications,
             transfer_storage=FileTransferStorage(states.path),
@@ -364,6 +592,7 @@ class TestSnapshotPublication:
         spotify = StatefulSpotify()
         states = FileTransferStorage(tmp_path / "transfers.json")
         transfer = Transfer(
+            publishing_guards=TEST_PUBLISHING_GUARDS,
             source=FixtureBeatportSource(FIXTURE), spotify=spotify,
             matching_knowledge=InMemoryStorage(),
             publication_storage=InMemoryStorage(), transfer_storage=states,
@@ -374,6 +603,7 @@ class TestSnapshotPublication:
 
         with pytest.raises(ValueError, match="another Spotify account"):
             Transfer(
+                publishing_guards=TEST_PUBLISHING_GUARDS,
                 source=FixtureBeatportSource(FIXTURE), spotify=spotify,
                 matching_knowledge=InMemoryStorage(),
                 publication_storage=InMemoryStorage(), transfer_storage=states,
@@ -393,6 +623,7 @@ class TestSnapshotPublication:
         storage = InMemoryStorage()
 
         report = Transfer(
+            publishing_guards=TEST_PUBLISHING_GUARDS,
             source=FixtureBeatportSource(FIXTURE),
             spotify=spotify,
             matching_knowledge=storage,
@@ -412,6 +643,7 @@ class TestSnapshotPublication:
         assert playlist.publication_manifest is manifest
         assert manifest.source_label == "Beatport"
         assert manifest.source_reference == "https://www.beatport.com/chart/fixture/14"
+        assert manifest.account_id == "spotify-user-1"
         assert [item.spotify_uri for item in manifest.items] == [
             "spotify:track:known", "spotify:track:new",
         ]
@@ -431,6 +663,7 @@ class TestSnapshotPublication:
         spotify = StatefulSpotify(matches)
         storage = InMemoryStorage()
         transfer = Transfer(
+            publishing_guards=TEST_PUBLISHING_GUARDS,
             source=FixtureBeatportSource(FIXTURE), spotify=spotify,
             matching_knowledge=storage, publication_storage=storage,
         )
@@ -459,6 +692,7 @@ class TestSnapshotPublication:
 
         with pytest.raises(RuntimeError, match="matching interrupted"):
             Transfer(
+                publishing_guards=TEST_PUBLISHING_GUARDS,
                 source=FixtureBeatportSource(FIXTURE), spotify=spotify,
                 matching_knowledge=storage, publication_storage=storage,
             ).execute(TransferRequest(source="fixture"))
@@ -477,6 +711,7 @@ class TestSnapshotPublication:
         storage = InMemoryStorage()
 
         report = Transfer(
+            publishing_guards=TEST_PUBLISHING_GUARDS,
             source=FixtureBeatportSource(FIXTURE), spotify=spotify,
             matching_knowledge=storage, publication_storage=storage,
         ).execute(TransferRequest(source="fixture"))
@@ -496,6 +731,7 @@ class TestSnapshotPublication:
         storage = InMemoryStorage()
 
         report = Transfer(
+            publishing_guards=TEST_PUBLISHING_GUARDS,
             source=EmptySource(), spotify=spotify,
             matching_knowledge=storage, publication_storage=storage,
         ).execute(TransferRequest(source="empty"))
@@ -522,6 +758,7 @@ class TestSnapshotPublication:
 
         with pytest.raises(OSError, match="disk full"):
             Transfer(
+                publishing_guards=TEST_PUBLISHING_GUARDS,
                 source=FixtureBeatportSource(FIXTURE), spotify=spotify,
                 matching_knowledge=InMemoryStorage(),
                 publication_storage=FailingPublicationStorage(),
@@ -543,6 +780,7 @@ class TestSnapshotPublication:
         storage = FilePublicationStorage(path)
 
         report = Transfer(
+            publishing_guards=TEST_PUBLISHING_GUARDS,
             source=FixtureBeatportSource(FIXTURE), spotify=StatefulSpotify(matches),
             matching_knowledge=InMemoryStorage(), publication_storage=storage,
         ).execute(TransferRequest(source="fixture"))
@@ -554,6 +792,37 @@ class TestSnapshotPublication:
         assert [item["source_track_id"] for item in reloaded.manifests[0]["items"]] == [
             "bp-1", "bp-2",
         ]
+
+    def test_file_publication_state_is_scoped_to_spotify_account(self, tmp_path):
+        matches = {
+            ("Known Artist", "Known Track"): _match(
+                "spotify:track:known", "Known Track", "Known Artist",
+            ),
+            ("New Artist", "New Track"): _match(
+                "spotify:track:new", "New Track", "New Artist",
+            ),
+        }
+        path = tmp_path / "publication-manifests.json"
+        storage = FilePublicationStorage(path)
+        for account_id in ("spotify-user-1", "spotify-user-2"):
+            spotify = StatefulSpotify(matches)
+            spotify.account_id = lambda value=account_id: value
+            Transfer(
+                publishing_guards=TEST_PUBLISHING_GUARDS,
+                source=FixtureBeatportSource(FIXTURE), spotify=spotify,
+                matching_knowledge=InMemoryStorage(),
+                publication_storage=storage,
+            ).execute(TransferRequest(source="fixture"))
+
+        reloaded = FilePublicationStorage(path)
+        assert {
+            item["account_id"]
+            for item in reloaded.manifests_for_account("spotify-user-1")
+        } == {"spotify-user-1"}
+        assert {
+            item["account_id"]
+            for item in reloaded.manifests_for_account("spotify-user-2")
+        } == {"spotify-user-2"}
 
 
 


### PR DESCRIPTION
Closes #17

## Summary
- scope publication manifests and durable Transfer mutations to the authenticated Spotify account
- serialize publishing Transfers across local processes with injected per-account advisory locks
- add bounded backoff for transient Spotify failures and short rate limits
- pause and checkpoint safely on authentication, exhausted rate-limit, and availability failures
- keep previously unmatched-track retry manual-only

## Validation
- 364 tests passed
- `python3 -m compileall -q djsupport tests`
- `git diff --check main...HEAD`
- Standards review: pass, no blocking findings
- Spec review: pass, no findings or scope creep