### PR TITLE
Review and approve a Provisional Playlist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Added
 
+- Playlist-scoped Provisional Playlist approval with durable approved, rejected,
+  and abandoned review outcomes
+- Clickable Spotify proposals and stable source references in Markdown reports,
+  plus editable CSV review files for Beatport Transfers
 - Account-scoped Provisional Playlist state, per-account publishing serialization,
   and bounded Spotify retries with safe Transfer checkpointing
 - Beatport chart playlists now include the curator/DJ name — e.g. `"Adam Beyer - Tech House Vibes"` instead of just `"Tech House Vibes"`

--- a/README.md
+++ b/README.md
@@ -145,6 +145,18 @@ Save a detailed Markdown report:
 djsupport sync --report report.md
 ```
 
+Beatport publication reports also create an editable CSV beside the Markdown
+file. Review the Provisional Playlist in Spotify, remove incorrect proposals,
+then approve that one playlist:
+
+```bash
+djsupport beatport <chart-url> --report review.md
+djsupport approve <spotify-playlist-id>
+```
+
+Approval records surviving proposals as approved, removed proposals as rejected,
+and a deleted Provisional Playlist as abandoned while retaining its history.
+
 ### Playlist naming
 
 Spotify playlists are prefixed with `djsupport /` by default. Change or disable the prefix:

--- a/agent.md
+++ b/agent.md
@@ -84,6 +84,7 @@ djsupport beatport <url> --state-path my.json        # Custom publication manife
 djsupport beatport <url> --prefix "dj"               # Prefix for playlist name
 djsupport beatport <url> --no-prefix                 # No prefix
 djsupport beatport <url> --report report.md          # Save Markdown report
+djsupport approve <spotify-playlist-id>              # Approve one reviewed Provisional Playlist
 djsupport beatport <url> --incremental               # Incremental updates (default)
 djsupport beatport <url> --resume <transfer-id>      # Resume a paused Transfer
 djsupport beatport <url> --abandon <transfer-id>     # Explicitly abandon a Transfer

--- a/djsupport/cache.py
+++ b/djsupport/cache.py
@@ -23,6 +23,7 @@ class CacheEntry:
     timestamp: str
     threshold: int
     match_type: str | None = None
+    approval_status: str | None = None
 
 
 class MatchCache:
@@ -63,6 +64,10 @@ class MatchCache:
         entry = self.entries.get(key)
         if entry is None:
             return None
+        if entry.approval_status == "rejected":
+            return None
+        if entry.approval_status == "approved":
+            return entry
         if entry.matched and entry.score is not None and entry.score >= threshold:
             return entry
         if not entry.matched and entry.threshold <= threshold:
@@ -98,6 +103,27 @@ class MatchCache:
         self._dirty_count += 1
         if self._dirty_count >= CHECKPOINT_INTERVAL:
             self.save()
+
+    def record_approval(
+        self, artist: str, title: str, status: str, result: dict,
+    ) -> None:
+        """Mark retained matching knowledge as explicitly approved or rejected."""
+        key = self.cache_key(artist, title)
+        entry = self.entries.get(key)
+        if entry is None or status == "approved":
+            entry = CacheEntry(
+                spotify_uri=result["uri"],
+                spotify_name=result["name"],
+                spotify_artist=result["artist"],
+                score=result["score"],
+                matched=True,
+                timestamp=datetime.now().isoformat(),
+                threshold=0,
+                match_type=result.get("match_type"),
+            )
+            self.entries[key] = entry
+        entry.approval_status = status
+        self._dirty_count += 1
 
     def is_retry_eligible(self, artist: str, title: str,
                           retry_days: int = DEFAULT_RETRY_DAYS,

--- a/djsupport/cli.py
+++ b/djsupport/cli.py
@@ -24,6 +24,7 @@ from djsupport.report import (
     SyncReport,
     print_report,
     save_report,
+    save_review_csv,
 )
 from djsupport.service import ProgressEvent, match_and_sync_playlist
 from djsupport.spotify import (
@@ -313,6 +314,52 @@ DEFAULT_BEATPORT_STATE_PATH = str(default_publication_manifest_path())
 
 
 @cli.command()
+@click.argument("playlist_id")
+@click.option(
+    "--state-path", default=DEFAULT_BEATPORT_STATE_PATH, show_default=True,
+    help="Path to durable Provisional Playlist manifests.",
+)
+@click.option(
+    "--cache-path", default=DEFAULT_BEATPORT_CACHE_PATH, show_default=True,
+    help="Path to durable matching knowledge.",
+)
+def approve(playlist_id: str, state_path: str, cache_path: str) -> None:
+    """Approve one Provisional Playlist after reviewing it in Spotify."""
+    from djsupport.cache import MatchCache
+    from djsupport.transfer import (
+        BeatportChartSource,
+        FilePublicationStorage,
+        MatchCacheKnowledge,
+        SpotifyMatcher,
+        Transfer,
+    )
+
+    cache = MatchCache(cache_path)
+    cache.load()
+    transfer = Transfer(
+        source=BeatportChartSource(),
+        spotify=SpotifyMatcher(get_client()),
+        publishing_guards=AccountPublishingGuards(),
+        matching_knowledge=MatchCacheKnowledge(cache),
+        publication_storage=FilePublicationStorage(state_path),
+    )
+    try:
+        review = transfer.approve(playlist_id)
+    except ValueError as exc:
+        raise click.ClickException(str(exc)) from exc
+    if review.status.value == "abandoned":
+        click.echo(
+            f"Provisional Playlist {playlist_id} is Abandoned; publication history retained."
+        )
+        return
+    click.echo(
+        f"Provisional Playlist {playlist_id}: "
+        f"{len(review.approved)} approved, {len(review.rejected)} rejected, "
+        f"{len(review.collisions)} collisions."
+    )
+
+
+@cli.command()
 @click.argument("url")
 @click.option("--dry-run", is_flag=True, help="Preview without modifying Spotify.")
 @click.option("--threshold", "-t", default=80, show_default=True, help="Minimum match confidence (0-100).")
@@ -427,7 +474,10 @@ def beatport(
     print_report(report)
     if report_path:
         save_report(report, report_path)
+        review_path = str(Path(report_path).with_suffix(".csv"))
+        save_review_csv(report, review_path)
         click.echo(f"\nDetailed report saved to {report_path}")
+        click.echo(f"Editable review CSV saved to {review_path}")
 
 
 DEFAULT_LABEL_CACHE_PATH = ".djsupport_label_cache.json"

--- a/djsupport/report.py
+++ b/djsupport/report.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import csv
 from dataclasses import dataclass, field
 from datetime import datetime
 from typing import TYPE_CHECKING
@@ -18,6 +19,14 @@ class MatchedTrack:
     score: float
     match_type: str = "exact"
     score_reasons: tuple[str, ...] = ()
+    source_track_id: str = ""
+    spotify_uri: str = ""
+
+
+def _spotify_url(uri: str) -> str:
+    if uri.startswith("spotify:track:"):
+        return f"https://open.spotify.com/track/{uri.removeprefix('spotify:track:')}"
+    return uri
 
 
 @dataclass
@@ -154,12 +163,20 @@ def save_report(report: SyncReport, path: str) -> None:
         lines.append("")
 
         if pl.matched:
-            lines.append(f"| {report.source_label} | Spotify Match | Score | Match Type | Score Reasons |")
-            lines.append("|-----------|---------------|-------|------------|---------------|")
+            lines.append(
+                f"| Source Reference | {report.source_label} | Spotify Proposal"
+                " | Score | Match Type | Score Reasons |"
+            )
+            lines.append(
+                "|------------------|-----------|------------------|-------|------------|---------------|"
+            )
             for m in pl.matched:
                 reasons = "; ".join(m.score_reasons)
+                proposal = f"{m.spotify_artist} - {m.spotify_name}"
+                if m.spotify_uri:
+                    proposal = f"[{proposal}]({_spotify_url(m.spotify_uri)})"
                 lines.append(
-                    f"| {m.source_name} | {m.spotify_artist} - {m.spotify_name}"
+                    f"| {m.source_track_id} | {m.source_name} | {proposal}"
                     f" | {m.score:.1f} | {m.match_type} | {reasons} |"
                 )
             lines.append("")
@@ -212,3 +229,23 @@ def save_report(report: SyncReport, path: str) -> None:
 
     with open(path, "w") as f:
         f.write("\n".join(lines))
+
+
+def save_review_csv(report: SyncReport, path: str) -> None:
+    """Write editable proposal rows keyed by stable source-track references."""
+    with open(path, "w", newline="") as csv_file:
+        writer = csv.writer(csv_file)
+        writer.writerow([
+            "source_track_id", "source_track", "spotify_url", "spotify_track",
+            "score", "match_type",
+        ])
+        for playlist in report.playlists:
+            for match in playlist.matched:
+                writer.writerow([
+                    match.source_track_id,
+                    match.source_name,
+                    _spotify_url(match.spotify_uri),
+                    f"{match.spotify_artist} - {match.spotify_name}",
+                    f"{match.score:.1f}",
+                    match.match_type,
+                ])

--- a/djsupport/transfer.py
+++ b/djsupport/transfer.py
@@ -13,6 +13,7 @@ import os
 import sys
 import tempfile
 import time
+from collections import Counter
 from contextlib import contextmanager
 from dataclasses import asdict, dataclass
 from datetime import datetime
@@ -71,6 +72,12 @@ class TransferStatus(str, Enum):
     RETAINING_PUBLICATION = "retaining publication"
     COMPLETED = "completed"
     ABANDONED = "abandoned"
+
+
+class ApprovalStatus(str, Enum):
+    APPROVED = "approved"
+    ABANDONED = "abandoned"
+    NEEDS_REVIEW = "needs review"
 
 
 @dataclass(frozen=True)
@@ -219,6 +226,19 @@ class PublicationManifest:
     items: tuple[PublicationItem, ...]
 
 
+@dataclass(frozen=True)
+class ApprovalOutcome:
+    """The durable outcome of approving one Provisional Playlist."""
+
+    account_id: str
+    spotify_playlist_id: str
+    reviewed_at: datetime
+    status: ApprovalStatus
+    approved: tuple[PublicationItem, ...] = ()
+    rejected: tuple[PublicationItem, ...] = ()
+    collisions: tuple[PublicationItem, ...] = ()
+
+
 class SourceAdapter(Protocol):
     source_label: str
 
@@ -237,9 +257,19 @@ class SpotifyAdapter(Protocol):
 
     def delete_provisional_snapshot(self, playlist_id: str) -> None: ...
 
+    def provisional_playlist_track_uris(
+        self, playlist_id: str,
+    ) -> list[str] | None: ...
+
 
 class PublicationStorage(Protocol):
     def retain_publication(self, manifest: PublicationManifest) -> None: ...
+
+    def publication_for_playlist(
+        self, account_id: str, playlist_id: str,
+    ) -> PublicationManifest | None: ...
+
+    def retain_approval(self, outcome: ApprovalOutcome) -> None: ...
 
 
 class FilePublicationStorage:
@@ -248,6 +278,7 @@ class FilePublicationStorage:
     def __init__(self, path: str | Path) -> None:
         self.path = Path(path)
         self.manifests: list[dict] = []
+        self.approvals: list[dict] = []
         self.load()
 
     def load(self) -> None:
@@ -260,6 +291,19 @@ class FilePublicationStorage:
         if data.get("version") != PUBLICATION_MANIFEST_VERSION:
             return
         self.manifests = data.get("manifests", [])
+        self.approvals = data.get("approvals", data.get("reviews", []))
+
+    def _save(self, manifests: list[dict], approvals: list[dict]) -> None:
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        temporary = self.path.with_suffix(f"{self.path.suffix}.tmp")
+        temporary.write_text(json.dumps({
+            "version": PUBLICATION_MANIFEST_VERSION,
+            "manifests": manifests,
+            "approvals": approvals,
+        }, indent=2))
+        os.replace(temporary, self.path)
+        self.manifests = manifests
+        self.approvals = approvals
 
     def retain_publication(self, manifest: PublicationManifest) -> None:
         stored = asdict(manifest)
@@ -272,14 +316,7 @@ class FilePublicationStorage:
             )
         ]
         next_manifests.append(stored)
-        self.path.parent.mkdir(parents=True, exist_ok=True)
-        temporary = self.path.with_suffix(f"{self.path.suffix}.tmp")
-        temporary.write_text(json.dumps({
-            "version": PUBLICATION_MANIFEST_VERSION,
-            "manifests": next_manifests,
-        }, indent=2))
-        os.replace(temporary, self.path)
-        self.manifests = next_manifests
+        self._save(next_manifests, self.approvals)
 
     def manifests_for_account(self, account_id: str) -> list[dict]:
         """Return only playlist-management state owned by one account."""
@@ -287,6 +324,29 @@ class FilePublicationStorage:
             manifest for manifest in self.manifests
             if manifest.get("account_id") == account_id
         ]
+
+    def publication_for_playlist(
+        self, account_id: str, playlist_id: str,
+    ) -> PublicationManifest | None:
+        stored = next((
+            manifest for manifest in self.manifests
+            if manifest.get("account_id") == account_id
+            and manifest.get("spotify_playlist_id") == playlist_id
+        ), None)
+        if stored is None:
+            return None
+        return PublicationManifest(
+            **{
+                **stored,
+                "created_at": datetime.fromisoformat(stored["created_at"]),
+                "items": tuple(PublicationItem(**item) for item in stored["items"]),
+            }
+        )
+
+    def retain_approval(self, outcome: ApprovalOutcome) -> None:
+        stored = asdict(outcome)
+        stored["reviewed_at"] = outcome.reviewed_at.isoformat()
+        self._save(self.manifests, [*self.approvals, stored])
 
 
 class TransferStorage(Protocol):
@@ -348,6 +408,10 @@ class MatchingKnowledge(Protocol):
     def retain(self, track: Track, threshold: int, result: dict | None) -> None: ...
 
     def checkpoint(self) -> None: ...
+
+    def approve(self, item: PublicationItem) -> None: ...
+
+    def reject(self, item: PublicationItem) -> None: ...
 
 
 class BeatportChartSource:
@@ -423,6 +487,24 @@ class SpotifyMatcher:
     def delete_provisional_snapshot(self, playlist_id: str) -> None:
         self._client.current_user_unfollow_playlist(playlist_id)
 
+    def provisional_playlist_track_uris(self, playlist_id: str) -> list[str] | None:
+        try:
+            page = self._client.playlist_items(playlist_id)
+        except spotipy.SpotifyException as exc:
+            if exc.http_status == 404:
+                return None
+            raise
+        uris: list[str] = []
+        while page:
+            for item in page.get("items", []):
+                track = item.get("track") or {}
+                if track.get("uri"):
+                    uris.append(track["uri"])
+            if not page.get("next"):
+                break
+            page = self._client.next(page)
+        return uris
+
 
 class MatchCacheKnowledge:
     """Expose the existing durable match cache as Transfer storage."""
@@ -460,6 +542,30 @@ class MatchCacheKnowledge:
     def checkpoint(self) -> None:
         self._cache.save()
 
+    def approve(self, item: PublicationItem) -> None:
+        self._cache.record_approval(
+            item.source_artist, item.source_title, ApprovalStatus.APPROVED.value,
+            {
+                "uri": item.spotify_uri,
+                "name": item.spotify_name,
+                "artist": item.spotify_artist,
+                "score": item.score,
+                "match_type": item.match_type,
+            },
+        )
+
+    def reject(self, item: PublicationItem) -> None:
+        self._cache.record_approval(
+            item.source_artist, item.source_title, "rejected",
+            {
+                "uri": item.spotify_uri,
+                "name": item.spotify_name,
+                "artist": item.spotify_artist,
+                "score": item.score,
+                "match_type": item.match_type,
+            },
+        )
+
 
 class EphemeralMatchingKnowledge:
     """Non-persistent matching knowledge used for explicit ``--no-cache``."""
@@ -478,6 +584,12 @@ class EphemeralMatchingKnowledge:
         pass
 
     def checkpoint(self) -> None:
+        pass
+
+    def approve(self, item: PublicationItem) -> None:
+        pass
+
+    def reject(self, item: PublicationItem) -> None:
         pass
 
 
@@ -521,6 +633,69 @@ class Transfer:
             raise ValueError("A Transfer cannot be abandoned under another Spotify account")
         state.status = TransferStatus.ABANDONED
         self._transfer_storage.save_transfer(transfer_id, state)
+
+    def approve(self, playlist_id: str) -> ApprovalOutcome:
+        """Review exactly one retained Provisional Playlist against Spotify."""
+        if self._publication_storage is None:
+            raise ValueError("Approval requires publication storage")
+        account_id = self._spotify.account_id()
+        manifest = self._publication_storage.publication_for_playlist(
+            account_id, playlist_id,
+        )
+        if manifest is None:
+            raise ValueError(
+                f"No Provisional Playlist {playlist_id} belongs to this Spotify account"
+            )
+        with self._publishing_guards.acquire(account_id):
+            current_uris = self._retry_policy.run(
+                lambda: self._spotify.provisional_playlist_track_uris(playlist_id)
+            )
+            if current_uris is None:
+                outcome = ApprovalOutcome(
+                    account_id=account_id,
+                    spotify_playlist_id=playlist_id,
+                    reviewed_at=datetime.now(),
+                    status=ApprovalStatus.ABANDONED,
+                )
+            else:
+                remaining = Counter(current_uris)
+                approved: list[PublicationItem] = []
+                rejected: list[PublicationItem] = []
+                proposed_counts = Counter(
+                    item.spotify_uri for item in manifest.items
+                )
+                collision_uris = {
+                    uri for uri, count in proposed_counts.items() if count > 1
+                }
+                collisions: list[PublicationItem] = []
+                for item in manifest.items:
+                    if item.spotify_uri in collision_uris:
+                        collisions.append(item)
+                        continue
+                    if remaining[item.spotify_uri] > 0:
+                        approved.append(item)
+                        remaining[item.spotify_uri] -= 1
+                    else:
+                        rejected.append(item)
+                outcome = ApprovalOutcome(
+                    account_id=account_id,
+                    spotify_playlist_id=playlist_id,
+                    reviewed_at=datetime.now(),
+                    status=(
+                        ApprovalStatus.NEEDS_REVIEW
+                        if collisions else ApprovalStatus.APPROVED
+                    ),
+                    approved=tuple(approved),
+                    rejected=tuple(rejected),
+                    collisions=tuple(collisions),
+                )
+                for item in outcome.approved:
+                    self._knowledge.approve(item)
+                for item in outcome.rejected:
+                    self._knowledge.reject(item)
+                self._knowledge.checkpoint()
+            self._publication_storage.retain_approval(outcome)
+            return outcome
 
     def execute(self, request: TransferRequest) -> SyncReport:
         """Execute at most one publishing Transfer per Spotify account."""
@@ -666,6 +841,8 @@ class Transfer:
                         spotify_artist=result["artist"],
                         score=result["score"],
                         match_type=result.get("match_type", "exact"),
+                        source_track_id=track.track_id,
+                        spotify_uri=result["uri"],
                     )
                     playlist.matched.append(matched_track)
                     publication_items.append(PublicationItem(

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -164,6 +164,35 @@ class TestMatchCacheLookup:
         entry = populated_cache.lookup("SOLOMUN", "VULTORA (ORIGINAL MIX)", 80)
         assert entry is not None
 
+    def test_rejected_match_is_not_reused(self, populated_cache):
+        populated_cache.record_approval(
+            "Solomun", "Vultora (Original Mix)", "rejected", _matched_result(),
+        )
+
+        assert populated_cache.lookup("Solomun", "Vultora (Original Mix)", 80) is None
+
+    def test_approved_match_is_authoritative_above_original_threshold(self, cache):
+        cache.record_approval(
+            "Artist", "Track", "approved", _matched_result(score=81.0),
+        )
+
+        entry = cache.lookup("Artist", "Track", 99)
+        assert entry is not None
+        assert entry.approval_status == "approved"
+
+    def test_approval_replaces_stale_cached_candidate(self, cache):
+        cache.store("Artist", "Track", 80, _matched_result(uri="spotify:track:old"))
+
+        cache.record_approval(
+            "Artist", "Track", "approved",
+            _matched_result(uri="spotify:track:approved", score=88.0),
+        )
+
+        entry = cache.lookup("Artist", "Track", 99)
+        assert entry is not None
+        assert entry.spotify_uri == "spotify:track:approved"
+        assert entry.score == 88.0
+
 
 class TestMatchCacheRetryEligibility:
     def test_not_eligible_for_recent_failed_entry(self, cache):

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -6,12 +6,19 @@ from unittest.mock import patch
 
 import pytest
 
-from djsupport.report import MatchedTrack, PlaylistReport, SyncReport, save_report
+from djsupport.report import (
+    MatchedTrack,
+    PlaylistReport,
+    SyncReport,
+    save_report,
+    save_review_csv,
+)
 
 
 def _matched(
     name="Track A", spotify_name="Track A", artist="Artist", score=95.0,
-    match_type="exact", score_reasons=(),
+    match_type="exact", score_reasons=(), source_track_id="source-1",
+    spotify_uri="spotify:track:abc123",
 ):
     return MatchedTrack(
         source_name=name,
@@ -20,6 +27,8 @@ def _matched(
         score=score,
         match_type=match_type,
         score_reasons=score_reasons,
+        source_track_id=source_track_id,
+        spotify_uri=spotify_uri,
     )
 
 
@@ -144,6 +153,14 @@ class TestSaveReport:
         content = (tmp_path / "report.md").read_text()
         assert "Peak Time" in content
 
+    def test_review_table_has_stable_source_reference_and_clickable_proposal(self, tmp_path):
+        path = str(tmp_path / "report.md")
+        save_report(_report(playlists=[_playlist(matched=[_matched()])]), path)
+
+        content = (tmp_path / "report.md").read_text()
+        assert "source-1" in content
+        assert "[Artist - Track A](https://open.spotify.com/track/abc123)" in content
+
     def test_file_contains_unmatched_tracks(self, tmp_path):
         path = str(tmp_path / "report.md")
         pl = _playlist(unmatched=["Obscure Track"])
@@ -193,3 +210,16 @@ class TestSaveReport:
         save_report(r, path)
         content = (tmp_path / "report.md").read_text()
         assert "Low Confidence" not in content
+
+
+class TestSaveReviewCsv:
+    def test_writes_editable_rows_with_stable_reference_and_spotify_url(self, tmp_path):
+        path = str(tmp_path / "review.csv")
+
+        save_review_csv(
+            _report(playlists=[_playlist(matched=[_matched()])]), path,
+        )
+
+        content = (tmp_path / "review.csv").read_text()
+        assert "source_track_id,source_track,spotify_url" in content
+        assert "source-1,Track A,https://open.spotify.com/track/abc123" in content

--- a/tests/test_transfer.py
+++ b/tests/test_transfer.py
@@ -25,9 +25,12 @@ from djsupport.transfer import (
     MatchCacheKnowledge,
     PublishingTransferConflict,
     RetryPolicy,
+    SpotifyMatcher,
     SourceSelection,
     Transfer,
     TransferRequest,
+    ApprovalStatus,
+    ApprovalOutcome,
 )
 
 
@@ -78,6 +81,12 @@ class StatefulSpotify:
     def delete_provisional_snapshot(self, playlist_id):
         del self.playlists[playlist_id]
 
+    def provisional_playlist_track_uris(self, playlist_id):
+        playlist = self.playlists.get(playlist_id)
+        if playlist is None:
+            return None
+        return list(playlist["tracks"])
+
     def match(self, track, threshold):
         self.searches.append((track.artist, track.name, threshold))
         return self.matches.get((track.artist, track.name))
@@ -91,6 +100,9 @@ class InMemoryStorage:
         self.playlist_state = {"must": "remain unchanged"}
         self.playlist_writes = 0
         self.publications = []
+        self.approvals = []
+        self.approved_matches = []
+        self.rejected_matches = []
 
     def lookup(self, track, threshold):
         result = self.matches.get((track.artist, track.name))
@@ -113,6 +125,25 @@ class InMemoryStorage:
     def retain_publication(self, manifest):
         self.publications.append(manifest)
         self.playlist_writes += 1
+
+    def publication_for_playlist(self, account_id, playlist_id):
+        return next(
+            (
+                manifest for manifest in self.publications
+                if manifest.account_id == account_id
+                and manifest.spotify_playlist_id == playlist_id
+            ),
+            None,
+        )
+
+    def retain_approval(self, outcome):
+        self.approvals.append(outcome)
+
+    def approve(self, item):
+        self.approved_matches.append(item)
+
+    def reject(self, item):
+        self.rejected_matches.append(item)
 
 
 FIXTURE = Path(__file__).parent / "fixtures" / "beatport_chart.json"
@@ -824,6 +855,149 @@ class TestSnapshotPublication:
             for item in reloaded.manifests_for_account("spotify-user-2")
         } == {"spotify-user-2"}
 
+class TestProvisionalPlaylistApproval:
+    def publish(self):
+        matches = {
+            ("Known Artist", "Known Track"): _match(
+                "spotify:track:known", "Known Track", "Known Artist",
+            ),
+            ("New Artist", "New Track"): _match(
+                "spotify:track:new", "New Track", "New Artist",
+            ),
+        }
+        spotify = StatefulSpotify(matches)
+        storage = InMemoryStorage()
+        transfer = Transfer(
+            publishing_guards=TEST_PUBLISHING_GUARDS,
+            source=FixtureBeatportSource(FIXTURE), spotify=spotify,
+            matching_knowledge=storage, publication_storage=storage,
+        )
+        report = transfer.execute(TransferRequest(source="fixture"))
+        return transfer, spotify, storage, report.playlists[0].spotify_playlist_id
+
+    def test_approval_is_scoped_to_one_playlist_and_records_review_outcomes(self):
+        transfer, spotify, storage, playlist_id = self.publish()
+        spotify.playlists[playlist_id]["tracks"] = [
+            "spotify:track:known", "spotify:track:manual",
+        ]
+
+        review = transfer.approve(playlist_id)
+
+        assert review.status == ApprovalStatus.APPROVED
+        assert [item.source_track_id for item in review.approved] == ["bp-1"]
+        assert [item.source_track_id for item in review.rejected] == ["bp-2"]
+        assert spotify.playlists[playlist_id]["tracks"] == [
+            "spotify:track:known", "spotify:track:manual",
+        ]
+        assert storage.approvals == [review]
+        assert storage.approved_matches == list(review.approved)
+        assert storage.rejected_matches == list(review.rejected)
+
+    def test_deleted_provisional_playlist_is_abandoned_with_history_retained(self):
+        transfer, spotify, storage, playlist_id = self.publish()
+        del spotify.playlists[playlist_id]
+
+        review = transfer.approve(playlist_id)
+
+        assert review.status == ApprovalStatus.ABANDONED
+        assert review.approved == ()
+        assert review.rejected == ()
+        assert len(storage.publications) == 1
+        assert storage.publications[0].spotify_playlist_id == playlist_id
+        assert storage.approvals == [review]
+
+    def test_cannot_approve_an_unknown_or_other_account_playlist(self):
+        transfer, _, _, _ = self.publish()
+
+        with pytest.raises(ValueError, match="No Provisional Playlist"):
+            transfer.approve("not-owned")
+
+    def test_file_storage_persists_review_without_removing_publication_history(
+        self, tmp_path,
+    ):
+        transfer, spotify, memory, playlist_id = self.publish()
+        path = tmp_path / "publication-manifests.json"
+        storage = FilePublicationStorage(path)
+        storage.retain_publication(memory.publications[0])
+        spotify.playlists[playlist_id]["tracks"] = ["spotify:track:known"]
+        file_transfer = Transfer(
+            publishing_guards=TEST_PUBLISHING_GUARDS,
+            source=FixtureBeatportSource(FIXTURE), spotify=spotify,
+            matching_knowledge=memory, publication_storage=storage,
+        )
+
+        file_transfer.approve(playlist_id)
+
+        reloaded = FilePublicationStorage(path)
+        assert len(reloaded.manifests) == 1
+        assert reloaded.approvals[0]["status"] == "approved"
+        assert [item["source_track_id"] for item in reloaded.approvals[0]["rejected"]] == [
+            "bp-2",
+        ]
+
+    def test_colliding_proposals_are_withheld_for_explicit_resolution(self):
+        transfer, spotify, storage, playlist_id = self.publish()
+        manifest = storage.publications[0]
+        duplicate = type(manifest)(
+            **{
+                **manifest.__dict__,
+                "items": (
+                    manifest.items[0],
+                    type(manifest.items[1])(
+                        **{
+                            **manifest.items[1].__dict__,
+                            "spotify_uri": manifest.items[0].spotify_uri,
+                        }
+                    ),
+                ),
+            }
+        )
+        storage.publications[0] = duplicate
+        spotify.playlists[playlist_id]["tracks"] = [manifest.items[0].spotify_uri]
+
+        outcome = transfer.approve(playlist_id)
+
+        assert outcome.approved == ()
+        assert outcome.rejected == ()
+        assert outcome.status == ApprovalStatus.NEEDS_REVIEW
+        assert [item.source_track_id for item in outcome.collisions] == ["bp-1", "bp-2"]
+
+    def test_later_abandonment_appends_to_approval_history(self):
+        transfer, spotify, storage, playlist_id = self.publish()
+        transfer.approve(playlist_id)
+        del spotify.playlists[playlist_id]
+
+        transfer.approve(playlist_id)
+
+        assert [outcome.status for outcome in storage.approvals] == [
+            ApprovalStatus.APPROVED, ApprovalStatus.ABANDONED,
+        ]
+
+
+class TestSpotifyApprovalAdapter:
+    def test_reads_all_current_playlist_track_uris(self):
+        client = MagicMock()
+        client.playlist_items.return_value = {
+            "items": [{"track": {"uri": "spotify:track:one"}}],
+            "next": "page-2",
+        }
+        client.next.return_value = {
+            "items": [
+                {"track": {"uri": "spotify:track:two"}},
+                {"track": None},
+            ],
+            "next": None,
+        }
+
+        assert SpotifyMatcher(client).provisional_playlist_track_uris("snapshot-1") == [
+            "spotify:track:one", "spotify:track:two",
+        ]
+
+    def test_missing_playlist_is_reported_without_hiding_other_errors(self):
+        client = MagicMock()
+        client.playlist_items.side_effect = _spotify_error(404)
+
+        assert SpotifyMatcher(client).provisional_playlist_track_uris("gone") is None
 
 
 class TestBeatportCliTransfer:
@@ -910,3 +1084,26 @@ class TestBeatportCliTransfer:
         assert result.exit_code == 0, result.output
         abandon.assert_called_once_with("stop-me")
         assert "Transfer stop-me abandoned" in result.output
+
+    @patch("djsupport.transfer.Transfer.approve")
+    @patch("djsupport.cli.get_client", return_value=MagicMock())
+    def test_cli_approves_one_provisional_playlist(
+        self, mock_client, approve, tmp_path,
+    ):
+        approve.return_value = ApprovalOutcome(
+            account_id="spotify-user-1",
+            spotify_playlist_id="snapshot-1",
+            reviewed_at=datetime.now(),
+            status=ApprovalStatus.APPROVED,
+            approved=(MagicMock(),),
+            rejected=(MagicMock(), MagicMock()),
+        )
+
+        result = CliRunner().invoke(cli, [
+            "approve", "snapshot-1", "--state-path", str(tmp_path / "state.json"),
+        ])
+
+        assert result.exit_code == 0, result.output
+        approve.assert_called_once_with("snapshot-1")
+        assert "1 approved" in result.output
+        assert "2 rejected" in result.output


### PR DESCRIPTION
## Summary
- add playlist-scoped Approval through the public Transfer interface
- persist approved, rejected, abandoned, and collision outcomes while retaining publication history
- generate stable-source Markdown links and editable CSV review artifacts
- add the djsupport approve CLI command and durable authoritative matching knowledge

## Verification
- pytest -q
- python3 -m compileall -q djsupport tests
- git diff --check
- Standards review: no findings
- Spec review: no findings

Closes #18