### PR TITLE
Reuse authoritative knowledge and expose uncertain outcomes

### DIFF
--- a/djsupport/cache.py
+++ b/djsupport/cache.py
@@ -74,6 +74,16 @@ class MatchCache:
         entry = self.entries.get(key)
         if entry is None and source_duration > 0:
             entry = self.entries.get(self.cache_key(artist, title))
+        if source_duration == 0:
+            identity_prefix = f"{self.cache_key(artist, title)}||"
+            approved = [
+                candidate for candidate_key, candidate in self.entries.items()
+                if candidate_key.startswith(identity_prefix)
+                and candidate.approval_status == "approved"
+            ]
+            approved_uris = {candidate.spotify_uri for candidate in approved}
+            if len(approved_uris) == 1:
+                entry = approved[0]
         if entry is None:
             return None
         if entry.approval_status == "rejected":

--- a/djsupport/cache.py
+++ b/djsupport/cache.py
@@ -24,6 +24,7 @@ class CacheEntry:
     threshold: int
     match_type: str | None = None
     approval_status: str | None = None
+    source_duration: int = 0
 
 
 class MatchCache:
@@ -31,6 +32,7 @@ class MatchCache:
         self.path = Path(path)
         self.entries: dict[str, CacheEntry] = {}
         self.local_regressions: list[dict] = []
+        self.approval_conflicts: list[dict] = []
         self._dirty_count: int = 0
 
     def load(self) -> None:
@@ -46,6 +48,7 @@ class MatchCache:
         for key, entry in data.get("entries", {}).items():
             self.entries[key] = CacheEntry(**entry)
         self.local_regressions = data.get("local_regressions", [])
+        self.approval_conflicts = data.get("approval_conflicts", [])
 
     def save(self) -> None:
         """Write cache to disk."""
@@ -54,22 +57,34 @@ class MatchCache:
             "version": CACHE_VERSION,
             "entries": {k: asdict(v) for k, v in self.entries.items()},
             "local_regressions": self.local_regressions,
+            "approval_conflicts": self.approval_conflicts,
         }
         self.path.write_text(json.dumps(data, indent=2))
         self._dirty_count = 0
 
-    def cache_key(self, artist: str, title: str) -> str:
-        return f"{_normalize(artist)}||{_normalize(title)}"
+    def cache_key(self, artist: str, title: str, source_duration: int = 0) -> str:
+        identity = f"{_normalize(artist)}||{_normalize(title)}"
+        return f"{identity}||{source_duration}s" if source_duration > 0 else identity
 
-    def lookup(self, artist: str, title: str, threshold: int) -> CacheEntry | None:
+    def lookup(
+        self, artist: str, title: str, threshold: int, source_duration: int = 0,
+    ) -> CacheEntry | None:
         """Return cached entry if valid for this threshold, else None."""
-        key = self.cache_key(artist, title)
+        key = self.cache_key(artist, title, source_duration)
         entry = self.entries.get(key)
+        if entry is None and source_duration > 0:
+            entry = self.entries.get(self.cache_key(artist, title))
         if entry is None:
             return None
         if entry.approval_status == "rejected":
             return None
         if entry.approval_status == "approved":
+            if (
+                entry.source_duration > 0
+                and source_duration > 0
+                and abs(entry.source_duration - source_duration) > 30
+            ):
+                return None
             return entry
         if entry.matched and entry.score is not None and entry.score >= threshold:
             return entry
@@ -109,10 +124,30 @@ class MatchCache:
 
     def record_approval(
         self, artist: str, title: str, status: str, result: dict,
-    ) -> None:
+        source_duration: int = 0,
+    ) -> dict | None:
         """Mark retained matching knowledge as explicitly approved or rejected."""
-        key = self.cache_key(artist, title)
+        key = self.cache_key(artist, title, source_duration)
+        if source_duration > 0:
+            self.entries.pop(self.cache_key(artist, title), None)
         entry = self.entries.get(key)
+        if (
+            status == "approved"
+            and entry is not None
+            and entry.approval_status == "approved"
+            and entry.spotify_uri != result["uri"]
+        ):
+            conflict = {
+                "source_artist": artist,
+                "source_title": title,
+                "source_duration": source_duration,
+                "approved_spotify_uri": entry.spotify_uri,
+                "proposed_spotify_uri": result["uri"],
+            }
+            if conflict not in self.approval_conflicts:
+                self.approval_conflicts.append(conflict)
+                self._dirty_count += 1
+            return conflict
         if entry is None or status == "approved":
             entry = CacheEntry(
                 spotify_uri=result["uri"],
@@ -123,10 +158,12 @@ class MatchCache:
                 timestamp=datetime.now().isoformat(),
                 threshold=0,
                 match_type=result.get("match_type"),
+                source_duration=source_duration,
             )
             self.entries[key] = entry
         entry.approval_status = status
         self._dirty_count += 1
+        return None
 
     def record_correction(self, correction: dict) -> None:
         """Retain user-derived matcher truth only in local application data."""

--- a/djsupport/matcher.py
+++ b/djsupport/matcher.py
@@ -288,42 +288,30 @@ def _select_best(track: Track, results: list[dict], threshold: int) -> dict | No
     return None
 
 
-def match_track(sp, track: Track, threshold: int = 80) -> dict | None:
-    """Try to find a Spotify match for a Rekordbox track.
-
-    Runs search strategies in order and picks the best result across all of them.
-    If Strategy 1 returns a high-confidence exact match (>= EARLY_EXIT_THRESHOLD),
-    remaining strategies are skipped to reduce API calls.
-    """
+def _search_candidates(sp, track: Track) -> list[dict]:
+    """Gather candidates through the shared ordered Spotify search strategy."""
     all_results: list[dict] = []
-
-    # Strategy 1: search with artist + title
     all_results.extend(search_track(sp, track.artist, track.name))
-
-    # Early exit: if Strategy 1 already found a high-confidence exact match,
-    # skip remaining strategies to reduce API calls.
     early = _select_best(track, all_results, EARLY_EXIT_THRESHOLD)
     if early is not None and early["match_type"] == "exact":
-        return early
-
-    # Strategy 2: strip mix info from title
+        return all_results
     stripped = _strip_mix_info(track.name)
     if stripped != track.name:
         all_results.extend(search_track(sp, track.artist, stripped))
-
-    # Strategy 3: include remixer as part of artist search
     if track.remixer:
         all_results.extend(search_track(sp, f"{track.artist} {track.remixer}", track.name))
-
-    # Strategy 4: clean artist (strips country tags) + stripped title
     clean_artist = _normalize(track.artist)
     clean_title = _normalize(stripped)
     if clean_artist != track.artist.lower().strip() or clean_title != stripped.lower().strip():
         all_results.extend(search_track(sp, clean_artist, clean_title))
-
-    # Strategy 5: plain-text search without field prefixes (forgiving of misspellings)
     if not all_results:
         all_results.extend(search_track(sp, track.artist, track.name, plain=True))
+    return all_results
+
+
+def match_track(sp, track: Track, threshold: int = 80) -> dict | None:
+    """Try to find a Spotify match for a Rekordbox track."""
+    all_results = _search_candidates(sp, track)
 
     return _select_best(track, all_results, threshold)
 
@@ -332,17 +320,7 @@ def match_track_with_alternatives(
     sp, track: Track, threshold: int = 80,
 ) -> dict | None:
     """Return an acceptable match or up to three explained alternatives."""
-    all_results: list[dict] = []
-    all_results.extend(search_track(sp, track.artist, track.name))
-    stripped = _strip_mix_info(track.name)
-    if stripped != track.name:
-        all_results.extend(search_track(sp, track.artist, stripped))
-    if track.remixer:
-        all_results.extend(search_track(
-            sp, f"{track.artist} {track.remixer}", track.name,
-        ))
-    if not all_results:
-        all_results.extend(search_track(sp, track.artist, track.name, plain=True))
+    all_results = _search_candidates(sp, track)
     match = _select_best(track, all_results, threshold)
     if match is not None:
         return match

--- a/djsupport/matcher.py
+++ b/djsupport/matcher.py
@@ -328,6 +328,45 @@ def match_track(sp, track: Track, threshold: int = 80) -> dict | None:
     return _select_best(track, all_results, threshold)
 
 
+def match_track_with_alternatives(
+    sp, track: Track, threshold: int = 80,
+) -> dict | None:
+    """Return an acceptable match or up to three explained alternatives."""
+    all_results: list[dict] = []
+    all_results.extend(search_track(sp, track.artist, track.name))
+    stripped = _strip_mix_info(track.name)
+    if stripped != track.name:
+        all_results.extend(search_track(sp, track.artist, stripped))
+    if track.remixer:
+        all_results.extend(search_track(
+            sp, f"{track.artist} {track.remixer}", track.name,
+        ))
+    if not all_results:
+        all_results.extend(search_track(sp, track.artist, track.name, plain=True))
+    match = _select_best(track, all_results, threshold)
+    if match is not None:
+        return match
+    unique = {candidate["uri"]: candidate for candidate in all_results}
+    ranked = []
+    for candidate in unique.values():
+        components = _score_components(track, candidate)
+        score = _score_result(track, candidate, components)
+        ranked.append({
+            **candidate,
+            "score": score,
+            "version": (
+                _extract_mix_descriptor(candidate["name"]) or "default version"
+            ),
+            "score_reasons": [
+                "title similarity "
+                f"{max(components['raw_title_score'], components['stripped_title_score']):.0f}",
+                f"artist similarity {components['artist_score']:.0f}",
+            ],
+        })
+    ranked.sort(key=lambda item: item["score"], reverse=True)
+    return {"alternatives": ranked[:3]} if ranked else None
+
+
 def match_track_cached(
     sp, track: Track, cache: "MatchCache", threshold: int = 80,
     retry_days: int = 7, force_retry: bool = False,

--- a/djsupport/report.py
+++ b/djsupport/report.py
@@ -23,6 +23,39 @@ class MatchedTrack:
     spotify_uri: str = ""
 
 
+@dataclass(frozen=True)
+class AlternativeCandidate:
+    rank: int
+    spotify_uri: str
+    spotify_name: str
+    spotify_artist: str
+    version: str
+    duration_ms: int
+    score: float
+    score_reasons: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class UnmatchedAlternatives:
+    source_track_id: str
+    source_name: str
+    candidates: tuple[AlternativeCandidate, ...]
+
+
+@dataclass(frozen=True)
+class UnavailableApprovedMatch:
+    source_track_id: str
+    source_name: str
+    spotify_uri: str
+
+
+@dataclass(frozen=True)
+class MatchCollision:
+    source_track_id: str
+    source_name: str
+    spotify_uri: str
+
+
 def _spotify_url(uri: str) -> str:
     if uri.startswith("spotify:track:"):
         return f"https://open.spotify.com/track/{uri.removeprefix('spotify:track:')}"
@@ -35,6 +68,9 @@ class PlaylistReport:
     path: str
     matched: list[MatchedTrack] = field(default_factory=list)
     unmatched: list[str] = field(default_factory=list)
+    alternatives: list[UnmatchedAlternatives] = field(default_factory=list)
+    unavailable_approved: list[UnavailableApprovedMatch] = field(default_factory=list)
+    match_collisions: list[MatchCollision] = field(default_factory=list)
     action: str = "dry-run"  # "created", "updated", "unchanged", or "dry-run"
     spotify_playlist_id: str | None = None
     publication_manifest: PublicationManifest | None = None
@@ -178,6 +214,39 @@ def save_report(report: SyncReport, path: str) -> None:
                 lines.append(
                     f"| {m.source_track_id} | {m.source_name} | {proposal}"
                     f" | {m.score:.1f} | {m.match_type} | {reasons} |"
+                )
+            lines.append("")
+
+        for uncertain in pl.alternatives:
+            lines.append(f"### Alternatives for {uncertain.source_name}")
+            lines.append("")
+            for candidate in uncertain.candidates:
+                reasons = "; ".join(candidate.score_reasons)
+                lines.append(
+                    f"{candidate.rank}. [{candidate.spotify_artist} - "
+                    f"{candidate.spotify_name}]({_spotify_url(candidate.spotify_uri)}) "
+                    f"— {candidate.version}, {candidate.duration_ms / 1000:.0f}s, "
+                    f"score {candidate.score:.1f} ({reasons})"
+                )
+            lines.append("")
+
+        if pl.unavailable_approved:
+            lines.append("### Unavailable Approved Matches")
+            lines.append("")
+            for unavailable in pl.unavailable_approved:
+                lines.append(
+                    f"- {unavailable.source_name}: retained authoritative mapping "
+                    f"to `{unavailable.spotify_uri}`; no replacement attempted"
+                )
+            lines.append("")
+
+        if pl.match_collisions:
+            lines.append("### Match Collisions (review required)")
+            lines.append("")
+            for collision in pl.match_collisions:
+                lines.append(
+                    f"- {collision.source_track_id}: {collision.source_name} → "
+                    f"`{collision.spotify_uri}`"
                 )
             lines.append("")
 

--- a/djsupport/transfer.py
+++ b/djsupport/transfer.py
@@ -33,9 +33,17 @@ else:
     import fcntl
 
 from djsupport.cache import MatchCache
-from djsupport.matcher import match_track
+from djsupport.matcher import match_track_with_alternatives
 from djsupport.rekordbox import Track
-from djsupport.report import MatchedTrack, PlaylistReport, SyncReport
+from djsupport.report import (
+    AlternativeCandidate,
+    MatchCollision,
+    MatchedTrack,
+    PlaylistReport,
+    SyncReport,
+    UnmatchedAlternatives,
+    UnavailableApprovedMatch,
+)
 from djsupport.spotify import MAX_RATE_LIMIT_WAIT, RateLimitError, _parse_retry_after
 
 
@@ -185,6 +193,7 @@ class TransferState:
     matched: list[dict]
     unmatched: list[str]
     publication_items: list[dict]
+    alternatives: list[dict]
     spotify_playlist_id: str | None = None
     spotify_playlist_name: str | None = None
     publication_manifest: dict | None = None
@@ -192,7 +201,10 @@ class TransferState:
 
     @classmethod
     def from_dict(cls, value: dict) -> TransferState:
-        return cls(**{**value, "status": TransferStatus(value["status"])})
+        return cls(**{
+            "alternatives": [], **value,
+            "status": TransferStatus(value["status"]),
+        })
 
 
 @dataclass(frozen=True)
@@ -217,6 +229,7 @@ class PublicationItem:
     spotify_artist: str
     score: float
     match_type: str
+    source_duration: int = 0
 
 
 @dataclass(frozen=True)
@@ -244,6 +257,16 @@ class ApprovalOutcome:
     rejected: tuple[PublicationItem, ...] = ()
     collisions: tuple[PublicationItem, ...] = ()
     corrections: tuple[PublicationItem, ...] = ()
+    conflicts: tuple[ApprovalConflict, ...] = ()
+
+
+@dataclass(frozen=True)
+class ApprovalConflict:
+    source_artist: str
+    source_title: str
+    source_duration: int
+    approved_spotify_uri: str
+    proposed_spotify_uri: str
 
 
 class SourceAdapter(Protocol):
@@ -422,11 +445,11 @@ class MatchingKnowledge(Protocol):
 
     def checkpoint(self) -> None: ...
 
-    def approve(self, item: PublicationItem) -> None: ...
+    def approve(self, item: PublicationItem) -> ApprovalConflict | None: ...
 
     def reject(self, item: PublicationItem) -> None: ...
 
-    def correct(self, item: PublicationItem) -> None: ...
+    def correct(self, item: PublicationItem) -> ApprovalConflict | None: ...
 
 
 class BeatportChartSource:
@@ -460,7 +483,9 @@ class SpotifyMatcher:
         return self._client.current_user()["id"]
 
     def match(self, track: Track, threshold: int) -> dict | None:
-        return match_track(self._client, track, threshold=threshold)
+        return match_track_with_alternatives(
+            self._client, track, threshold=threshold,
+        )
 
     def publish_provisional_snapshot(
         self, name: str, track_uris: list[str], description: str,
@@ -547,7 +572,9 @@ class MatchCacheKnowledge:
         self._cache = cache
 
     def lookup(self, track: Track, threshold: int) -> dict | None:
-        entry = self._cache.lookup(track.artist, track.name, threshold)
+        entry = self._cache.lookup(
+            track.artist, track.name, threshold, track.duration,
+        )
         if entry is None or not entry.matched:
             return None
         return {
@@ -556,12 +583,15 @@ class MatchCacheKnowledge:
             "artist": entry.spotify_artist,
             "score": entry.score,
             "match_type": entry.match_type or "exact",
+            "authoritative": entry.approval_status == "approved",
         }
 
     def should_retry(
         self, track: Track, threshold: int, retry_days: int, force: bool,
     ) -> bool:
-        entry = self._cache.lookup(track.artist, track.name, threshold)
+        entry = self._cache.lookup(
+            track.artist, track.name, threshold, track.duration,
+        )
         if entry is None:
             return True
         if entry.matched:
@@ -574,8 +604,8 @@ class MatchCacheKnowledge:
     def checkpoint(self) -> None:
         self._cache.save()
 
-    def approve(self, item: PublicationItem) -> None:
-        self._cache.record_approval(
+    def approve(self, item: PublicationItem) -> ApprovalConflict | None:
+        conflict = self._cache.record_approval(
             item.source_artist, item.source_title, ApprovalStatus.APPROVED.value,
             {
                 "uri": item.spotify_uri,
@@ -583,8 +613,9 @@ class MatchCacheKnowledge:
                 "artist": item.spotify_artist,
                 "score": item.score,
                 "match_type": item.match_type,
-            },
+            }, item.source_duration,
         )
+        return ApprovalConflict(**conflict) if conflict else None
 
     def reject(self, item: PublicationItem) -> None:
         self._cache.record_approval(
@@ -595,11 +626,13 @@ class MatchCacheKnowledge:
                 "artist": item.spotify_artist,
                 "score": item.score,
                 "match_type": item.match_type,
-            },
+            }, item.source_duration,
         )
 
-    def correct(self, item: PublicationItem) -> None:
-        self.approve(item)
+    def correct(self, item: PublicationItem) -> ApprovalConflict | None:
+        conflict = self.approve(item)
+        if conflict is not None:
+            return conflict
         self._cache.record_correction({
             "source_track_id": item.source_track_id,
             "source_artist": item.source_artist,
@@ -608,6 +641,7 @@ class MatchCacheKnowledge:
             "spotify_name": item.spotify_name,
             "spotify_artist": item.spotify_artist,
         })
+        return None
 
 
 class EphemeralMatchingKnowledge:
@@ -748,13 +782,34 @@ class Transfer:
                         if item.source_track_id in corrected_items
                     ),
                 )
+                conflicts: list[ApprovalConflict] = []
                 for item in outcome.approved:
                     if item.source_track_id in corrected_items:
-                        self._knowledge.correct(item)
+                        conflict = self._knowledge.correct(item)
                     else:
-                        self._knowledge.approve(item)
+                        conflict = self._knowledge.approve(item)
+                    if conflict is not None:
+                        conflicts.append(conflict)
                 for item in outcome.rejected:
                     self._knowledge.reject(item)
+                if conflicts:
+                    conflict_identities = {
+                        (item.source_artist, item.source_title, item.source_duration)
+                        for item in conflicts
+                    }
+                    outcome = replace(
+                        outcome,
+                        status=ApprovalStatus.NEEDS_REVIEW,
+                        approved=tuple(item for item in outcome.approved if (
+                            item.source_artist, item.source_title,
+                            item.source_duration,
+                        ) not in conflict_identities),
+                        corrections=tuple(item for item in outcome.corrections if (
+                            item.source_artist, item.source_title,
+                            item.source_duration,
+                        ) not in conflict_identities),
+                        conflicts=tuple(conflicts),
+                    )
                 self._knowledge.checkpoint()
             self._publication_storage.retain_approval(outcome)
             return outcome
@@ -918,6 +973,7 @@ class Transfer:
                 matched=[],
                 unmatched=[],
                 publication_items=[],
+                alternatives=[],
             )
             self._save_transfer(transfer_id, state)
         else:
@@ -954,6 +1010,17 @@ class Transfer:
         )
         playlist.matched = [MatchedTrack(**item) for item in state.matched]
         playlist.unmatched = list(state.unmatched)
+        playlist.alternatives = [
+            UnmatchedAlternatives(
+                source_track_id=item["source_track_id"],
+                source_name=item["source_name"],
+                candidates=tuple(
+                    AlternativeCandidate(**candidate)
+                    for candidate in item["candidates"]
+                ),
+            )
+            for item in state.alternatives
+        ]
         publication_items = [
             PublicationItem(**item) for item in state.publication_items
         ]
@@ -982,8 +1049,6 @@ class Transfer:
                     )
             elif not request.preview and not selection.tracks:
                 playlist.action = "not published: empty source"
-            elif not request.preview and playlist.unmatched:
-                playlist.action = "not published: incomplete matching"
             return report
 
         try:
@@ -992,6 +1057,17 @@ class Transfer:
                 result = self._knowledge.lookup(track, request.threshold)
                 if result is not None:
                     playlist.cache_hits += 1
+                    if result.get("authoritative") and not self._approved_available(
+                        result["uri"]
+                    ):
+                        playlist.unavailable_approved.append(
+                            UnavailableApprovedMatch(
+                                source_track_id=track.track_id,
+                                source_name=track.display,
+                                spotify_uri=result["uri"],
+                            )
+                        )
+                        result = None
                 elif self._knowledge.should_retry(
                     track, request.threshold, request.retry_days, request.retry,
                 ):
@@ -999,13 +1075,37 @@ class Transfer:
                         lambda: self._spotify.match(track, request.threshold)
                     )
                     playlist.api_lookups += 1
-                    self._knowledge.retain(track, request.threshold, result)
+                    self._knowledge.retain(
+                        track, request.threshold,
+                        None if result and "alternatives" in result else result,
+                    )
                 else:
                     result = None
                     playlist.cache_hits += 1
 
-                if result is None:
+                if result is None or "alternatives" in result:
                     playlist.unmatched.append(track.display)
+                    candidates = tuple(
+                        AlternativeCandidate(
+                            rank=rank,
+                            spotify_uri=candidate["uri"],
+                            spotify_name=candidate["name"],
+                            spotify_artist=candidate["artist"],
+                            version=candidate.get("version", "default version"),
+                            duration_ms=candidate.get("duration_ms", 0),
+                            score=candidate["score"],
+                            score_reasons=tuple(candidate.get("score_reasons", ())),
+                        )
+                        for rank, candidate in enumerate(
+                            (result or {}).get("alternatives", ())[:3], start=1,
+                        )
+                    )
+                    if candidates:
+                        playlist.alternatives.append(UnmatchedAlternatives(
+                            source_track_id=track.track_id,
+                            source_name=track.display,
+                            candidates=candidates,
+                        ))
                 else:
                     matched_track = MatchedTrack(
                         source_name=track.display,
@@ -1027,11 +1127,13 @@ class Transfer:
                         spotify_artist=matched_track.spotify_artist,
                         score=matched_track.score,
                         match_type=matched_track.match_type,
+                        source_duration=track.duration,
                     ))
 
                 state.next_track_index = index + 1
                 state.matched = [asdict(item) for item in playlist.matched]
                 state.unmatched = list(playlist.unmatched)
+                state.alternatives = [asdict(item) for item in playlist.alternatives]
                 state.publication_items = [
                     asdict(item) for item in publication_items
                 ]
@@ -1045,10 +1147,38 @@ class Transfer:
                     return report
                 self._save_transfer(transfer_id, state)
 
+            collision_uris = {
+                uri for uri, count in Counter(
+                    item.spotify_uri for item in publication_items
+                ).items() if count > 1
+            }
+            if collision_uris:
+                colliding_items = [
+                    item for item in publication_items
+                    if item.spotify_uri in collision_uris
+                ]
+                playlist.match_collisions = [
+                    MatchCollision(
+                        item.source_track_id, item.source_name, item.spotify_uri,
+                    )
+                    for item in colliding_items
+                ]
+                colliding_ids = {
+                    item.source_track_id for item in colliding_items
+                }
+                playlist.matched = [
+                    item for item in playlist.matched
+                    if item.source_track_id not in colliding_ids
+                ]
+                playlist.unmatched.extend(
+                    item.source_name for item in colliding_items
+                    if item.source_name not in playlist.unmatched
+                )
+                state.matched = [asdict(item) for item in playlist.matched]
+                state.unmatched = list(playlist.unmatched)
+
             if not request.preview and not selection.tracks:
                 playlist.action = "not published: empty source"
-            elif not request.preview and playlist.unmatched:
-                playlist.action = "not published: incomplete matching"
             elif not request.preview:
                 playlist_id = state.spotify_playlist_id
                 snapshot_name = state.spotify_playlist_name
@@ -1066,7 +1196,9 @@ class Transfer:
                     playlist_id = self._retry_policy.run(
                         lambda: self._spotify.publish_provisional_snapshot(
                             snapshot_name,
-                            [item.spotify_uri for item in publication_items],
+                            list(dict.fromkeys(
+                                item.spotify_uri for item in publication_items
+                            )),
                             description,
                             transfer_id,
                         )
@@ -1141,3 +1273,14 @@ class Transfer:
     def _save_transfer(self, transfer_id: str, state: TransferState) -> None:
         if self._transfer_storage is not None:
             self._transfer_storage.save_transfer(transfer_id, state)
+
+    def _approved_available(self, spotify_uri: str) -> bool:
+        try:
+            track = self._retry_policy.run(
+                lambda: self._spotify.spotify_track(spotify_uri)
+            )
+        except spotipy.SpotifyException as exc:
+            if exc.http_status == 404:
+                return False
+            raise
+        return track.get("is_playable", True) is not False

--- a/djsupport/transfer.py
+++ b/djsupport/transfer.py
@@ -1147,10 +1147,14 @@ class Transfer:
                     return report
                 self._save_transfer(transfer_id, state)
 
+            source_ids_by_uri: dict[str, set[str]] = {}
+            for item in publication_items:
+                source_ids_by_uri.setdefault(item.spotify_uri, set()).add(
+                    item.source_track_id
+                )
             collision_uris = {
-                uri for uri, count in Counter(
-                    item.spotify_uri for item in publication_items
-                ).items() if count > 1
+                uri for uri, source_ids in source_ids_by_uri.items()
+                if len(source_ids) > 1
             }
             if collision_uris:
                 colliding_items = [
@@ -1198,6 +1202,7 @@ class Transfer:
                             snapshot_name,
                             list(dict.fromkeys(
                                 item.spotify_uri for item in publication_items
+                                if item.spotify_uri not in collision_uris
                             )),
                             description,
                             transfer_id,

--- a/tests/test_matcher.py
+++ b/tests/test_matcher.py
@@ -15,6 +15,7 @@ from djsupport.matcher import (
     _duration_penalty,
     _score_result,
     match_track,
+    match_track_with_alternatives,
 )
 from djsupport.rekordbox import Track
 
@@ -381,6 +382,22 @@ class TestMatchTrack:
         last_call_query = sp.search.call_args_list[-1][1].get("q") or sp.search.call_args_list[-1][0][0]
         assert "artist:" not in last_call_query
         assert "track:" not in last_call_query
+
+    def test_alternative_aware_matching_keeps_normalized_search_strategy(self):
+        sp = MagicMock()
+        candidate = make_spotify_item("Track", "Artist", "uri:normalized")
+        sp.search.side_effect = [
+            {"tracks": {"items": []}},
+            {"tracks": {"items": []}},
+            {"tracks": {"items": [candidate]}},
+        ]
+        track = make_track("Track [Label]", "Artist (UK)")
+
+        result = match_track_with_alternatives(sp, track, threshold=80)
+
+        assert result is not None
+        assert result["uri"] == "uri:normalized"
+        assert sp.search.call_args_list[2].kwargs["q"] == "artist:artist track:track"
 
 
 class TestEarlyExit:

--- a/tests/test_transfer.py
+++ b/tests/test_transfer.py
@@ -299,7 +299,34 @@ class TestProtectedTransferBehavior:
         assert [item.source_track_id for item in playlist.match_collisions] == [
             "bp-1", "bp-2",
         ]
-        assert spotify.playlists[playlist.spotify_playlist_id]["tracks"] == [
+        assert spotify.playlists[playlist.spotify_playlist_id]["tracks"] == []
+
+    def test_repeated_occurrence_of_same_source_track_is_not_a_collision(self):
+        class RepeatedSource:
+            source_label = "Rekordbox"
+
+            def consume(self, reference):
+                track = Track(
+                    track_id="rb-1", artist="Artist", name="Track", album="",
+                    remixer="", label="", genre="", date_added="",
+                )
+                return SourceSelection("Repeated", reference, [track, track])
+
+        spotify = StatefulSpotify({
+            ("Artist", "Track"): _match(
+                "spotify:track:shared", "Track", "Artist",
+            ),
+        })
+        storage = InMemoryStorage()
+
+        report = Transfer(
+            publishing_guards=TEST_PUBLISHING_GUARDS,
+            source=RepeatedSource(), spotify=spotify,
+            matching_knowledge=storage, publication_storage=storage,
+        ).execute(TransferRequest(source="playlist"))
+
+        assert report.playlists[0].match_collisions == []
+        assert spotify.playlists[report.playlists[0].spotify_playlist_id]["tracks"] == [
             "spotify:track:shared",
         ]
 
@@ -1181,6 +1208,17 @@ class TestProvisionalPlaylistApproval:
         assert different_version_spotify.searches == [
             ("Shared Artist", "Shared Track (Extended Mix)", 80),
         ]
+
+        duration_missing_spotify = StatefulSpotify()
+        duration_missing = Transfer(
+            publishing_guards=TEST_PUBLISHING_GUARDS,
+            source=Source("Beatport", "bp-101", duration=0),
+            spotify=duration_missing_spotify,
+            matching_knowledge=MatchCacheKnowledge(cache),
+        ).execute(TransferRequest(source="chart", preview=True))
+
+        assert duration_missing.total_matched == 1
+        assert duration_missing_spotify.searches == []
 
     def test_conflicting_correction_does_not_overwrite_approved_truth(self, tmp_path):
         transfer, spotify, publications, playlist_id = self.publish()

--- a/tests/test_transfer.py
+++ b/tests/test_transfer.py
@@ -235,6 +235,74 @@ def test_preview_with_zero_acceptable_matches_succeeds_with_zero_percent():
 
 class TestProtectedTransferBehavior:
 
+    def test_below_threshold_candidates_are_reported_but_not_published(self):
+        spotify = StatefulSpotify({
+            ("Known Artist", "Known Track"): _match(
+                "spotify:track:known", "Known Track", "Known Artist",
+            ),
+            ("New Artist", "New Track"): {
+                "alternatives": [
+                    {
+                        "uri": f"spotify:track:alternative-{rank}",
+                        "name": f"New Track Candidate {rank}",
+                        "artist": "New Artist",
+                        "version": "Extended Mix" if rank == 1 else "Radio Edit",
+                        "duration_ms": 360000 - rank * 1000,
+                        "score": 79.0 - rank,
+                        "score_reasons": [
+                            "title similarity 92",
+                            "artist similarity 88",
+                        ],
+                    }
+                    for rank in range(1, 5)
+                ],
+            },
+        })
+        storage = InMemoryStorage()
+
+        report = Transfer(
+            publishing_guards=TEST_PUBLISHING_GUARDS,
+            source=FixtureBeatportSource(FIXTURE), spotify=spotify,
+            matching_knowledge=storage, publication_storage=storage,
+        ).execute(TransferRequest(source="fixture", threshold=80))
+
+        playlist = report.playlists[0]
+        assert playlist.action == "provisional snapshot created"
+        assert spotify.playlists[playlist.spotify_playlist_id]["tracks"] == [
+            "spotify:track:known",
+        ]
+        assert len(playlist.unmatched) == 1
+        assert [candidate.rank for candidate in playlist.alternatives[0].candidates] == [
+            1, 2, 3,
+        ]
+        assert playlist.alternatives[0].candidates[0].score_reasons == (
+            "title similarity 92", "artist similarity 88",
+        )
+
+    def test_match_collision_is_reported_and_not_counted_as_representation(self):
+        shared = _match("spotify:track:shared", "Shared", "Artist")
+        spotify = StatefulSpotify({
+            ("Known Artist", "Known Track"): shared,
+            ("New Artist", "New Track"): shared,
+        })
+        storage = InMemoryStorage()
+
+        report = Transfer(
+            publishing_guards=TEST_PUBLISHING_GUARDS,
+            source=FixtureBeatportSource(FIXTURE), spotify=spotify,
+            matching_knowledge=storage, publication_storage=storage,
+        ).execute(TransferRequest(source="fixture"))
+
+        playlist = report.playlists[0]
+        assert report.total_matched == 0
+        assert report.total_unmatched == 2
+        assert [item.source_track_id for item in playlist.match_collisions] == [
+            "bp-1", "bp-2",
+        ]
+        assert spotify.playlists[playlist.spotify_playlist_id]["tracks"] == [
+            "spotify:track:shared",
+        ]
+
     def test_previously_unmatched_tracks_retry_only_when_explicitly_requested(
         self, tmp_path,
     ):
@@ -281,7 +349,9 @@ class TestProtectedTransferBehavior:
                 self.attempts += 1
                 if self.attempts < 3:
                     raise requests.Timeout("Spotify timed out")
-                return _match("spotify:track:known", track.name, track.artist)
+                return _match(
+                    f"spotify:track:{track.track_id}", track.name, track.artist,
+                )
 
         spotify = TimeoutThenMatch()
         sleeps = []
@@ -330,7 +400,9 @@ class TestProtectedTransferBehavior:
                 if not self.rate_limited:
                     self.rate_limited = True
                     raise _spotify_error(429, retry_after=4)
-                return _match("spotify:track:match", track.name, track.artist)
+                return _match(
+                    f"spotify:track:{track.track_id}", track.name, track.artist,
+                )
 
         sleeps = []
         report = Transfer(
@@ -751,7 +823,7 @@ class TestSnapshotPublication:
         assert storage.checkpoints >= 1
 
 
-    def test_incomplete_matching_does_not_publish_snapshot(self):
+    def test_unmatched_tracks_are_omitted_from_provisional_snapshot(self):
         spotify = StatefulSpotify({
             ("Known Artist", "Known Track"): _match(
                 "spotify:track:known", "Known Track", "Known Artist",
@@ -765,9 +837,12 @@ class TestSnapshotPublication:
             matching_knowledge=storage, publication_storage=storage,
         ).execute(TransferRequest(source="fixture"))
 
-        assert report.playlists[0].action == "not published: incomplete matching"
-        assert spotify.playlists == {"existing": ["spotify:track:untouched"]}
-        assert storage.publications == []
+        playlist = report.playlists[0]
+        assert playlist.action == "provisional snapshot created"
+        assert spotify.playlists[playlist.spotify_playlist_id]["tracks"] == [
+            "spotify:track:known",
+        ]
+        assert len(storage.publications) == 1
 
     def test_empty_chart_does_not_publish_snapshot(self):
         class EmptySource:
@@ -1044,6 +1119,131 @@ class TestProvisionalPlaylistApproval:
             "spotify_name": "Corrected abcdefghijklmnopqrstuv",
             "spotify_artist": "Correction Artist",
         }]
+
+    def test_approved_match_is_reused_across_sources_with_specific_identity(
+        self, tmp_path,
+    ):
+        cache = MatchCache(str(tmp_path / "matching-knowledge.json"))
+        beatport_spotify = StatefulSpotify({
+            ("Shared Artist", "Shared Track (Extended Mix)"): _match(
+                "spotify:track:approved", "Shared Track (Extended Mix)",
+                "Shared Artist",
+            ),
+        })
+
+        class Source:
+            def __init__(self, label, track_id, duration=420):
+                self.source_label = label
+                self.track_id = track_id
+                self.duration = duration
+
+            def consume(self, reference):
+                return SourceSelection(reference, reference, [Track(
+                    track_id=self.track_id,
+                    artist="Shared Artist",
+                    name="Shared Track (Extended Mix)",
+                    album="", remixer="", label="", genre="", date_added="",
+                    duration=self.duration,
+                )])
+
+        publications = InMemoryStorage()
+        beatport = Transfer(
+            publishing_guards=TEST_PUBLISHING_GUARDS,
+            source=Source("Beatport", "bp-42"), spotify=beatport_spotify,
+            matching_knowledge=MatchCacheKnowledge(cache),
+            publication_storage=publications,
+        )
+        published = beatport.execute(TransferRequest(source="chart"))
+        beatport.approve(published.playlists[0].spotify_playlist_id)
+
+        rekordbox_spotify = StatefulSpotify()
+        reused = Transfer(
+            publishing_guards=TEST_PUBLISHING_GUARDS,
+            source=Source("Rekordbox", "rb-99"), spotify=rekordbox_spotify,
+            matching_knowledge=MatchCacheKnowledge(cache),
+        ).execute(TransferRequest(source="playlist", preview=True))
+
+        assert reused.total_matched == 1
+        assert reused.playlists[0].matched[0].spotify_uri == (
+            "spotify:track:approved"
+        )
+        assert rekordbox_spotify.searches == []
+
+        different_version_spotify = StatefulSpotify()
+        different_version = Transfer(
+            publishing_guards=TEST_PUBLISHING_GUARDS,
+            source=Source("Rekordbox", "rb-100", duration=210),
+            spotify=different_version_spotify,
+            matching_knowledge=MatchCacheKnowledge(cache),
+        ).execute(TransferRequest(source="playlist", preview=True))
+
+        assert different_version.total_matched == 0
+        assert different_version_spotify.searches == [
+            ("Shared Artist", "Shared Track (Extended Mix)", 80),
+        ]
+
+    def test_conflicting_correction_does_not_overwrite_approved_truth(self, tmp_path):
+        transfer, spotify, publications, playlist_id = self.publish()
+        cache = MatchCache(str(tmp_path / "matching-knowledge.json"))
+        durable = Transfer(
+            publishing_guards=TEST_PUBLISHING_GUARDS,
+            source=FixtureBeatportSource(FIXTURE), spotify=spotify,
+            matching_knowledge=MatchCacheKnowledge(cache),
+            publication_storage=publications,
+        )
+        durable.approve(playlist_id)
+        review_csv = tmp_path / "review.csv"
+        review_csv.write_text(
+            "source_track_id,spotify_url\n"
+            "bp-1,spotify:track:abcdefghijklmnopqrstuv\n"
+        )
+
+        conflict = durable.approve(playlist_id, corrections=review_csv)
+
+        assert conflict.status == ApprovalStatus.NEEDS_REVIEW
+        assert len(conflict.conflicts) == 1
+        assert conflict.conflicts[0].approved_spotify_uri == "spotify:track:known"
+        assert conflict.conflicts[0].proposed_spotify_uri == (
+            "spotify:track:abcdefghijklmnopqrstuv"
+        )
+        reloaded = MatchCache(str(tmp_path / "matching-knowledge.json"))
+        reloaded.load()
+        assert reloaded.lookup("Known Artist", "Known Track", 100).spotify_uri == (
+            "spotify:track:known"
+        )
+
+    def test_unavailable_approved_match_is_reported_without_replacement(self, tmp_path):
+        class UnavailableApprovedSpotify(StatefulSpotify):
+            def spotify_track(self, uri):
+                if uri == "spotify:track:approved":
+                    raise _spotify_error(404)
+                return super().spotify_track(uri)
+
+        cache = MatchCache(str(tmp_path / "matching-knowledge.json"))
+        cache.record_approval(
+            "Known Artist", "Known Track", "approved",
+            _match("spotify:track:approved", "Known Track", "Known Artist"),
+        )
+        cache.save()
+        spotify = UnavailableApprovedSpotify({
+            ("Known Artist", "Known Track"): _match(
+                "spotify:track:replacement", "Known Track", "Known Artist",
+            ),
+        })
+
+        report = Transfer(
+            publishing_guards=TEST_PUBLISHING_GUARDS,
+            source=FixtureBeatportSource(FIXTURE), spotify=spotify,
+            matching_knowledge=MatchCacheKnowledge(cache),
+        ).execute(TransferRequest(source="fixture", preview=True))
+
+        assert [item.spotify_uri for item in report.playlists[0].unavailable_approved] == [
+            "spotify:track:approved",
+        ]
+        assert ("Known Artist", "Known Track", 80) not in spotify.searches
+        assert cache.lookup("Known Artist", "Known Track", 100).spotify_uri == (
+            "spotify:track:approved"
+        )
 
     def test_missing_correction_is_added_once_across_repeated_approval(self, tmp_path):
         transfer, spotify, _, playlist_id = self.publish()


### PR DESCRIPTION
Closes #20

## Summary
- reuse Approved Matches across Rekordbox and Beatport with normalized title/version identity and optional duration disambiguation
- keep uncertain candidates out of Provisional Playlists while reporting up to three ranked, explained alternatives
- surface Match Collisions, Approval Conflicts, and unavailable Approved Matches without silently replacing user truth
- preserve explicit-only retries for previously unmatched tracks

## Validation
- 396 offline tests pass
- Python compilation passes
- git diff validation passes
- parallel Standards and Spec reviews pass after all blocking findings were resolved