### PR TITLE
Apply Corrections and capture local regression knowledge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Added
 
+- Explicit Corrections from edited review CSV files, with validated stable source
+  references and Spotify track URLs/URIs, idempotent playlist repair, Approved
+  Match promotion, and local-only matcher regression knowledge
 - Playlist-scoped Provisional Playlist approval with durable approved, rejected,
   and abandoned review outcomes
 - Clickable Spotify proposals and stable source references in Markdown reports,

--- a/README.md
+++ b/README.md
@@ -151,11 +151,14 @@ then approve that one playlist:
 
 ```bash
 djsupport beatport <chart-url> --report review.md
-djsupport approve <spotify-playlist-id>
+djsupport approve <spotify-playlist-id> --review-csv review.csv
 ```
 
 Approval records surviving proposals as approved, removed proposals as rejected,
 and a deleted Provisional Playlist as abandoned while retaining its history.
+Edit a row's Spotify URL to provide a Correction. Corrections repair the playlist
+without duplicates and become approved matching knowledge stored only in your
+local application data.
 
 ### Playlist naming
 

--- a/agent.md
+++ b/agent.md
@@ -85,6 +85,7 @@ djsupport beatport <url> --prefix "dj"               # Prefix for playlist name
 djsupport beatport <url> --no-prefix                 # No prefix
 djsupport beatport <url> --report report.md          # Save Markdown report
 djsupport approve <spotify-playlist-id>              # Approve one reviewed Provisional Playlist
+djsupport approve <spotify-playlist-id> --review-csv review.csv  # Apply Corrections while approving
 djsupport beatport <url> --incremental               # Incremental updates (default)
 djsupport beatport <url> --resume <transfer-id>      # Resume a paused Transfer
 djsupport beatport <url> --abandon <transfer-id>     # Explicitly abandon a Transfer

--- a/djsupport/cache.py
+++ b/djsupport/cache.py
@@ -30,6 +30,7 @@ class MatchCache:
     def __init__(self, path: str = DEFAULT_CACHE_PATH):
         self.path = Path(path)
         self.entries: dict[str, CacheEntry] = {}
+        self.local_regressions: list[dict] = []
         self._dirty_count: int = 0
 
     def load(self) -> None:
@@ -44,6 +45,7 @@ class MatchCache:
             return
         for key, entry in data.get("entries", {}).items():
             self.entries[key] = CacheEntry(**entry)
+        self.local_regressions = data.get("local_regressions", [])
 
     def save(self) -> None:
         """Write cache to disk."""
@@ -51,6 +53,7 @@ class MatchCache:
         data = {
             "version": CACHE_VERSION,
             "entries": {k: asdict(v) for k, v in self.entries.items()},
+            "local_regressions": self.local_regressions,
         }
         self.path.write_text(json.dumps(data, indent=2))
         self._dirty_count = 0
@@ -123,6 +126,16 @@ class MatchCache:
             )
             self.entries[key] = entry
         entry.approval_status = status
+        self._dirty_count += 1
+
+    def record_correction(self, correction: dict) -> None:
+        """Retain user-derived matcher truth only in local application data."""
+        identity = correction["source_track_id"]
+        self.local_regressions = [
+            item for item in self.local_regressions
+            if item.get("source_track_id") != identity
+        ]
+        self.local_regressions.append(correction)
         self._dirty_count += 1
 
     def is_retry_eligible(self, artist: str, title: str,

--- a/djsupport/cli.py
+++ b/djsupport/cli.py
@@ -323,7 +323,13 @@ DEFAULT_BEATPORT_STATE_PATH = str(default_publication_manifest_path())
     "--cache-path", default=DEFAULT_BEATPORT_CACHE_PATH, show_default=True,
     help="Path to durable matching knowledge.",
 )
-def approve(playlist_id: str, state_path: str, cache_path: str) -> None:
+@click.option(
+    "--review-csv", type=click.Path(exists=True, dir_okay=False),
+    help="Edited review CSV containing explicit Corrections.",
+)
+def approve(
+    playlist_id: str, state_path: str, cache_path: str, review_csv: str | None,
+) -> None:
     """Approve one Provisional Playlist after reviewing it in Spotify."""
     from djsupport.cache import MatchCache
     from djsupport.transfer import (
@@ -344,7 +350,10 @@ def approve(playlist_id: str, state_path: str, cache_path: str) -> None:
         publication_storage=FilePublicationStorage(state_path),
     )
     try:
-        review = transfer.approve(playlist_id)
+        if review_csv is None:
+            review = transfer.approve(playlist_id)
+        else:
+            review = transfer.approve(playlist_id, corrections=review_csv)
     except ValueError as exc:
         raise click.ClickException(str(exc)) from exc
     if review.status.value == "abandoned":
@@ -355,7 +364,8 @@ def approve(playlist_id: str, state_path: str, cache_path: str) -> None:
     click.echo(
         f"Provisional Playlist {playlist_id}: "
         f"{len(review.approved)} approved, {len(review.rejected)} rejected, "
-        f"{len(review.collisions)} collisions."
+        f"{len(review.collisions)} collisions, "
+        f"{len(review.corrections)} Corrections."
     )
 
 

--- a/djsupport/transfer.py
+++ b/djsupport/transfer.py
@@ -769,6 +769,7 @@ class Transfer:
         )
         manifest_items = {item.source_track_id: item for item in manifest.items}
         corrected: dict[str, PublicationItem] = {}
+        seen_source_references: set[str] = set()
         with Path(corrections).open(newline="") as csv_file:
             reader = csv.DictReader(csv_file)
             required = {"source_track_id", "spotify_url"}
@@ -790,20 +791,18 @@ class Transfer:
                         f"Correction row {row_number} source_track_id "
                         f"{source_track_id} is not a unique stable source reference"
                     )
-                if source_track_id in corrected:
+                if source_track_id in seen_source_references:
                     raise ValueError(
                         f"Correction row {row_number} repeats source_track_id "
                         f"{source_track_id}"
                     )
+                seen_source_references.add(source_track_id)
                 original = manifest_items[source_track_id]
-                if spotify_reference == original.spotify_uri or (
-                    original.spotify_uri.startswith("spotify:track:")
-                    and spotify_reference.split("?", 1)[0].endswith(
-                        f"/track/{original.spotify_uri.removeprefix('spotify:track:')}"
-                    )
-                ):
+                if spotify_reference == original.spotify_uri:
                     continue
                 spotify_uri = self._spotify_uri(spotify_reference, row_number)
+                if spotify_uri == original.spotify_uri:
+                    continue
                 spotify_track = self._retry_policy.run(
                     lambda uri=spotify_uri: self._spotify.spotify_track(uri)
                 )

--- a/djsupport/transfer.py
+++ b/djsupport/transfer.py
@@ -9,13 +9,15 @@ from __future__ import annotations
 
 import json
 import hashlib
+import csv
 import os
+import re
 import sys
 import tempfile
 import time
 from collections import Counter
 from contextlib import contextmanager
-from dataclasses import asdict, dataclass
+from dataclasses import asdict, dataclass, replace
 from datetime import datetime
 from enum import Enum
 from pathlib import Path
@@ -39,6 +41,10 @@ from djsupport.spotify import MAX_RATE_LIMIT_WAIT, RateLimitError, _parse_retry_
 
 PUBLICATION_MANIFEST_VERSION = 1
 TRANSFER_STATE_VERSION = 1
+SPOTIFY_TRACK_URI = re.compile(r"^spotify:track:([A-Za-z0-9]{22})$")
+SPOTIFY_TRACK_URL = re.compile(
+    r"^https://open\.spotify\.com/track/([A-Za-z0-9]{22})(?:\?.*)?$"
+)
 ResultT = TypeVar("ResultT")
 
 
@@ -237,6 +243,7 @@ class ApprovalOutcome:
     approved: tuple[PublicationItem, ...] = ()
     rejected: tuple[PublicationItem, ...] = ()
     collisions: tuple[PublicationItem, ...] = ()
+    corrections: tuple[PublicationItem, ...] = ()
 
 
 class SourceAdapter(Protocol):
@@ -260,6 +267,12 @@ class SpotifyAdapter(Protocol):
     def provisional_playlist_track_uris(
         self, playlist_id: str,
     ) -> list[str] | None: ...
+
+    def replace_provisional_playlist_tracks(
+        self, playlist_id: str, track_uris: list[str],
+    ) -> None: ...
+
+    def spotify_track(self, uri: str) -> dict: ...
 
 
 class PublicationStorage(Protocol):
@@ -413,6 +426,8 @@ class MatchingKnowledge(Protocol):
 
     def reject(self, item: PublicationItem) -> None: ...
 
+    def correct(self, item: PublicationItem) -> None: ...
+
 
 class BeatportChartSource:
     """Production source adapter for one Beatport chart."""
@@ -505,6 +520,23 @@ class SpotifyMatcher:
             page = self._client.next(page)
         return uris
 
+    def replace_provisional_playlist_tracks(
+        self, playlist_id: str, track_uris: list[str],
+    ) -> None:
+        self._client.playlist_replace_items(playlist_id, track_uris[:100])
+        for offset in range(100, len(track_uris), 100):
+            self._client.playlist_add_items(
+                playlist_id, track_uris[offset:offset + 100],
+            )
+
+    def spotify_track(self, uri: str) -> dict:
+        track = self._client.track(uri)
+        return {
+            "uri": track["uri"],
+            "name": track["name"],
+            "artist": ", ".join(artist["name"] for artist in track["artists"]),
+        }
+
 
 class MatchCacheKnowledge:
     """Expose the existing durable match cache as Transfer storage."""
@@ -566,6 +598,17 @@ class MatchCacheKnowledge:
             },
         )
 
+    def correct(self, item: PublicationItem) -> None:
+        self.approve(item)
+        self._cache.record_correction({
+            "source_track_id": item.source_track_id,
+            "source_artist": item.source_artist,
+            "source_title": item.source_title,
+            "spotify_uri": item.spotify_uri,
+            "spotify_name": item.spotify_name,
+            "spotify_artist": item.spotify_artist,
+        })
+
 
 class EphemeralMatchingKnowledge:
     """Non-persistent matching knowledge used for explicit ``--no-cache``."""
@@ -590,6 +633,9 @@ class EphemeralMatchingKnowledge:
         pass
 
     def reject(self, item: PublicationItem) -> None:
+        pass
+
+    def correct(self, item: PublicationItem) -> None:
         pass
 
 
@@ -634,7 +680,9 @@ class Transfer:
         state.status = TransferStatus.ABANDONED
         self._transfer_storage.save_transfer(transfer_id, state)
 
-    def approve(self, playlist_id: str) -> ApprovalOutcome:
+    def approve(
+        self, playlist_id: str, *, corrections: str | Path | None = None,
+    ) -> ApprovalOutcome:
         """Review exactly one retained Provisional Playlist against Spotify."""
         if self._publication_storage is None:
             raise ValueError("Approval requires publication storage")
@@ -647,6 +695,7 @@ class Transfer:
                 f"No Provisional Playlist {playlist_id} belongs to this Spotify account"
             )
         with self._publishing_guards.acquire(account_id):
+            corrected_items = self._read_corrections(corrections, manifest)
             current_uris = self._retry_policy.run(
                 lambda: self._spotify.provisional_playlist_track_uris(playlist_id)
             )
@@ -658,17 +707,23 @@ class Transfer:
                     status=ApprovalStatus.ABANDONED,
                 )
             else:
+                if corrected_items:
+                    current_uris = self._repair_corrections(
+                        playlist_id, manifest, current_uris, corrected_items,
+                    )
                 remaining = Counter(current_uris)
                 approved: list[PublicationItem] = []
                 rejected: list[PublicationItem] = []
-                proposed_counts = Counter(
-                    item.spotify_uri for item in manifest.items
+                reviewed_items = tuple(
+                    corrected_items.get(item.source_track_id, item)
+                    for item in manifest.items
                 )
+                proposed_counts = Counter(item.spotify_uri for item in reviewed_items)
                 collision_uris = {
                     uri for uri, count in proposed_counts.items() if count > 1
                 }
                 collisions: list[PublicationItem] = []
-                for item in manifest.items:
+                for item in reviewed_items:
                     if item.spotify_uri in collision_uris:
                         collisions.append(item)
                         continue
@@ -688,14 +743,132 @@ class Transfer:
                     approved=tuple(approved),
                     rejected=tuple(rejected),
                     collisions=tuple(collisions),
+                    corrections=tuple(
+                        item for item in approved
+                        if item.source_track_id in corrected_items
+                    ),
                 )
                 for item in outcome.approved:
-                    self._knowledge.approve(item)
+                    if item.source_track_id in corrected_items:
+                        self._knowledge.correct(item)
+                    else:
+                        self._knowledge.approve(item)
                 for item in outcome.rejected:
                     self._knowledge.reject(item)
                 self._knowledge.checkpoint()
             self._publication_storage.retain_approval(outcome)
             return outcome
+
+    def _read_corrections(
+        self, corrections: str | Path | None, manifest: PublicationManifest,
+    ) -> dict[str, PublicationItem]:
+        if corrections is None:
+            return {}
+        source_reference_counts = Counter(
+            item.source_track_id for item in manifest.items
+        )
+        manifest_items = {item.source_track_id: item for item in manifest.items}
+        corrected: dict[str, PublicationItem] = {}
+        with Path(corrections).open(newline="") as csv_file:
+            reader = csv.DictReader(csv_file)
+            required = {"source_track_id", "spotify_url"}
+            if not required.issubset(reader.fieldnames or ()):
+                raise ValueError(
+                    "Correction CSV requires source_track_id and spotify_url columns"
+                )
+            for row_number, row in enumerate(reader, start=2):
+                source_track_id = (row.get("source_track_id") or "").strip()
+                spotify_reference = (row.get("spotify_url") or "").strip()
+                if not spotify_reference:
+                    continue
+                if not source_track_id or source_track_id not in manifest_items:
+                    raise ValueError(
+                        f"Correction row {row_number} has an unknown source_track_id"
+                    )
+                if source_reference_counts[source_track_id] != 1:
+                    raise ValueError(
+                        f"Correction row {row_number} source_track_id "
+                        f"{source_track_id} is not a unique stable source reference"
+                    )
+                if source_track_id in corrected:
+                    raise ValueError(
+                        f"Correction row {row_number} repeats source_track_id "
+                        f"{source_track_id}"
+                    )
+                original = manifest_items[source_track_id]
+                if spotify_reference == original.spotify_uri or (
+                    original.spotify_uri.startswith("spotify:track:")
+                    and spotify_reference.split("?", 1)[0].endswith(
+                        f"/track/{original.spotify_uri.removeprefix('spotify:track:')}"
+                    )
+                ):
+                    continue
+                spotify_uri = self._spotify_uri(spotify_reference, row_number)
+                spotify_track = self._retry_policy.run(
+                    lambda uri=spotify_uri: self._spotify.spotify_track(uri)
+                )
+                if spotify_track.get("uri") != spotify_uri:
+                    raise ValueError(
+                        f"Correction row {row_number} did not resolve to its Spotify track"
+                    )
+                corrected[source_track_id] = replace(
+                    original,
+                    spotify_uri=spotify_uri,
+                    spotify_name=spotify_track["name"],
+                    spotify_artist=spotify_track["artist"],
+                    score=100.0,
+                    match_type="correction",
+                )
+        return corrected
+
+    @staticmethod
+    def _spotify_uri(reference: str, row_number: int) -> str:
+        uri_match = SPOTIFY_TRACK_URI.fullmatch(reference)
+        if uri_match:
+            return reference
+        url_match = SPOTIFY_TRACK_URL.fullmatch(reference)
+        if url_match:
+            return f"spotify:track:{url_match.group(1)}"
+        raise ValueError(
+            f"Correction row {row_number} has an invalid Spotify track URL or URI"
+        )
+
+    def _repair_corrections(
+        self,
+        playlist_id: str,
+        manifest: PublicationManifest,
+        current_uris: list[str],
+        corrected_items: dict[str, PublicationItem],
+    ) -> list[str]:
+        original_uris = {item.spotify_uri for item in manifest.items}
+        corrected_uris = {item.spotify_uri for item in corrected_items.values()}
+        managed_uris = original_uris | corrected_uris
+        present = Counter(current_uris)
+        desired = []
+        for item in manifest.items:
+            correction = corrected_items.get(item.source_track_id)
+            if correction is not None:
+                if correction.spotify_uri not in desired:
+                    desired.append(correction.spotify_uri)
+            elif present[item.spotify_uri] and item.spotify_uri not in desired:
+                desired.append(item.spotify_uri)
+
+        first_managed = next(
+            (index for index, uri in enumerate(current_uris) if uri in managed_uris),
+            0,
+        )
+        manual = [uri for uri in current_uris if uri not in managed_uris]
+        insertion = sum(
+            1 for uri in current_uris[:first_managed] if uri not in managed_uris
+        )
+        repaired = [*manual[:insertion], *desired, *manual[insertion:]]
+        if repaired != current_uris:
+            self._retry_policy.run(
+                lambda: self._spotify.replace_provisional_playlist_tracks(
+                    playlist_id, repaired,
+                )
+            )
+        return repaired
 
     def execute(self, request: TransferRequest) -> SyncReport:
         """Execute at most one publishing Transfer per Spotify account."""

--- a/tests/test_transfer.py
+++ b/tests/test_transfer.py
@@ -1,6 +1,7 @@
 """Behavior tests at the public Transfer seam."""
 
 import json
+import csv
 import threading
 from concurrent.futures import ThreadPoolExecutor
 from datetime import datetime, timedelta
@@ -58,6 +59,7 @@ class StatefulSpotify:
         self.searches = []
         self.playlists = {"existing": ["spotify:track:untouched"]}
         self.publication_keys = {}
+        self.playlist_replacements = 0
 
     def account_id(self):
         return "spotify-user-1"
@@ -87,6 +89,18 @@ class StatefulSpotify:
             return None
         return list(playlist["tracks"])
 
+    def replace_provisional_playlist_tracks(self, playlist_id, track_uris):
+        self.playlist_replacements += 1
+        self.playlists[playlist_id]["tracks"] = list(track_uris)
+
+    def spotify_track(self, uri):
+        track_id = uri.removeprefix("spotify:track:")
+        return {
+            "uri": uri,
+            "name": f"Corrected {track_id}",
+            "artist": "Correction Artist",
+        }
+
     def match(self, track, threshold):
         self.searches.append((track.artist, track.name, threshold))
         return self.matches.get((track.artist, track.name))
@@ -103,6 +117,7 @@ class InMemoryStorage:
         self.approvals = []
         self.approved_matches = []
         self.rejected_matches = []
+        self.corrections = []
 
     def lookup(self, track, threshold):
         result = self.matches.get((track.artist, track.name))
@@ -144,6 +159,9 @@ class InMemoryStorage:
 
     def reject(self, item):
         self.rejected_matches.append(item)
+
+    def correct(self, item):
+        self.corrections.append(item)
 
 
 FIXTURE = Path(__file__).parent / "fixtures" / "beatport_chart.json"
@@ -893,6 +911,182 @@ class TestProvisionalPlaylistApproval:
         assert storage.approved_matches == list(review.approved)
         assert storage.rejected_matches == list(review.rejected)
 
+    def test_review_csv_corrections_repair_playlist_and_become_local_truth(
+        self, tmp_path,
+    ):
+        transfer, spotify, storage, playlist_id = self.publish()
+        spotify.playlists[playlist_id]["tracks"] = [
+            "spotify:track:abcdefghijklmnopqrstuv",
+            "spotify:track:known",
+            "spotify:track:new",
+            "spotify:track:manual",
+        ]
+        review_csv = tmp_path / "review.csv"
+        with review_csv.open("w", newline="") as csv_file:
+            writer = csv.DictWriter(csv_file, fieldnames=[
+                "source_track_id", "source_track", "spotify_url",
+                "spotify_track", "score", "match_type",
+            ])
+            writer.writeheader()
+            writer.writerow({
+                "source_track_id": "bp-2",
+                "spotify_url": (
+                    "https://open.spotify.com/track/abcdefghijklmnopqrstuv"
+                    "?si=review"
+                ),
+            })
+
+        review = transfer.approve(playlist_id, corrections=review_csv)
+
+        assert spotify.playlists[playlist_id]["tracks"] == [
+            "spotify:track:known",
+            "spotify:track:abcdefghijklmnopqrstuv",
+            "spotify:track:manual",
+        ]
+        assert [item.source_track_id for item in review.approved] == ["bp-1", "bp-2"]
+        assert [item.spotify_uri for item in review.approved] == [
+            "spotify:track:known", "spotify:track:abcdefghijklmnopqrstuv",
+        ]
+        assert review.rejected == ()
+        assert review.corrections == (review.approved[1],)
+        assert storage.corrections == [review.approved[1]]
+
+    def test_unchanged_review_rows_are_ordinary_approvals(self, tmp_path):
+        transfer, _, storage, playlist_id = self.publish()
+        review_csv = tmp_path / "review.csv"
+        with review_csv.open("w", newline="") as csv_file:
+            writer = csv.DictWriter(
+                csv_file, fieldnames=["source_track_id", "spotify_url"],
+            )
+            writer.writeheader()
+            writer.writerow({
+                "source_track_id": "bp-1",
+                "spotify_url": "spotify:track:known",
+            })
+
+        review = transfer.approve(playlist_id, corrections=review_csv)
+
+        assert [item.source_track_id for item in review.approved] == ["bp-1", "bp-2"]
+        assert storage.corrections == []
+
+    @pytest.mark.parametrize(
+        ("rows", "message"),
+        [
+            ([{"source_track_id": "missing", "spotify_url": "spotify:track:abcdefghijklmnopqrstuv"}], "unknown source_track_id"),
+            ([{"source_track_id": "bp-1", "spotify_url": "https://example.com/track/abcdefghijklmnopqrstuv"}], "invalid Spotify track"),
+            ([
+                {"source_track_id": "bp-1", "spotify_url": "spotify:track:abcdefghijklmnopqrstuv"},
+                {"source_track_id": "bp-1", "spotify_url": "spotify:track:zyxwvutsrqponmlkjihgfe"},
+            ], "repeats source_track_id"),
+        ],
+    )
+    def test_invalid_corrections_are_rejected_before_playlist_changes(
+        self, tmp_path, rows, message,
+    ):
+        transfer, spotify, storage, playlist_id = self.publish()
+        original = list(spotify.playlists[playlist_id]["tracks"])
+        review_csv = tmp_path / "review.csv"
+        with review_csv.open("w", newline="") as csv_file:
+            writer = csv.DictWriter(
+                csv_file, fieldnames=["source_track_id", "spotify_url"],
+            )
+            writer.writeheader()
+            writer.writerows(rows)
+
+        with pytest.raises(ValueError, match=message):
+            transfer.approve(playlist_id, corrections=review_csv)
+
+        assert spotify.playlists[playlist_id]["tracks"] == original
+        assert storage.approvals == []
+        assert storage.corrections == []
+
+    def test_correction_is_durable_approved_knowledge_and_local_regression(
+        self, tmp_path,
+    ):
+        _, spotify, publications, playlist_id = self.publish()
+        cache_path = tmp_path / "matching-knowledge.json"
+        cache = MatchCache(str(cache_path))
+        transfer = Transfer(
+            publishing_guards=TEST_PUBLISHING_GUARDS,
+            source=FixtureBeatportSource(FIXTURE), spotify=spotify,
+            matching_knowledge=MatchCacheKnowledge(cache),
+            publication_storage=publications,
+        )
+        review_csv = tmp_path / "review.csv"
+        with review_csv.open("w", newline="") as csv_file:
+            writer = csv.DictWriter(
+                csv_file, fieldnames=["source_track_id", "spotify_url"],
+            )
+            writer.writeheader()
+            writer.writerow({
+                "source_track_id": "bp-2",
+                "spotify_url": "spotify:track:abcdefghijklmnopqrstuv",
+            })
+
+        transfer.approve(playlist_id, corrections=review_csv)
+
+        reloaded = MatchCache(str(cache_path))
+        reloaded.load()
+        approved = reloaded.lookup("New Artist", "New Track", 100)
+        assert approved is not None
+        assert approved.spotify_uri == "spotify:track:abcdefghijklmnopqrstuv"
+        assert approved.approval_status == "approved"
+        assert reloaded.local_regressions == [{
+            "source_track_id": "bp-2",
+            "source_artist": "New Artist",
+            "source_title": "New Track",
+            "spotify_uri": "spotify:track:abcdefghijklmnopqrstuv",
+            "spotify_name": "Corrected abcdefghijklmnopqrstuv",
+            "spotify_artist": "Correction Artist",
+        }]
+
+    def test_missing_correction_is_added_once_across_repeated_approval(self, tmp_path):
+        transfer, spotify, _, playlist_id = self.publish()
+        spotify.playlists[playlist_id]["tracks"] = [
+            "spotify:track:known", "spotify:track:manual",
+        ]
+        review_csv = tmp_path / "review.csv"
+        review_csv.write_text(
+            "source_track_id,spotify_url\n"
+            "bp-2,spotify:track:abcdefghijklmnopqrstuv\n"
+        )
+
+        transfer.approve(playlist_id, corrections=review_csv)
+        transfer.approve(playlist_id, corrections=review_csv)
+
+        assert spotify.playlists[playlist_id]["tracks"] == [
+            "spotify:track:known",
+            "spotify:track:abcdefghijklmnopqrstuv",
+            "spotify:track:manual",
+        ]
+        assert spotify.playlist_replacements == 1
+
+    def test_ambiguous_source_reference_cannot_receive_a_correction(self, tmp_path):
+        transfer, _, storage, playlist_id = self.publish()
+        manifest = storage.publications[0]
+        storage.publications[0] = type(manifest)(
+            **{
+                **manifest.__dict__,
+                "items": (
+                    manifest.items[0],
+                    type(manifest.items[1])(
+                        **{
+                            **manifest.items[1].__dict__,
+                            "source_track_id": manifest.items[0].source_track_id,
+                        }
+                    ),
+                ),
+            }
+        )
+        review_csv = tmp_path / "review.csv"
+        review_csv.write_text(
+            "source_track_id,spotify_url\n"
+            "bp-1,spotify:track:abcdefghijklmnopqrstuv\n"
+        )
+
+        with pytest.raises(ValueError, match="not a unique stable source reference"):
+            transfer.approve(playlist_id, corrections=review_csv)
+
     def test_deleted_provisional_playlist_is_abandoned_with_history_retained(self):
         transfer, spotify, storage, playlist_id = self.publish()
         del spotify.playlists[playlist_id]
@@ -1107,3 +1301,25 @@ class TestBeatportCliTransfer:
         approve.assert_called_once_with("snapshot-1")
         assert "1 approved" in result.output
         assert "2 rejected" in result.output
+
+    @patch("djsupport.transfer.Transfer.approve")
+    @patch("djsupport.cli.get_client", return_value=MagicMock())
+    def test_cli_applies_an_edited_review_csv(
+        self, mock_client, approve, tmp_path,
+    ):
+        approve.return_value = ApprovalOutcome(
+            account_id="spotify-user-1",
+            spotify_playlist_id="snapshot-1",
+            reviewed_at=datetime.now(),
+            status=ApprovalStatus.APPROVED,
+        )
+        review_csv = tmp_path / "review.csv"
+        review_csv.write_text("source_track_id,spotify_url\n")
+
+        result = CliRunner().invoke(cli, [
+            "approve", "snapshot-1", "--review-csv", str(review_csv),
+            "--state-path", str(tmp_path / "state.json"),
+        ])
+
+        assert result.exit_code == 0, result.output
+        approve.assert_called_once_with("snapshot-1", corrections=str(review_csv))

--- a/tests/test_transfer.py
+++ b/tests/test_transfer.py
@@ -974,9 +974,14 @@ class TestProvisionalPlaylistApproval:
         [
             ([{"source_track_id": "missing", "spotify_url": "spotify:track:abcdefghijklmnopqrstuv"}], "unknown source_track_id"),
             ([{"source_track_id": "bp-1", "spotify_url": "https://example.com/track/abcdefghijklmnopqrstuv"}], "invalid Spotify track"),
+            ([{"source_track_id": "bp-1", "spotify_url": "https://example.com/track/known"}], "invalid Spotify track"),
             ([
                 {"source_track_id": "bp-1", "spotify_url": "spotify:track:abcdefghijklmnopqrstuv"},
                 {"source_track_id": "bp-1", "spotify_url": "spotify:track:zyxwvutsrqponmlkjihgfe"},
+            ], "repeats source_track_id"),
+            ([
+                {"source_track_id": "bp-1", "spotify_url": "spotify:track:known"},
+                {"source_track_id": "bp-1", "spotify_url": "spotify:track:abcdefghijklmnopqrstuv"},
             ], "repeats source_track_id"),
         ],
     )


### PR DESCRIPTION
Closes #19

## Summary
- accept and validate edited review CSV Corrections through the public Transfer approval seam
- repair Provisional Playlists idempotently while preserving manual tracks and source-relative order
- promote Corrections to Approved Matches and durable local-only regression knowledge
- expose Corrections in approval outcomes and the CLI

## Validation
- 389 offline tests passed
- Python compilation passed
- git diff validation passed
- parallel Standards and Spec reviews: no blocking findings