### PR TITLE
Create and approve one Rekordbox Mirror

### DIFF
--- a/djsupport/transfer.py
+++ b/djsupport/transfer.py
@@ -47,7 +47,7 @@ from djsupport.report import (
 from djsupport.spotify import MAX_RATE_LIMIT_WAIT, RateLimitError, _parse_retry_after
 
 
-PUBLICATION_MANIFEST_VERSION = 1
+PUBLICATION_MANIFEST_VERSION = 2
 TRANSFER_STATE_VERSION = 1
 SPOTIFY_TRACK_URI = re.compile(r"^spotify:track:([A-Za-z0-9]{22})$")
 SPOTIFY_TRACK_URL = re.compile(
@@ -289,7 +289,6 @@ class ApprovalConflict:
 
 class SourceAdapter(Protocol):
     source_label: str
-    default_mode: TransferMode
 
     def consume(self, reference: str) -> SourceSelection: ...
 
@@ -346,7 +345,7 @@ class FilePublicationStorage:
             data = json.loads(self.path.read_text())
         except (json.JSONDecodeError, OSError):
             return
-        if data.get("version") != PUBLICATION_MANIFEST_VERSION:
+        if data.get("version") not in (1, PUBLICATION_MANIFEST_VERSION):
             return
         self.manifests = data.get("manifests", [])
         self.approvals = data.get("approvals", data.get("reviews", []))
@@ -581,10 +580,18 @@ class RekordboxPlaylistSource:
                 f"Rekordbox playlist name is ambiguous; select its path: {reference}"
             )
         playlist = selected[0]
+        missing_track_ids = [
+            track_id for track_id in playlist.track_ids if track_id not in tracks
+        ]
+        if missing_track_ids:
+            raise ValueError(
+                "Rekordbox playlist has missing track references: "
+                + ", ".join(missing_track_ids)
+            )
         return SourceSelection(
             playlist.name,
             playlist.path,
-            [tracks[track_id] for track_id in playlist.track_ids if track_id in tracks],
+            [tracks[track_id] for track_id in playlist.track_ids],
         )
 
 
@@ -1074,6 +1081,7 @@ class Transfer:
             raise ValueError("Publishing Transfers require publication storage")
 
         if request.mode is None:
+            # Older internal/test adapters predate source-owned mode policy.
             request = replace(
                 request,
                 mode=getattr(self._source, "default_mode", TransferMode.SNAPSHOT),

--- a/djsupport/transfer.py
+++ b/djsupport/transfer.py
@@ -77,7 +77,7 @@ class TransferRequest:
     """Everything an adapter must provide to start one Transfer."""
 
     source: str
-    mode: TransferMode = TransferMode.SNAPSHOT
+    mode: TransferMode | None = None
     preview: bool = False
     threshold: int = 80
     retry: bool = False
@@ -252,6 +252,18 @@ class PublicationManifest:
 
 
 @dataclass(frozen=True)
+class MirrorRelationship:
+    """An Approved, account-owned relationship to one source playlist."""
+
+    account_id: str
+    source_label: str
+    source_reference: str
+    spotify_playlist_id: str
+    spotify_playlist_name: str
+    approved_at: datetime
+
+
+@dataclass(frozen=True)
 class ApprovalOutcome:
     """The durable outcome of approving one Provisional Playlist."""
 
@@ -277,6 +289,7 @@ class ApprovalConflict:
 
 class SourceAdapter(Protocol):
     source_label: str
+    default_mode: TransferMode
 
     def consume(self, reference: str) -> SourceSelection: ...
 
@@ -313,6 +326,8 @@ class PublicationStorage(Protocol):
 
     def retain_approval(self, outcome: ApprovalOutcome) -> None: ...
 
+    def retain_mirror(self, relationship: MirrorRelationship) -> None: ...
+
 
 class FilePublicationStorage:
     """Versioned, durable publication manifests for later review."""
@@ -321,6 +336,7 @@ class FilePublicationStorage:
         self.path = Path(path)
         self.manifests: list[dict] = []
         self.approvals: list[dict] = []
+        self.mirrors: list[dict] = []
         self.load()
 
     def load(self) -> None:
@@ -334,6 +350,7 @@ class FilePublicationStorage:
             return
         self.manifests = data.get("manifests", [])
         self.approvals = data.get("approvals", data.get("reviews", []))
+        self.mirrors = data.get("mirrors", [])
 
     def _save(self, manifests: list[dict], approvals: list[dict]) -> None:
         self.path.parent.mkdir(parents=True, exist_ok=True)
@@ -342,6 +359,7 @@ class FilePublicationStorage:
             "version": PUBLICATION_MANIFEST_VERSION,
             "manifests": manifests,
             "approvals": approvals,
+            "mirrors": self.mirrors,
         }, indent=2))
         os.replace(temporary, self.path)
         self.manifests = manifests
@@ -392,6 +410,30 @@ class FilePublicationStorage:
         stored = asdict(outcome)
         stored["reviewed_at"] = outcome.reviewed_at.isoformat()
         self._save(self.manifests, [*self.approvals, stored])
+
+    def retain_mirror(self, relationship: MirrorRelationship) -> None:
+        stored = asdict(relationship)
+        stored["approved_at"] = relationship.approved_at.isoformat()
+        self.mirrors = [
+            item for item in self.mirrors
+            if not (
+                item.get("account_id") == relationship.account_id
+                and item.get("source_label") == relationship.source_label
+                and item.get("source_reference") == relationship.source_reference
+            )
+        ]
+        self.mirrors.append(stored)
+        self._save(self.manifests, self.approvals)
+
+    def mirrors_for_account(self, account_id: str) -> list[MirrorRelationship]:
+        return [
+            MirrorRelationship(**{
+                **item,
+                "approved_at": datetime.fromisoformat(item["approved_at"]),
+            })
+            for item in self.mirrors
+            if item.get("account_id") == account_id
+        ]
 
 
 class TransferStorage(Protocol):
@@ -465,6 +507,7 @@ class BeatportChartSource:
     """Production source adapter for one Beatport chart."""
 
     source_label = "Beatport"
+    default_mode = TransferMode.SNAPSHOT
 
     def consume(self, reference: str) -> SourceSelection:
         from djsupport.beatport import (
@@ -486,6 +529,7 @@ class BeatportLabelSource:
     """Production source adapter for one Beatport record-label selection."""
 
     source_label = "Beatport label"
+    default_mode = TransferMode.SNAPSHOT
 
     def __init__(
         self,
@@ -511,6 +555,37 @@ class BeatportLabelSource:
         if self._on_deduplicated is not None:
             self._on_deduplicated(duplicates_removed, len(unique_tracks))
         return SourceSelection(label_name, url, unique_tracks)
+
+
+class RekordboxPlaylistSource:
+    """Fixture-friendly intake for one explicitly selected Rekordbox playlist."""
+
+    source_label = "Rekordbox"
+    default_mode = TransferMode.MIRROR
+
+    def __init__(self, xml_path: str | Path) -> None:
+        self._xml_path = Path(xml_path)
+
+    def consume(self, reference: str) -> SourceSelection:
+        from djsupport.rekordbox import parse_xml
+
+        tracks, playlists = parse_xml(self._xml_path)
+        selected = [
+            playlist for playlist in playlists
+            if playlist.path == reference or playlist.name == reference
+        ]
+        if not selected:
+            raise ValueError(f"Rekordbox playlist not found: {reference}")
+        if len(selected) > 1:
+            raise ValueError(
+                f"Rekordbox playlist name is ambiguous; select its path: {reference}"
+            )
+        playlist = selected[0]
+        return SourceSelection(
+            playlist.name,
+            playlist.path,
+            [tracks[track_id] for track_id in playlist.track_ids if track_id in tracks],
+        )
 
 
 class SpotifyMatcher:
@@ -854,6 +929,18 @@ class Transfer:
                         conflicts=tuple(conflicts),
                     )
                 self._knowledge.checkpoint()
+                if (
+                    outcome.status == ApprovalStatus.APPROVED
+                    and manifest.mode == TransferMode.MIRROR
+                ):
+                    self._publication_storage.retain_mirror(MirrorRelationship(
+                        account_id=account_id,
+                        source_label=manifest.source_label,
+                        source_reference=manifest.source_reference,
+                        spotify_playlist_id=manifest.spotify_playlist_id,
+                        spotify_playlist_name=manifest.spotify_playlist_name,
+                        approved_at=outcome.reviewed_at,
+                    ))
             self._publication_storage.retain_approval(outcome)
             return outcome
 
@@ -985,6 +1072,12 @@ class Transfer:
         """
         if not request.preview and self._publication_storage is None:
             raise ValueError("Publishing Transfers require publication storage")
+
+        if request.mode is None:
+            request = replace(
+                request,
+                mode=getattr(self._source, "default_mode", TransferMode.SNAPSHOT),
+            )
 
         transfer_id = request.transfer_id or uuid4().hex
         state = (

--- a/tests/fixtures/rekordbox_missing_track.xml
+++ b/tests/fixtures/rekordbox_missing_track.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<DJ_PLAYLISTS Version="1.0.0">
+    <COLLECTION Entries="1">
+        <TRACK TrackID="1" Name="Complete Track" Artist="Fixture Artist"
+               Album="" Remixer="" Label="" Genre="" DateAdded="2026-08-01"
+               TotalTime="240"/>
+    </COLLECTION>
+    <PLAYLISTS>
+        <NODE Type="0" Name="ROOT" Count="1">
+            <NODE Type="1" Name="Incomplete" KeyType="0" Entries="2">
+                <TRACK Key="1"/>
+                <TRACK Key="missing"/>
+            </NODE>
+        </NODE>
+    </PLAYLISTS>
+</DJ_PLAYLISTS>

--- a/tests/test_transfer.py
+++ b/tests/test_transfer.py
@@ -34,6 +34,7 @@ from djsupport.transfer import (
     ApprovalStatus,
     ApprovalOutcome,
     BeatportLabelSource,
+    RekordboxPlaylistSource,
 )
 
 
@@ -120,6 +121,7 @@ class InMemoryStorage:
         self.approved_matches = []
         self.rejected_matches = []
         self.corrections = []
+        self.mirrors = []
 
     def lookup(self, track, threshold):
         result = self.matches.get((track.artist, track.name))
@@ -156,6 +158,9 @@ class InMemoryStorage:
     def retain_approval(self, outcome):
         self.approvals.append(outcome)
 
+    def retain_mirror(self, relationship):
+        self.mirrors.append(relationship)
+
     def approve(self, item):
         self.approved_matches.append(item)
 
@@ -167,6 +172,7 @@ class InMemoryStorage:
 
 
 FIXTURE = Path(__file__).parent / "fixtures" / "beatport_chart.json"
+REKORDBOX_FIXTURE = Path(__file__).parent / "fixtures" / "library.xml"
 LABEL_FIXTURE = Path(__file__).parent / "fixtures" / "beatport_label_page.json"
 TEST_PUBLISHING_GUARDS = AccountPublishingGuards()
 
@@ -593,6 +599,69 @@ class TestSnapshotPublication:
         assert second.playlists[0].publication_manifest.mode == TransferMode.MIRROR
 
 
+class TestRekordboxMirror:
+    def test_one_selected_playlist_previews_publishes_and_approval_retains_mirror(
+        self, tmp_path,
+    ):
+        matches = {
+            ("Solomun", "Vultora (Original Mix)"): _match(
+                "spotify:track:vultora", "Vultora (Original Mix)", "Solomun",
+            ),
+            ("Eagles & Butterflies", "Sapphire (Joris Voorn Remix)"): _match(
+                "spotify:track:sapphire", "Sapphire (Joris Voorn Remix)",
+                "Eagles & Butterflies",
+            ),
+        }
+        spotify = StatefulSpotify(matches)
+        cache = MatchCache(str(tmp_path / "matching-knowledge.json"))
+        knowledge = MatchCacheKnowledge(cache)
+        publications = FilePublicationStorage(tmp_path / "playlist-state.json")
+        transfer = Transfer(
+            publishing_guards=TEST_PUBLISHING_GUARDS,
+            source=RekordboxPlaylistSource(REKORDBOX_FIXTURE), spotify=spotify,
+            matching_knowledge=knowledge, publication_storage=publications,
+        )
+
+        preview = transfer.execute(TransferRequest(
+            source="My Playlists/Peak Time", preview=True,
+        ))
+        published = transfer.execute(TransferRequest(
+            source="My Playlists/Peak Time",
+        ))
+
+        playlist = published.playlists[0]
+        assert preview.playlists[0].action == "preview"
+        assert preview.total_matched == 2
+        assert spotify.searches == [
+            ("Solomun", "Vultora (Original Mix)", 80),
+            ("Eagles & Butterflies", "Sapphire (Joris Voorn Remix)", 80),
+        ]
+        assert playlist.action == "provisional mirror updated"
+        assert playlist.publication_manifest.mode == TransferMode.MIRROR
+        assert spotify.playlists[playlist.spotify_playlist_id]["tracks"] == [
+            "spotify:track:vultora", "spotify:track:sapphire",
+        ]
+        assert publications.mirrors_for_account("spotify-user-1") == []
+
+        approval = transfer.approve(playlist.spotify_playlist_id)
+
+        assert approval.status == ApprovalStatus.APPROVED
+        reloaded_state = FilePublicationStorage(tmp_path / "playlist-state.json")
+        mirrors = reloaded_state.mirrors_for_account("spotify-user-1")
+        assert len(mirrors) == 1
+        assert mirrors[0].source_reference == "My Playlists/Peak Time"
+        assert mirrors[0].spotify_playlist_id == playlist.spotify_playlist_id
+        assert MatchCacheKnowledge(cache).lookup(
+            Track(
+                track_id="another-source-id", name="Vultora (Original Mix)",
+                artist="Solomun", album="", remixer="", label="", genre="",
+                date_added="", duration=412,
+            ),
+            80,
+        )["authoritative"] is True
+
+
+class TestSnapshotPublicationContinued:
     def test_paused_transfer_reloads_and_resumes_without_repeating_work(self, tmp_path):
         matches = {
             ("Known Artist", "Known Track"): _match(

--- a/tests/test_transfer.py
+++ b/tests/test_transfer.py
@@ -35,6 +35,7 @@ from djsupport.transfer import (
     ApprovalOutcome,
     BeatportLabelSource,
     RekordboxPlaylistSource,
+    MirrorRelationship,
 )
 
 
@@ -173,6 +174,9 @@ class InMemoryStorage:
 
 FIXTURE = Path(__file__).parent / "fixtures" / "beatport_chart.json"
 REKORDBOX_FIXTURE = Path(__file__).parent / "fixtures" / "library.xml"
+INCOMPLETE_REKORDBOX_FIXTURE = (
+    Path(__file__).parent / "fixtures" / "rekordbox_missing_track.xml"
+)
 LABEL_FIXTURE = Path(__file__).parent / "fixtures" / "beatport_label_page.json"
 TEST_PUBLISHING_GUARDS = AccountPublishingGuards()
 
@@ -600,6 +604,22 @@ class TestSnapshotPublication:
 
 
 class TestRekordboxMirror:
+    def test_missing_rekordbox_track_stops_before_matching_or_publication(self):
+        spotify = StatefulSpotify()
+        storage = InMemoryStorage()
+
+        with pytest.raises(ValueError, match="missing track references: missing"):
+            Transfer(
+                publishing_guards=TEST_PUBLISHING_GUARDS,
+                source=RekordboxPlaylistSource(INCOMPLETE_REKORDBOX_FIXTURE),
+                spotify=spotify, matching_knowledge=storage,
+                publication_storage=storage,
+            ).execute(TransferRequest(source="Incomplete"))
+
+        assert spotify.searches == []
+        assert spotify.playlists == {"existing": ["spotify:track:untouched"]}
+        assert storage.publications == []
+
     def test_one_selected_playlist_previews_publishes_and_approval_retains_mirror(
         self, tmp_path,
     ):
@@ -661,7 +681,7 @@ class TestRekordboxMirror:
         )["authoritative"] is True
 
 
-class TestSnapshotPublicationContinued:
+class TestTransferPublicationLifecycle:
     def test_paused_transfer_reloads_and_resumes_without_repeating_work(self, tmp_path):
         matches = {
             ("Known Artist", "Known Track"): _match(
@@ -1122,6 +1142,31 @@ class TestSnapshotPublicationContinued:
             item["account_id"]
             for item in reloaded.manifests_for_account("spotify-user-2")
         } == {"spotify-user-2"}
+
+    def test_version_one_publication_state_migrates_when_mirror_state_is_saved(
+        self, tmp_path,
+    ):
+        path = tmp_path / "publication-manifests.json"
+        path.write_text(json.dumps({
+            "version": 1,
+            "manifests": [],
+            "approvals": [],
+        }))
+        storage = FilePublicationStorage(path)
+
+        storage.retain_mirror(MirrorRelationship(
+            account_id="spotify-user-1",
+            source_label="Rekordbox",
+            source_reference="My Playlists/Peak Time",
+            spotify_playlist_id="mirror-1",
+            spotify_playlist_name="Peak Time",
+            approved_at=datetime(2026, 8, 1),
+        ))
+
+        assert json.loads(path.read_text())["version"] == 2
+        assert len(FilePublicationStorage(path).mirrors_for_account(
+            "spotify-user-1"
+        )) == 1
 
 class TestProvisionalPlaylistApproval:
     def publish(self):


### PR DESCRIPTION
## Summary
- add fixture-backed Rekordbox playlist intake with Mirror as the source default
- Preview and publish one explicitly selected playlist through the public Transfer seam
- retain account-scoped Mirror state only after playlist Approval while keeping Approved Match knowledge separate
- reject incomplete Rekordbox playlist references before matching or publication
- migrate publication state from schema version 1 to version 2

## Validation
- 405 offline tests passed
- Python compilation passed
- git diff validation passed
- parallel Standards and Spec reviews passed with no remaining blockers

Closes #22