### PR TITLE
Route Beatport labels through the Transfer workflow

### DIFF
--- a/agent.md
+++ b/agent.md
@@ -87,6 +87,7 @@ djsupport beatport <url> --report report.md          # Save Markdown report
 djsupport approve <spotify-playlist-id>              # Approve one reviewed Provisional Playlist
 djsupport approve <spotify-playlist-id> --review-csv review.csv  # Apply Corrections while approving
 djsupport beatport <url> --incremental               # Incremental updates (default)
+djsupport beatport <url> --mirror                    # Explicit recurring Mirror (Snapshot is default)
 djsupport beatport <url> --resume <transfer-id>      # Resume a paused Transfer
 djsupport beatport <url> --abandon <transfer-id>     # Explicitly abandon a Transfer
 
@@ -104,6 +105,9 @@ djsupport label <url-or-name> --prefix "dj"          # Prefix for playlist name
 djsupport label <url-or-name> --no-prefix            # No prefix
 djsupport label <url-or-name> --report report.md     # Save Markdown report
 djsupport label <url-or-name> --incremental          # Incremental updates (default)
+djsupport label <url-or-name> --mirror               # Explicit recurring Mirror (Snapshot is default)
+djsupport label <url-or-name> --resume <transfer-id> # Resume a paused Transfer
+djsupport label <url-or-name> --abandon <transfer-id> # Explicitly abandon a Transfer
 
 # Testing
 pytest                     # Run all tests

--- a/djsupport/cli.py
+++ b/djsupport/cli.py
@@ -385,6 +385,7 @@ def approve(
 @click.option("--prefix", default="djsupport", show_default=True, help="Prefix for Spotify playlist name.")
 @click.option("--no-prefix", is_flag=True, help="Disable playlist name prefix.")
 @click.option("--incremental/--no-incremental", default=True, show_default=True, help="Use incremental playlist updates.")
+@click.option("--mirror", is_flag=True, help="Maintain one recurring Beatport Mirror instead of distinct Snapshots.")
 @click.option("--resume", "resume_id", default=None, help="Resume a durable Transfer ID.")
 @click.option("--abandon", "abandon_id", default=None, help="Explicitly abandon a durable Transfer ID.")
 def beatport(
@@ -400,6 +401,7 @@ def beatport(
     prefix: str,
     no_prefix: bool,
     incremental: bool,
+    mirror: bool,
     resume_id: str | None,
     abandon_id: str | None,
 ) -> None:
@@ -424,6 +426,7 @@ def beatport(
         MatchCacheKnowledge,
         SpotifyMatcher,
         Transfer,
+        TransferMode,
         TransferRequest,
     )
 
@@ -459,6 +462,7 @@ def beatport(
     try:
         report = transfer.execute(TransferRequest(
             source=url,
+            mode=TransferMode.MIRROR if mirror else TransferMode.SNAPSHOT,
             preview=dry_run,
             threshold=threshold,
             retry=retry,
@@ -490,8 +494,10 @@ def beatport(
         click.echo(f"Editable review CSV saved to {review_path}")
 
 
-DEFAULT_LABEL_CACHE_PATH = ".djsupport_label_cache.json"
-DEFAULT_LABEL_STATE_PATH = ".djsupport_label_playlists.json"
+# Charts and labels share user-local authoritative knowledge and publication
+# manifests; callers can still override either path explicitly.
+DEFAULT_LABEL_CACHE_PATH = DEFAULT_BEATPORT_CACHE_PATH
+DEFAULT_LABEL_STATE_PATH = DEFAULT_BEATPORT_STATE_PATH
 
 
 @cli.command()
@@ -507,6 +513,9 @@ DEFAULT_LABEL_STATE_PATH = ".djsupport_label_playlists.json"
 @click.option("--prefix", default="djsupport", show_default=True, help="Prefix for Spotify playlist name.")
 @click.option("--no-prefix", is_flag=True, help="Disable playlist name prefix.")
 @click.option("--incremental/--no-incremental", default=True, show_default=True, help="Use incremental playlist updates.")
+@click.option("--mirror", is_flag=True, help="Maintain one recurring Beatport Mirror instead of distinct Snapshots.")
+@click.option("--resume", "resume_id", default=None, help="Resume a durable Transfer ID.")
+@click.option("--abandon", "abandon_id", default=None, help="Explicitly abandon a durable Transfer ID.")
 def label(
     url_or_name: str,
     dry_run: bool,
@@ -520,6 +529,9 @@ def label(
     prefix: str,
     no_prefix: bool,
     incremental: bool,
+    mirror: bool,
+    resume_id: str | None,
+    abandon_id: str | None,
 ) -> None:
     """Create a Spotify playlist from a Beatport record label.
 
@@ -585,9 +597,6 @@ def label(
         except InvalidLabelURL as e:
             raise click.ClickException(str(e))
 
-    # Fetch tracks with pagination
-    click.echo("Fetching tracks from Beatport label...")
-
     def on_total(total: int) -> bool | None:
         click.echo(f"Label has {total} tracks.")
         if total > LARGE_LABEL_THRESHOLD:
@@ -606,94 +615,77 @@ def label(
             err=True,
         )
 
-    try:
-        label_name, tracks = fetch_label_tracks(
-            label_url, on_total=on_total, on_page=on_page,
-            on_page_error=on_page_error,
+    def fetcher(url: str):
+        click.echo("Fetching tracks from Beatport label...")
+        return fetch_label_tracks(
+            url, on_total=on_total, on_page=on_page, on_page_error=on_page_error,
         )
-    except LabelParseError as e:
-        raise click.ClickException(str(e))
-    except requests.RequestException as e:
-        if hasattr(e, "response") and e.response is not None and e.response.status_code == 404:
-            raise click.ClickException("Label not found — check the URL.")
-        raise click.ClickException(f"Failed to fetch label: {e}")
 
-    if not tracks:
-        click.echo(f"No tracks found for label '{label_name}'.")
-        return
-
-    # Deduplicate tracks across compilations
-    tracks, dupes_removed = deduplicate_tracks(tracks)
-    if dupes_removed:
-        click.echo(f"Removed {dupes_removed} duplicate tracks. {len(tracks)} unique tracks remaining.")
-    else:
-        click.echo(f"{len(tracks)} tracks (newest first).")
-
-    # Initialize cache
-    cache = None
-    if not no_cache:
-        from djsupport.cache import MatchCache
-        cache = MatchCache(cache_path)
-        cache.load()
-        if cache.entries:
-            click.echo(f"Loaded {len(cache.entries)} cached label matches from {cache_path}")
-
-    actual_prefix = None if no_prefix else prefix
-
-    from djsupport.state import PlaylistStateManager
-    state_mgr = PlaylistStateManager(state_path)
-    state_mgr.load()
-
-    sp = get_client()
-    existing = get_user_playlists(sp) if not dry_run else None
-
-    report = SyncReport(
-        timestamp=datetime.now(),
-        threshold=threshold,
-        dry_run=dry_run,
-        cache_enabled=cache is not None,
-        source_label="Beatport",
+    from djsupport.cache import MatchCache
+    from djsupport.transfer import (
+        BeatportLabelSource,
+        EphemeralMatchingKnowledge,
+        FilePublicationStorage,
+        FileTransferStorage,
+        MatchCacheKnowledge,
+        SpotifyMatcher,
+        Transfer,
+        TransferMode,
+        TransferRequest,
     )
 
-    try:
-        pl_report = _cli_match_and_sync(
-            tracks,
-            label_name,
-            label_url,
-            sp=sp,
-            cache=cache,
-            state_mgr=state_mgr,
-            existing_playlists=existing,
-            threshold=threshold,
-            dry_run=dry_run,
-            incremental=incremental,
-            prefix=actual_prefix,
-            retry_days=retry_days,
-            retry=retry,
-            source_type="label",
-        )
-    except RateLimitError as e:
-        click.echo(f"\n{e}", err=True)
-        if cache is not None:
-            cache.save()
-            click.echo(f"Cache saved to {cache_path} ({len(cache.entries)} entries).", err=True)
-        print_report(report)
-        if report_path:
-            save_report(report, report_path)
-        sys.exit(1)
-
-    report.playlists.append(pl_report)
-
+    cache = None if no_cache else MatchCache(cache_path)
     if cache is not None:
-        cache.save()
-
-    if not dry_run:
-        state_mgr.save()
+        cache.load()
+    if resume_id and abandon_id:
+        raise click.UsageError("Use either --resume or --abandon, not both.")
+    transfer_storage = FileTransferStorage(
+        str(Path(state_path).with_suffix(".transfers.json"))
+    )
+    transfer = Transfer(
+        source=BeatportLabelSource(fetcher=fetcher),
+        spotify=SpotifyMatcher(get_client()),
+        publishing_guards=AccountPublishingGuards(),
+        matching_knowledge=(
+            EphemeralMatchingKnowledge()
+            if cache is None else MatchCacheKnowledge(cache)
+        ),
+        publication_storage=None if dry_run else FilePublicationStorage(state_path),
+        transfer_storage=transfer_storage,
+    )
+    if abandon_id:
+        transfer.abandon(abandon_id)
+        click.echo(f"Transfer {abandon_id} abandoned.")
+        return
+    if resume_id and transfer_storage.load_transfer(resume_id) is None:
+        raise click.ClickException(f"Unknown Transfer: {resume_id}")
+    transfer_id = resume_id or uuid4().hex
+    click.echo(f"Transfer ID: {transfer_id}")
+    try:
+        report = transfer.execute(TransferRequest(
+            source=label_url,
+            mode=TransferMode.MIRROR if mirror else TransferMode.SNAPSHOT,
+            preview=dry_run,
+            threshold=threshold,
+            retry=retry,
+            retry_days=retry_days,
+            playlist_prefix=None if no_prefix else prefix,
+            transfer_id=transfer_id,
+        ))
+    except (InvalidLabelURL, LabelParseError) as e:
+        raise click.ClickException(str(e))
+    except requests.RequestException as e:
+        raise click.ClickException(f"Failed to fetch label: {e}")
+    except RateLimitError as e:
+        raise click.ClickException(str(e))
 
     print_report(report)
     if report_path:
         save_report(report, report_path)
+        review_path = str(Path(report_path).with_suffix(".csv"))
+        save_review_csv(report, review_path)
         click.echo(f"\nDetailed report saved to {report_path}")
+        click.echo(f"Editable review CSV saved to {review_path}")
 
 
 @cli.command()

--- a/djsupport/cli.py
+++ b/djsupport/cli.py
@@ -547,7 +547,6 @@ def label(
     from djsupport.label import (
         InvalidLabelURL,
         LabelParseError,
-        deduplicate_tracks,
         fetch_label_tracks,
         search_labels,
         validate_label_url,
@@ -621,6 +620,15 @@ def label(
             url, on_total=on_total, on_page=on_page, on_page_error=on_page_error,
         )
 
+    def on_deduplicated(duplicates_removed: int, unique_count: int) -> None:
+        if duplicates_removed:
+            click.echo(
+                f"Removed {duplicates_removed} duplicate tracks. "
+                f"{unique_count} unique tracks remaining."
+            )
+        else:
+            click.echo(f"{unique_count} tracks (newest first).")
+
     from djsupport.cache import MatchCache
     from djsupport.transfer import (
         BeatportLabelSource,
@@ -643,7 +651,9 @@ def label(
         str(Path(state_path).with_suffix(".transfers.json"))
     )
     transfer = Transfer(
-        source=BeatportLabelSource(fetcher=fetcher),
+        source=BeatportLabelSource(
+            fetcher=fetcher, on_deduplicated=on_deduplicated,
+        ),
         spotify=SpotifyMatcher(get_client()),
         publishing_guards=AccountPublishingGuards(),
         matching_knowledge=(
@@ -675,6 +685,12 @@ def label(
     except (InvalidLabelURL, LabelParseError) as e:
         raise click.ClickException(str(e))
     except requests.RequestException as e:
+        if (
+            hasattr(e, "response")
+            and e.response is not None
+            and e.response.status_code == 404
+        ):
+            raise click.ClickException("Label not found — check the URL.")
         raise click.ClickException(f"Failed to fetch label: {e}")
     except RateLimitError as e:
         raise click.ClickException(str(e))

--- a/djsupport/transfer.py
+++ b/djsupport/transfer.py
@@ -492,9 +492,11 @@ class BeatportLabelSource:
         *,
         fetcher: Callable[[str], tuple[str, list[Track]]] | None = None,
         validator: Callable[[str], str] | None = None,
+        on_deduplicated: Callable[[int, int], None] | None = None,
     ) -> None:
         self._fetcher = fetcher
         self._validator = validator
+        self._on_deduplicated = on_deduplicated
 
     def consume(self, reference: str) -> SourceSelection:
         from djsupport.label import (
@@ -505,12 +507,14 @@ class BeatportLabelSource:
 
         url = (self._validator or validate_label_url)(reference)
         label_name, tracks = (self._fetcher or fetch_label_tracks)(url)
-        unique_tracks, _ = deduplicate_tracks(tracks)
+        unique_tracks, duplicates_removed = deduplicate_tracks(tracks)
+        if self._on_deduplicated is not None:
+            self._on_deduplicated(duplicates_removed, len(unique_tracks))
         return SourceSelection(label_name, url, unique_tracks)
 
 
 class SpotifyMatcher:
-    """Production Spotify matching and Snapshot publication adapter."""
+    """Production Spotify matching and Transfer publication adapter."""
 
     def __init__(self, client) -> None:
         self._client = client
@@ -527,6 +531,9 @@ class SpotifyMatcher:
         self, name: str, track_uris: list[str], description: str,
         publication_key: str,
     ) -> str:
+        # This marker is the durable identity contract for recurring Mirrors.
+        # It lives with the Spotify playlist, so a new process/client can find
+        # the relationship without depending on process-local state.
         marker = f"djsupport-transfer:{publication_key}"
         description = f"{description} {marker}"
         playlist_id = self._find_publication(marker)

--- a/djsupport/transfer.py
+++ b/djsupport/transfer.py
@@ -67,18 +67,23 @@ def default_matching_knowledge_path() -> Path:
     return root / "djsupport" / "matching-knowledge.json"
 
 
+class TransferMode(str, Enum):
+    SNAPSHOT = "snapshot"
+    MIRROR = "mirror"
+
+
 @dataclass(frozen=True)
 class TransferRequest:
     """Everything an adapter must provide to start one Transfer."""
 
     source: str
+    mode: TransferMode = TransferMode.SNAPSHOT
     preview: bool = False
     threshold: int = 80
     retry: bool = False
     retry_days: int = 7
     playlist_prefix: str | None = "djsupport"
     transfer_id: str | None = None
-
 
 class TransferStatus(str, Enum):
     MATCHING = "matching"
@@ -243,6 +248,7 @@ class PublicationManifest:
     source_reference: str
     created_at: datetime
     items: tuple[PublicationItem, ...]
+    mode: TransferMode = TransferMode.SNAPSHOT
 
 
 @dataclass(frozen=True)
@@ -374,6 +380,9 @@ class FilePublicationStorage:
         return PublicationManifest(
             **{
                 **stored,
+                "mode": TransferMode(
+                    stored.get("mode", TransferMode.SNAPSHOT.value)
+                ),
                 "created_at": datetime.fromisoformat(stored["created_at"]),
                 "items": tuple(PublicationItem(**item) for item in stored["items"]),
             }
@@ -471,6 +480,33 @@ class BeatportChartSource:
             reference=url,
             tracks=tracks,
         )
+
+
+class BeatportLabelSource:
+    """Production source adapter for one Beatport record-label selection."""
+
+    source_label = "Beatport label"
+
+    def __init__(
+        self,
+        *,
+        fetcher: Callable[[str], tuple[str, list[Track]]] | None = None,
+        validator: Callable[[str], str] | None = None,
+    ) -> None:
+        self._fetcher = fetcher
+        self._validator = validator
+
+    def consume(self, reference: str) -> SourceSelection:
+        from djsupport.label import (
+            deduplicate_tracks,
+            fetch_label_tracks,
+            validate_label_url,
+        )
+
+        url = (self._validator or validate_label_url)(reference)
+        label_name, tracks = (self._fetcher or fetch_label_tracks)(url)
+        unique_tracks, _ = deduplicate_tracks(tracks)
+        return SourceSelection(label_name, url, unique_tracks)
 
 
 class SpotifyMatcher:
@@ -957,6 +993,7 @@ class Transfer:
                 account_id=self._spotify.account_id(),
                 request={
                     "source": request.source,
+                    "mode": request.mode.value,
                     "preview": request.preview,
                     "threshold": request.threshold,
                     "retry": request.retry,
@@ -984,7 +1021,13 @@ class Transfer:
             if state.account_id != self._spotify.account_id():
                 raise ValueError("A Transfer cannot resume under another Spotify account")
             request = TransferRequest(
-                **state.request, transfer_id=transfer_id,
+                **{
+                    **state.request,
+                    "mode": TransferMode(
+                        state.request.get("mode", TransferMode.SNAPSHOT.value)
+                    ),
+                },
+                transfer_id=transfer_id,
             )
             stored_selection = state.selection
             selection = SourceSelection(
@@ -1029,12 +1072,21 @@ class Transfer:
             if state.spotify_playlist_id:
                 playlist.name = state.spotify_playlist_name or playlist.name
                 playlist.spotify_playlist_id = state.spotify_playlist_id
-                playlist.action = "provisional snapshot created"
+                playlist.action = (
+                    "provisional mirror updated"
+                    if request.mode == TransferMode.MIRROR
+                    else "provisional snapshot created"
+                )
                 stored_manifest = state.publication_manifest
                 if stored_manifest:
                     playlist.publication_manifest = PublicationManifest(
                         **{
                             **stored_manifest,
+                            "mode": TransferMode(
+                                stored_manifest.get(
+                                    "mode", TransferMode.SNAPSHOT.value,
+                                )
+                            ),
                             "account_id": stored_manifest.get(
                                 "account_id", state.account_id,
                             ),
@@ -1187,16 +1239,25 @@ class Transfer:
                 playlist_id = state.spotify_playlist_id
                 snapshot_name = state.spotify_playlist_name
                 if playlist_id is None:
-                    discriminator = (
-                        f"{created_at:%Y-%m-%d %H%M%S} {uuid4().hex[:8]}"
-                    )
-                    snapshot_name = f"{selection.name} — {discriminator}"
+                    if request.mode == TransferMode.MIRROR:
+                        snapshot_name = selection.name
+                    else:
+                        discriminator = (
+                            f"{created_at:%Y-%m-%d %H%M%S} {uuid4().hex[:8]}"
+                        )
+                        snapshot_name = f"{selection.name} — {discriminator}"
                     if request.playlist_prefix:
                         snapshot_name = f"{request.playlist_prefix} / {snapshot_name}"
                     description = (
-                        f"Provisional Snapshot from {self._source.source_label}: "
+                        f"Provisional {request.mode.value.title()} from "
+                        f"{self._source.source_label}: "
                         f"{selection.reference}. Created {created_at.isoformat()}."
                     )
+                    publication_key = transfer_id
+                    if request.mode == TransferMode.MIRROR:
+                        publication_key = hashlib.sha256(
+                            f"{state.account_id}\0{selection.reference}".encode()
+                        ).hexdigest()
                     playlist_id = self._retry_policy.run(
                         lambda: self._spotify.publish_provisional_snapshot(
                             snapshot_name,
@@ -1205,7 +1266,7 @@ class Transfer:
                                 if item.spotify_uri not in collision_uris
                             )),
                             description,
-                            transfer_id,
+                            publication_key,
                         )
                     )
                     state.spotify_playlist_id = playlist_id
@@ -1230,6 +1291,7 @@ class Transfer:
                     source_reference=selection.reference,
                     created_at=created_at,
                     items=tuple(publication_items),
+                    mode=request.mode,
                 )
                 stored_manifest = asdict(manifest)
                 stored_manifest["created_at"] = manifest.created_at.isoformat()
@@ -1248,7 +1310,11 @@ class Transfer:
                 playlist.name = snapshot_name
                 playlist.spotify_playlist_id = playlist_id
                 playlist.publication_manifest = manifest
-                playlist.action = "provisional snapshot created"
+                playlist.action = (
+                    "provisional mirror updated"
+                    if request.mode == TransferMode.MIRROR
+                    else "provisional snapshot created"
+                )
             state.outcome = playlist.action
             state.status = TransferStatus.COMPLETED
             self._save_transfer(transfer_id, state)

--- a/tests/fixtures/beatport_label_page.json
+++ b/tests/fixtures/beatport_label_page.json
@@ -1,0 +1,50 @@
+{
+  "props": {
+    "pageProps": {
+      "label": {"name": "Fixture Label"},
+      "dehydratedState": {
+        "queries": [
+          {
+            "state": {
+              "data": {
+                "count": 3,
+                "results": [
+                  {
+                    "id": 2101,
+                    "name": "Known Track",
+                    "mix_name": "Original Mix",
+                    "artists": [{"name": "Known Artist"}],
+                    "release": {"name": "Newest Release", "label": {"name": "Fixture Label"}},
+                    "genre": {"name": "Techno"},
+                    "publish_date": "2026-07-03",
+                    "length": "05:00"
+                  },
+                  {
+                    "id": 2102,
+                    "name": "Known Track",
+                    "mix_name": "Original Mix",
+                    "artists": [{"name": "Known Artist"}],
+                    "release": {"name": "Older Compilation", "label": {"name": "Fixture Label"}},
+                    "genre": {"name": "Techno"},
+                    "publish_date": "2026-06-02",
+                    "length": "05:00"
+                  },
+                  {
+                    "id": 2103,
+                    "name": "New Track",
+                    "mix_name": "Extended Mix",
+                    "artists": [{"name": "New Artist"}],
+                    "release": {"name": "New Release", "label": {"name": "Fixture Label"}},
+                    "genre": {"name": "House"},
+                    "publish_date": "2026-05-01",
+                    "length": "06:30"
+                  }
+                ]
+              }
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/tests/test_transfer.py
+++ b/tests/test_transfer.py
@@ -167,25 +167,28 @@ class InMemoryStorage:
 
 
 FIXTURE = Path(__file__).parent / "fixtures" / "beatport_chart.json"
+LABEL_FIXTURE = Path(__file__).parent / "fixtures" / "beatport_label_page.json"
 TEST_PUBLISHING_GUARDS = AccountPublishingGuards()
 
 
-def test_beatport_label_source_preserves_fixture_order_and_deduplicates():
-    tracks = [
-        Track("label-1", "Artist", "Track", "", "", "Label", "", ""),
-        Track("label-2", "Artist", "Track", "Compilation", "", "Label", "", ""),
-        Track("label-3", "Other", "Newest", "", "", "Label", "", ""),
-    ]
-    source = BeatportLabelSource(
-        fetcher=lambda url: ("Fixture Label", tracks),
-        validator=lambda url: "https://www.beatport.com/label/fixture/21",
-    )
+class TestBeatportLabelSource:
+    def test_production_intake_parses_fixture_order_and_deduplicates(self, monkeypatch):
+        fixture_data = LABEL_FIXTURE.read_text()
+        fixture_html = f'<script id="__NEXT_DATA__">{fixture_data}</script>'
+        monkeypatch.setattr("djsupport.label._fetch_page", lambda url, page: fixture_html)
 
-    selection = source.consume("fixture")
+        selection = BeatportLabelSource().consume(
+            "https://www.beatport.com/label/fixture/21"
+        )
 
-    assert selection.name == "Fixture Label"
-    assert selection.reference == "https://www.beatport.com/label/fixture/21"
-    assert [track.track_id for track in selection.tracks] == ["label-1", "label-3"]
+        assert selection.name == "Fixture Label"
+        assert selection.reference == "https://www.beatport.com/label/fixture/21"
+        assert [track.track_id for track in selection.tracks] == [
+            "bp-label-2101", "bp-label-2103",
+        ]
+        assert [track.name for track in selection.tracks] == [
+            "Known Track", "New Track (Extended Mix)",
+        ]
 
 
 def _match(uri, name, artist):
@@ -1488,6 +1491,34 @@ class TestProvisionalPlaylistApproval:
 
 
 class TestSpotifyApprovalAdapter:
+    def test_recurring_mirror_marker_survives_adapter_reconstruction(self):
+        client = MagicMock()
+        playlists = []
+        client.current_user.return_value = {"id": "spotify-user-1"}
+        client.current_user_playlists.side_effect = lambda limit: {
+            "items": list(playlists), "next": None,
+        }
+
+        def create_playlist(user_id, name, public, description):
+            playlist = {"id": "mirror-1", "description": description}
+            playlists.append(playlist)
+            return playlist
+
+        client.user_playlist_create.side_effect = create_playlist
+
+        first_id = SpotifyMatcher(client).publish_provisional_snapshot(
+            "Fixture Mirror", ["spotify:track:first"], "description", "stable-key",
+        )
+        second_id = SpotifyMatcher(client).publish_provisional_snapshot(
+            "Fixture Mirror", ["spotify:track:second"], "description", "stable-key",
+        )
+
+        assert first_id == second_id == "mirror-1"
+        assert client.user_playlist_create.call_count == 1
+        assert client.playlist_replace_items.call_args.args == (
+            "mirror-1", ["spotify:track:second"],
+        )
+
     def test_reads_all_current_playlist_track_uris(self):
         client = MagicMock()
         client.playlist_items.return_value = {

--- a/tests/test_transfer.py
+++ b/tests/test_transfer.py
@@ -29,9 +29,11 @@ from djsupport.transfer import (
     SpotifyMatcher,
     SourceSelection,
     Transfer,
+    TransferMode,
     TransferRequest,
     ApprovalStatus,
     ApprovalOutcome,
+    BeatportLabelSource,
 )
 
 
@@ -166,6 +168,24 @@ class InMemoryStorage:
 
 FIXTURE = Path(__file__).parent / "fixtures" / "beatport_chart.json"
 TEST_PUBLISHING_GUARDS = AccountPublishingGuards()
+
+
+def test_beatport_label_source_preserves_fixture_order_and_deduplicates():
+    tracks = [
+        Track("label-1", "Artist", "Track", "", "", "Label", "", ""),
+        Track("label-2", "Artist", "Track", "Compilation", "", "Label", "", ""),
+        Track("label-3", "Other", "Newest", "", "", "Label", "", ""),
+    ]
+    source = BeatportLabelSource(
+        fetcher=lambda url: ("Fixture Label", tracks),
+        validator=lambda url: "https://www.beatport.com/label/fixture/21",
+    )
+
+    selection = source.consume("fixture")
+
+    assert selection.name == "Fixture Label"
+    assert selection.reference == "https://www.beatport.com/label/fixture/21"
+    assert [track.track_id for track in selection.tracks] == ["label-1", "label-3"]
 
 
 def _match(uri, name, artist):
@@ -513,6 +533,62 @@ class TestProtectedTransferBehavior:
 
 
 class TestSnapshotPublication:
+    def test_beatport_label_defaults_to_distinct_snapshots_after_approval(self):
+        class FixtureLabelSource(FixtureBeatportSource):
+            source_label = "Beatport label"
+
+        spotify = StatefulSpotify({
+            ("Known Artist", "Known Track"): _match(
+                "spotify:track:known", "Known Track", "Known Artist",
+            ),
+            ("New Artist", "New Track"): _match(
+                "spotify:track:new", "New Track", "New Artist",
+            ),
+        })
+        storage = InMemoryStorage()
+        transfer = Transfer(
+            publishing_guards=TEST_PUBLISHING_GUARDS,
+            source=FixtureLabelSource(FIXTURE), spotify=spotify,
+            matching_knowledge=storage, publication_storage=storage,
+        )
+
+        first = transfer.execute(TransferRequest(source="fixture-label"))
+        transfer.approve(first.playlists[0].spotify_playlist_id)
+        second = transfer.execute(TransferRequest(source="fixture-label"))
+
+        assert first.playlists[0].spotify_playlist_id != second.playlists[0].spotify_playlist_id
+        assert first.playlists[0].action == "provisional snapshot created"
+        assert second.playlists[0].action == "provisional snapshot created"
+        assert first.playlists[0].publication_manifest.mode == TransferMode.SNAPSHOT
+
+    def test_beatport_source_can_explicitly_recur_as_one_mirror(self):
+        spotify = StatefulSpotify({
+            ("Known Artist", "Known Track"): _match(
+                "spotify:track:known", "Known Track", "Known Artist",
+            ),
+            ("New Artist", "New Track"): _match(
+                "spotify:track:new", "New Track", "New Artist",
+            ),
+        })
+        storage = InMemoryStorage()
+        transfer = Transfer(
+            publishing_guards=TEST_PUBLISHING_GUARDS,
+            source=FixtureBeatportSource(FIXTURE), spotify=spotify,
+            matching_knowledge=storage, publication_storage=storage,
+        )
+
+        first = transfer.execute(TransferRequest(
+            source="fixture", mode=TransferMode.MIRROR,
+        ))
+        transfer.approve(first.playlists[0].spotify_playlist_id)
+        second = transfer.execute(TransferRequest(
+            source="fixture", mode=TransferMode.MIRROR,
+        ))
+
+        assert second.playlists[0].spotify_playlist_id == first.playlists[0].spotify_playlist_id
+        assert second.playlists[0].action == "provisional mirror updated"
+        assert second.playlists[0].publication_manifest.mode == TransferMode.MIRROR
+
 
     def test_paused_transfer_reloads_and_resumes_without_repeating_work(self, tmp_path):
         matches = {
@@ -1485,6 +1561,47 @@ class TestBeatportCliTransfer:
         request = execute.call_args.args[0]
         assert request.preview is False
         assert request.source == "https://www.beatport.com/chart/fixture/14"
+        assert request.mode == TransferMode.SNAPSHOT
+
+    @patch("djsupport.transfer.Transfer.execute")
+    @patch("djsupport.cli.get_client", return_value=MagicMock())
+    def test_cli_beatport_can_explicitly_choose_mirror(
+        self, mock_client, execute, tmp_path,
+    ):
+        execute.return_value = SyncReport(
+            timestamp=datetime.now(), threshold=80, dry_run=False,
+            playlists=[PlaylistReport(name="Fixture", path="fixture")],
+            source_label="Beatport",
+        )
+
+        result = CliRunner().invoke(cli, [
+            "beatport", "https://www.beatport.com/chart/fixture/14", "--mirror",
+            "--state-path", str(tmp_path / "publications.json"),
+        ])
+
+        assert result.exit_code == 0, result.output
+        assert execute.call_args.args[0].mode == TransferMode.MIRROR
+
+    @patch("djsupport.transfer.Transfer.execute")
+    @patch("djsupport.cli.get_client", return_value=MagicMock())
+    def test_cli_label_defaults_to_snapshot_through_transfer(
+        self, mock_client, execute, tmp_path,
+    ):
+        execute.return_value = SyncReport(
+            timestamp=datetime.now(), threshold=80, dry_run=False,
+            playlists=[PlaylistReport(name="Fixture Label", path="fixture")],
+            source_label="Beatport label",
+        )
+
+        result = CliRunner().invoke(cli, [
+            "label", "https://www.beatport.com/label/fixture/21",
+            "--state-path", str(tmp_path / "publications.json"),
+        ])
+
+        assert result.exit_code == 0, result.output
+        request = execute.call_args.args[0]
+        assert request.source == "https://www.beatport.com/label/fixture/21"
+        assert request.mode == TransferMode.SNAPSHOT
 
     @patch("djsupport.transfer.FileTransferStorage.load_transfer")
     @patch("djsupport.transfer.Transfer.execute")


### PR DESCRIPTION
Closes #21

## Summary
- route Beatport labels through the public Transfer interface with shared Preview, review, Approval, Correction, knowledge, and reporting behavior
- preserve Snapshot defaults for charts and labels while adding an explicit recurring Mirror mode
- keep repeated Snapshots distinct and prove durable Mirror identity across adapter reconstruction
- keep shared user data in platform-local application storage and preserve label-specific UX

## Validation
- 402 offline tests pass
- Python compilation passes
- git diff validation passes
- parallel Standards and Spec reviews report zero blocking findings