### PR TITLE
Refresh Rekordbox Mirrors with drift decisions

### DIFF
--- a/djsupport/cache.py
+++ b/djsupport/cache.py
@@ -185,6 +185,15 @@ class MatchCache:
         self.local_regressions.append(correction)
         self._dirty_count += 1
 
+    def revoke_approval(
+        self, artist: str, title: str, source_duration: int = 0,
+    ) -> None:
+        """Remove authoritative knowledge after an explicit user decision."""
+        self.entries.pop(self.cache_key(artist, title, source_duration), None)
+        if source_duration > 0:
+            self.entries.pop(self.cache_key(artist, title), None)
+        self._dirty_count += 1
+
     def is_retry_eligible(self, artist: str, title: str,
                           retry_days: int = DEFAULT_RETRY_DAYS,
                           force: bool = False) -> bool:

--- a/djsupport/report.py
+++ b/djsupport/report.py
@@ -56,6 +56,20 @@ class MatchCollision:
     spotify_uri: str
 
 
+@dataclass(frozen=True)
+class SourceRemoval:
+    source_track_id: str
+    source_name: str
+    spotify_uri: str
+
+
+@dataclass(frozen=True)
+class PlaylistDrift:
+    source_track_id: str
+    source_name: str
+    spotify_uri: str
+
+
 def _spotify_url(uri: str) -> str:
     if uri.startswith("spotify:track:"):
         return f"https://open.spotify.com/track/{uri.removeprefix('spotify:track:')}"
@@ -71,6 +85,9 @@ class PlaylistReport:
     alternatives: list[UnmatchedAlternatives] = field(default_factory=list)
     unavailable_approved: list[UnavailableApprovedMatch] = field(default_factory=list)
     match_collisions: list[MatchCollision] = field(default_factory=list)
+    source_removals: list[SourceRemoval] = field(default_factory=list)
+    playlist_drift: list[PlaylistDrift] = field(default_factory=list)
+    drift_choices: tuple[str, ...] = ()
     action: str = "dry-run"  # "created", "updated", "unchanged", or "dry-run"
     spotify_playlist_id: str | None = None
     publication_manifest: PublicationManifest | None = None
@@ -248,6 +265,29 @@ def save_report(report: SyncReport, path: str) -> None:
                     f"- {collision.source_track_id}: {collision.source_name} → "
                     f"`{collision.spotify_uri}`"
                 )
+            lines.append("")
+
+        if pl.source_removals:
+            lines.append("### Source Removals")
+            lines.append("")
+            for removal in pl.source_removals:
+                lines.append(
+                    f"- {removal.source_track_id}: {removal.source_name} → "
+                    f"`{removal.spotify_uri}` removed from the Mirror"
+                )
+            lines.append("")
+
+        if pl.playlist_drift:
+            lines.append("### Playlist Drift (decision required)")
+            lines.append("")
+            for drift in pl.playlist_drift:
+                lines.append(
+                    f"- {drift.source_track_id}: {drift.source_name} → "
+                    f"`{drift.spotify_uri}` is missing in Spotify"
+                )
+            lines.append(
+                "Choose explicitly: " + " or ".join(pl.drift_choices)
+            )
             lines.append("")
 
         if pl.unmatched:

--- a/djsupport/transfer.py
+++ b/djsupport/transfer.py
@@ -39,15 +39,17 @@ from djsupport.report import (
     AlternativeCandidate,
     MatchCollision,
     MatchedTrack,
+    PlaylistDrift,
     PlaylistReport,
     SyncReport,
+    SourceRemoval,
     UnmatchedAlternatives,
     UnavailableApprovedMatch,
 )
 from djsupport.spotify import MAX_RATE_LIMIT_WAIT, RateLimitError, _parse_retry_after
 
 
-PUBLICATION_MANIFEST_VERSION = 2
+PUBLICATION_MANIFEST_VERSION = 3
 TRANSFER_STATE_VERSION = 1
 SPOTIFY_TRACK_URI = re.compile(r"^spotify:track:([A-Za-z0-9]{22})$")
 SPOTIFY_TRACK_URL = re.compile(
@@ -72,6 +74,11 @@ class TransferMode(str, Enum):
     MIRROR = "mirror"
 
 
+class DriftResolution(str, Enum):
+    RESTORE = "restore"
+    REVOKE = "revoke"
+
+
 @dataclass(frozen=True)
 class TransferRequest:
     """Everything an adapter must provide to start one Transfer."""
@@ -84,6 +91,7 @@ class TransferRequest:
     retry_days: int = 7
     playlist_prefix: str | None = "djsupport"
     transfer_id: str | None = None
+    drift_resolution: DriftResolution | None = None
 
 class TransferStatus(str, Enum):
     MATCHING = "matching"
@@ -235,6 +243,7 @@ class PublicationItem:
     score: float
     match_type: str
     source_duration: int = 0
+    authoritative: bool = False
 
 
 @dataclass(frozen=True)
@@ -249,6 +258,7 @@ class PublicationManifest:
     created_at: datetime
     items: tuple[PublicationItem, ...]
     mode: TransferMode = TransferMode.SNAPSHOT
+    managed_items: tuple[PublicationItem, ...] = ()
 
 
 @dataclass(frozen=True)
@@ -327,6 +337,10 @@ class PublicationStorage(Protocol):
 
     def retain_mirror(self, relationship: MirrorRelationship) -> None: ...
 
+    def mirror_for_source(
+        self, account_id: str, source_label: str, source_reference: str,
+    ) -> MirrorRelationship | None: ...
+
 
 class FilePublicationStorage:
     """Versioned, durable publication manifests for later review."""
@@ -345,7 +359,7 @@ class FilePublicationStorage:
             data = json.loads(self.path.read_text())
         except (json.JSONDecodeError, OSError):
             return
-        if data.get("version") not in (1, PUBLICATION_MANIFEST_VERSION):
+        if data.get("version") not in (1, 2, PUBLICATION_MANIFEST_VERSION):
             return
         self.manifests = data.get("manifests", [])
         self.approvals = data.get("approvals", data.get("reviews", []))
@@ -402,6 +416,10 @@ class FilePublicationStorage:
                 ),
                 "created_at": datetime.fromisoformat(stored["created_at"]),
                 "items": tuple(PublicationItem(**item) for item in stored["items"]),
+                "managed_items": tuple(
+                    PublicationItem(**item)
+                    for item in stored.get("managed_items", stored["items"])
+                ),
             }
         )
 
@@ -433,6 +451,15 @@ class FilePublicationStorage:
             for item in self.mirrors
             if item.get("account_id") == account_id
         ]
+
+    def mirror_for_source(
+        self, account_id: str, source_label: str, source_reference: str,
+    ) -> MirrorRelationship | None:
+        return next((
+            mirror for mirror in self.mirrors_for_account(account_id)
+            if mirror.source_label == source_label
+            and mirror.source_reference == source_reference
+        ), None)
 
 
 class TransferStorage(Protocol):
@@ -500,6 +527,8 @@ class MatchingKnowledge(Protocol):
     def reject(self, item: PublicationItem) -> None: ...
 
     def correct(self, item: PublicationItem) -> ApprovalConflict | None: ...
+
+    def revoke(self, item: PublicationItem) -> None: ...
 
 
 class BeatportChartSource:
@@ -768,6 +797,11 @@ class MatchCacheKnowledge:
         })
         return None
 
+    def revoke(self, item: PublicationItem) -> None:
+        self._cache.revoke_approval(
+            item.source_artist, item.source_title, item.source_duration,
+        )
+
 
 class EphemeralMatchingKnowledge:
     """Non-persistent matching knowledge used for explicit ``--no-cache``."""
@@ -795,6 +829,9 @@ class EphemeralMatchingKnowledge:
         pass
 
     def correct(self, item: PublicationItem) -> None:
+        pass
+
+    def revoke(self, item: PublicationItem) -> None:
         pass
 
 
@@ -1107,6 +1144,10 @@ class Transfer:
                     "retry": request.retry,
                     "retry_days": request.retry_days,
                     "playlist_prefix": request.playlist_prefix,
+                    "drift_resolution": (
+                        request.drift_resolution.value
+                        if request.drift_resolution else None
+                    ),
                 },
                 selection={
                     "name": selection.name,
@@ -1133,6 +1174,10 @@ class Transfer:
                     **state.request,
                     "mode": TransferMode(
                         state.request.get("mode", TransferMode.SNAPSHOT.value)
+                    ),
+                    "drift_resolution": (
+                        DriftResolution(state.request["drift_resolution"])
+                        if state.request.get("drift_resolution") else None
                     ),
                 },
                 transfer_id=transfer_id,
@@ -1204,6 +1249,12 @@ class Transfer:
                             "items": tuple(
                                 PublicationItem(**item)
                                 for item in stored_manifest["items"]
+                            ),
+                            "managed_items": tuple(
+                                PublicationItem(**item)
+                                for item in stored_manifest.get(
+                                    "managed_items", stored_manifest["items"],
+                                )
                             ),
                         }
                     )
@@ -1288,6 +1339,7 @@ class Transfer:
                         score=matched_track.score,
                         match_type=matched_track.match_type,
                         source_duration=track.duration,
+                        authoritative=bool(result.get("authoritative")),
                     ))
 
                 state.next_track_index = index + 1
@@ -1307,10 +1359,14 @@ class Transfer:
                     return report
                 self._save_transfer(transfer_id, state)
 
-            source_ids_by_uri: dict[str, set[str]] = {}
+            source_ids_by_uri: dict[str, set[tuple[str, str, int]]] = {}
             for item in publication_items:
                 source_ids_by_uri.setdefault(item.spotify_uri, set()).add(
-                    item.source_track_id
+                    (
+                        item.source_artist.casefold(),
+                        item.source_title.casefold(),
+                        item.source_duration,
+                    )
                 )
             collision_uris = {
                 uri for uri, source_ids in source_ids_by_uri.items()
@@ -1340,6 +1396,95 @@ class Transfer:
                 )
                 state.matched = [asdict(item) for item in playlist.matched]
                 state.unmatched = list(playlist.unmatched)
+
+            if request.mode == TransferMode.MIRROR:
+                assert self._publication_storage is not None or request.preview
+                relationship = (
+                    self._publication_storage.mirror_for_source(
+                        state.account_id, self._source.source_label,
+                        selection.reference,
+                    )
+                    if self._publication_storage is not None else None
+                )
+                previous_manifest = (
+                    self._publication_storage.publication_for_playlist(
+                        state.account_id, relationship.spotify_playlist_id,
+                    )
+                    if relationship is not None else None
+                )
+                current_source_ids = {
+                    item.source_track_id for item in publication_items
+                }
+                if previous_manifest is not None:
+                    playlist.source_removals = [
+                        SourceRemoval(
+                            item.source_track_id, item.source_name,
+                            item.spotify_uri,
+                        )
+                        for item in (
+                            previous_manifest.managed_items
+                            or previous_manifest.items
+                        )
+                        if item.source_track_id not in current_source_ids
+                    ]
+                if relationship is not None:
+                    current_uris = self._retry_policy.run(
+                        lambda: self._spotify.provisional_playlist_track_uris(
+                            relationship.spotify_playlist_id
+                        )
+                    )
+                    current_uri_set = set(current_uris or ())
+                    playlist.playlist_drift = [
+                        PlaylistDrift(
+                            item.source_track_id, item.source_name,
+                            item.spotify_uri,
+                        )
+                        for item in publication_items
+                        if item.authoritative
+                        and item.spotify_uri not in current_uri_set
+                    ]
+                    if (
+                        playlist.playlist_drift
+                        and request.drift_resolution is None
+                    ):
+                        playlist.action = "restore or revoke required"
+                        playlist.drift_choices = tuple(
+                            choice.value for choice in DriftResolution
+                        )
+                        report.status = "playlist drift"
+                        return report
+                    if (
+                        playlist.playlist_drift
+                        and request.drift_resolution == DriftResolution.REVOKE
+                    ):
+                        drifted_ids = {
+                            item.source_track_id for item in playlist.playlist_drift
+                        }
+                        revoked_items = [
+                            item for item in publication_items
+                            if item.source_track_id in drifted_ids
+                        ]
+                        for item in revoked_items:
+                            self._knowledge.revoke(item)
+                        self._knowledge.checkpoint()
+                        publication_items = [
+                            item for item in publication_items
+                            if item.source_track_id not in drifted_ids
+                        ]
+                        playlist.matched = [
+                            item for item in playlist.matched
+                            if item.source_track_id not in drifted_ids
+                        ]
+                        playlist.unmatched.extend(
+                            item.source_name for item in revoked_items
+                            if item.source_name not in playlist.unmatched
+                        )
+                        state.publication_items = [
+                            asdict(item) for item in publication_items
+                        ]
+                        state.matched = [asdict(item) for item in playlist.matched]
+                        state.unmatched = list(playlist.unmatched)
+                        self._save_transfer(transfer_id, state)
 
             if not request.preview and not selection.tracks:
                 playlist.action = "not published: empty source"
@@ -1391,6 +1536,10 @@ class Transfer:
                         report.status = "paused"
                         return report
                 assert snapshot_name is not None
+                managed_items_by_uri: dict[str, PublicationItem] = {}
+                for item in publication_items:
+                    if item.spotify_uri not in collision_uris:
+                        managed_items_by_uri.setdefault(item.spotify_uri, item)
                 manifest = PublicationManifest(
                     account_id=state.account_id,
                     spotify_playlist_id=playlist_id,
@@ -1398,8 +1547,13 @@ class Transfer:
                     source_label=self._source.source_label,
                     source_reference=selection.reference,
                     created_at=created_at,
-                    items=tuple(publication_items),
+                    items=tuple(
+                        item for item in publication_items
+                        if not item.authoritative
+                        and item.spotify_uri not in collision_uris
+                    ),
                     mode=request.mode,
+                    managed_items=tuple(managed_items_by_uri.values()),
                 )
                 stored_manifest = asdict(manifest)
                 stored_manifest["created_at"] = manifest.created_at.isoformat()

--- a/djsupport/transfer.py
+++ b/djsupport/transfer.py
@@ -1278,6 +1278,19 @@ class Transfer:
                                 spotify_uri=result["uri"],
                             )
                         )
+                        publication_items.append(PublicationItem(
+                            source_track_id=track.track_id,
+                            source_name=track.display,
+                            source_artist=track.artist,
+                            source_title=track.name,
+                            spotify_uri=result["uri"],
+                            spotify_name=result["name"],
+                            spotify_artist=result["artist"],
+                            score=result["score"],
+                            match_type=result.get("match_type", "exact"),
+                            source_duration=track.duration,
+                            authoritative=True,
+                        ))
                         result = None
                 elif self._knowledge.should_retry(
                     track, request.threshold, request.retry_days, request.retry,
@@ -1413,7 +1426,7 @@ class Transfer:
                     if relationship is not None else None
                 )
                 current_source_ids = {
-                    item.source_track_id for item in publication_items
+                    track.track_id for track in selection.tracks
                 }
                 if previous_manifest is not None:
                     playlist.source_removals = [

--- a/tests/fixtures/rekordbox_mirror_refresh.json
+++ b/tests/fixtures/rekordbox_mirror_refresh.json
@@ -1,0 +1,16 @@
+{
+  "name": "Peak Time",
+  "reference": "My Playlists/Peak Time",
+  "initial": [
+    {"track_id": "rb-1", "artist": "Artist One", "name": "First Track", "duration": 301},
+    {"track_id": "rb-2", "artist": "Artist Two", "name": "Second Track", "duration": 302}
+  ],
+  "refreshed": [
+    {"track_id": "rb-2", "artist": "Artist Two", "name": "Second Track", "duration": 302},
+    {"track_id": "rb-3", "artist": "Artist Three", "name": "Third Track", "duration": 303},
+    {"track_id": "rb-2-copy", "artist": "Artist Two", "name": "Second Track", "duration": 302}
+  ],
+  "final": [
+    {"track_id": "rb-3", "artist": "Artist Three", "name": "Third Track", "duration": 303}
+  ]
+}

--- a/tests/test_transfer.py
+++ b/tests/test_transfer.py
@@ -781,6 +781,58 @@ class TestRekordboxMirror:
             for item in refreshed.playlists[0].publication_manifest.items
         ] == ["rb-3"]
 
+    def test_unavailable_approved_track_is_not_a_genuine_source_removal(self, tmp_path):
+        fixture = json.loads(MIRROR_REFRESH_FIXTURE.read_text())
+
+        class MirrorSource:
+            source_label = "Rekordbox"
+            default_mode = TransferMode.MIRROR
+
+            def consume(self, reference):
+                return SourceSelection(
+                    fixture["name"], fixture["reference"],
+                    [Track(
+                        track_id=item["track_id"], artist=item["artist"],
+                        name=item["name"], duration=item["duration"], album="",
+                        remixer="", label="", genre="", date_added="",
+                    ) for item in fixture["initial"]],
+                )
+
+        spotify = StatefulSpotify({
+            ("Artist One", "First Track"): _match(
+                "spotify:track:first", "First Track", "Artist One",
+            ),
+            ("Artist Two", "Second Track"): _match(
+                "spotify:track:second", "Second Track", "Artist Two",
+            ),
+        })
+        knowledge = MatchCacheKnowledge(MatchCache(tmp_path / "knowledge.json"))
+        publications = FilePublicationStorage(tmp_path / "publications.json")
+        transfer = Transfer(
+            publishing_guards=TEST_PUBLISHING_GUARDS, source=MirrorSource(),
+            spotify=spotify, matching_knowledge=knowledge,
+            publication_storage=publications,
+        )
+        initial = transfer.execute(TransferRequest(source=fixture["reference"]))
+        playlist_id = initial.playlists[0].spotify_playlist_id
+        transfer.approve(playlist_id)
+        original_spotify_track = spotify.spotify_track
+        spotify.spotify_track = lambda uri: (
+            {**original_spotify_track(uri), "is_playable": False}
+            if uri == "spotify:track:first" else original_spotify_track(uri)
+        )
+
+        refreshed = transfer.execute(TransferRequest(source=fixture["reference"]))
+
+        assert refreshed.playlists[0].source_removals == []
+        assert [
+            item.source_track_id
+            for item in refreshed.playlists[0].unavailable_approved
+        ] == ["rb-1"]
+        assert spotify.playlists[playlist_id]["tracks"] == [
+            "spotify:track:first", "spotify:track:second",
+        ]
+
     def test_refresh_deduplicates_orders_and_reports_genuine_source_removals(
         self, tmp_path,
     ):

--- a/tests/test_transfer.py
+++ b/tests/test_transfer.py
@@ -17,7 +17,7 @@ from click.testing import CliRunner
 from djsupport.cli import cli
 from djsupport.cache import MatchCache
 from djsupport.rekordbox import Track
-from djsupport.report import PlaylistReport, SyncReport
+from djsupport.report import PlaylistReport, SyncReport, save_report
 from djsupport.spotify import RateLimitError
 from djsupport.transfer import (
     AccountPublishingGuards,
@@ -31,6 +31,7 @@ from djsupport.transfer import (
     Transfer,
     TransferMode,
     TransferRequest,
+    DriftResolution,
     ApprovalStatus,
     ApprovalOutcome,
     BeatportLabelSource,
@@ -162,6 +163,14 @@ class InMemoryStorage:
     def retain_mirror(self, relationship):
         self.mirrors.append(relationship)
 
+    def mirror_for_source(self, account_id, source_label, source_reference):
+        return next((
+            mirror for mirror in self.mirrors
+            if mirror.account_id == account_id
+            and mirror.source_label == source_label
+            and mirror.source_reference == source_reference
+        ), None)
+
     def approve(self, item):
         self.approved_matches.append(item)
 
@@ -171,6 +180,9 @@ class InMemoryStorage:
     def correct(self, item):
         self.corrections.append(item)
 
+    def revoke(self, item):
+        self.matches.pop((item.source_artist, item.source_title), None)
+
 
 FIXTURE = Path(__file__).parent / "fixtures" / "beatport_chart.json"
 REKORDBOX_FIXTURE = Path(__file__).parent / "fixtures" / "library.xml"
@@ -178,6 +190,9 @@ INCOMPLETE_REKORDBOX_FIXTURE = (
     Path(__file__).parent / "fixtures" / "rekordbox_missing_track.xml"
 )
 LABEL_FIXTURE = Path(__file__).parent / "fixtures" / "beatport_label_page.json"
+MIRROR_REFRESH_FIXTURE = (
+    Path(__file__).parent / "fixtures" / "rekordbox_mirror_refresh.json"
+)
 TEST_PUBLISHING_GUARDS = AccountPublishingGuards()
 
 
@@ -604,6 +619,232 @@ class TestSnapshotPublication:
 
 
 class TestRekordboxMirror:
+    def test_refresh_reports_playlist_drift_without_silently_restoring(self, tmp_path):
+        fixture = json.loads(MIRROR_REFRESH_FIXTURE.read_text())
+
+        class MirrorSource:
+            source_label = "Rekordbox"
+            default_mode = TransferMode.MIRROR
+
+            def consume(self, reference):
+                return SourceSelection(
+                    fixture["name"], fixture["reference"],
+                    [Track(
+                        track_id=item["track_id"], artist=item["artist"],
+                        name=item["name"], duration=item["duration"], album="",
+                        remixer="", label="", genre="", date_added="",
+                    ) for item in fixture["initial"]],
+                )
+
+        spotify = StatefulSpotify({
+            ("Artist One", "First Track"): _match(
+                "spotify:track:first", "First Track", "Artist One",
+            ),
+            ("Artist Two", "Second Track"): _match(
+                "spotify:track:second", "Second Track", "Artist Two",
+            ),
+        })
+        knowledge = MatchCacheKnowledge(MatchCache(tmp_path / "knowledge.json"))
+        publications = FilePublicationStorage(tmp_path / "publications.json")
+        transfer = Transfer(
+            publishing_guards=TEST_PUBLISHING_GUARDS, source=MirrorSource(),
+            spotify=spotify, matching_knowledge=knowledge,
+            publication_storage=publications,
+        )
+        initial = transfer.execute(TransferRequest(source=fixture["reference"]))
+        playlist_id = initial.playlists[0].spotify_playlist_id
+        transfer.approve(playlist_id)
+        spotify.playlists[playlist_id]["tracks"] = ["spotify:track:second"]
+
+        drifted = transfer.execute(TransferRequest(source=fixture["reference"]))
+
+        assert drifted.status == "playlist drift"
+        assert drifted.playlists[0].action == "restore or revoke required"
+        assert [item.source_track_id for item in drifted.playlists[0].playlist_drift] == [
+            "rb-1"
+        ]
+        assert drifted.playlists[0].drift_choices == (
+            DriftResolution.RESTORE.value, DriftResolution.REVOKE.value,
+        )
+        assert spotify.playlists[playlist_id]["tracks"] == ["spotify:track:second"]
+
+        restored = transfer.execute(TransferRequest(
+            source=fixture["reference"],
+            drift_resolution=DriftResolution.RESTORE,
+        ))
+
+        assert restored.status == "completed"
+        assert spotify.playlists[playlist_id]["tracks"] == [
+            "spotify:track:first", "spotify:track:second",
+        ]
+
+    def test_refresh_can_explicitly_revoke_a_drifted_approved_match(self, tmp_path):
+        fixture = json.loads(MIRROR_REFRESH_FIXTURE.read_text())
+
+        class MirrorSource:
+            source_label = "Rekordbox"
+            default_mode = TransferMode.MIRROR
+
+            def consume(self, reference):
+                return SourceSelection(
+                    fixture["name"], fixture["reference"],
+                    [Track(
+                        track_id=item["track_id"], artist=item["artist"],
+                        name=item["name"], duration=item["duration"], album="",
+                        remixer="", label="", genre="", date_added="",
+                    ) for item in fixture["initial"]],
+                )
+
+        spotify = StatefulSpotify({
+            ("Artist One", "First Track"): _match(
+                "spotify:track:first", "First Track", "Artist One",
+            ),
+            ("Artist Two", "Second Track"): _match(
+                "spotify:track:second", "Second Track", "Artist Two",
+            ),
+        })
+        cache = MatchCache(tmp_path / "knowledge.json")
+        knowledge = MatchCacheKnowledge(cache)
+        publications = FilePublicationStorage(tmp_path / "publications.json")
+        transfer = Transfer(
+            publishing_guards=TEST_PUBLISHING_GUARDS, source=MirrorSource(),
+            spotify=spotify, matching_knowledge=knowledge,
+            publication_storage=publications,
+        )
+        initial = transfer.execute(TransferRequest(source=fixture["reference"]))
+        playlist_id = initial.playlists[0].spotify_playlist_id
+        transfer.approve(playlist_id)
+        spotify.playlists[playlist_id]["tracks"] = ["spotify:track:second"]
+
+        revoked = transfer.execute(TransferRequest(
+            source=fixture["reference"],
+            drift_resolution=DriftResolution.REVOKE,
+        ))
+
+        assert revoked.status == "completed"
+        assert spotify.playlists[playlist_id]["tracks"] == ["spotify:track:second"]
+        assert knowledge.lookup(
+            Track(
+                track_id="rb-1", artist="Artist One", name="First Track",
+                duration=301, album="", remixer="", label="", genre="",
+                date_added="",
+            ), 80,
+        ) is None
+
+    def test_refresh_reuses_approved_matches_without_repeated_review(self, tmp_path):
+        fixture = json.loads(MIRROR_REFRESH_FIXTURE.read_text())
+
+        class RefreshSource:
+            source_label = "Rekordbox"
+            default_mode = TransferMode.MIRROR
+            phase = "initial"
+
+            def consume(self, reference):
+                tracks = [
+                    Track(
+                        track_id=item["track_id"], artist=item["artist"],
+                        name=item["name"], duration=item["duration"], album="",
+                        remixer="", label="", genre="", date_added="",
+                    )
+                    for item in fixture[self.phase]
+                ]
+                return SourceSelection(fixture["name"], fixture["reference"], tracks)
+
+        source = RefreshSource()
+        spotify = StatefulSpotify({
+            ("Artist One", "First Track"): _match(
+                "spotify:track:first", "First Track", "Artist One",
+            ),
+            ("Artist Two", "Second Track"): _match(
+                "spotify:track:second", "Second Track", "Artist Two",
+            ),
+            ("Artist Three", "Third Track"): _match(
+                "spotify:track:third", "Third Track", "Artist Three",
+            ),
+        })
+        knowledge = MatchCacheKnowledge(MatchCache(tmp_path / "knowledge.json"))
+        publications = FilePublicationStorage(tmp_path / "publications.json")
+        transfer = Transfer(
+            publishing_guards=TEST_PUBLISHING_GUARDS, source=source,
+            spotify=spotify, matching_knowledge=knowledge,
+            publication_storage=publications,
+        )
+        initial = transfer.execute(TransferRequest(source=fixture["reference"]))
+        transfer.approve(initial.playlists[0].spotify_playlist_id)
+
+        source.phase = "refreshed"
+        refreshed = transfer.execute(TransferRequest(source=fixture["reference"]))
+
+        assert spotify.searches.count(("Artist Two", "Second Track", 80)) == 1
+        assert [
+            item.source_track_id
+            for item in refreshed.playlists[0].publication_manifest.items
+        ] == ["rb-3"]
+
+    def test_refresh_deduplicates_orders_and_reports_genuine_source_removals(
+        self, tmp_path,
+    ):
+        fixture = json.loads(MIRROR_REFRESH_FIXTURE.read_text())
+
+        class RefreshSource:
+            source_label = "Rekordbox"
+            default_mode = TransferMode.MIRROR
+            phase = "initial"
+
+            def consume(self, reference):
+                return SourceSelection(
+                    fixture["name"], fixture["reference"],
+                    [Track(
+                        track_id=item["track_id"], artist=item["artist"],
+                        name=item["name"], duration=item["duration"], album="",
+                        remixer="", label="", genre="", date_added="",
+                    ) for item in fixture[self.phase]],
+                )
+
+        source = RefreshSource()
+        spotify = StatefulSpotify({
+            ("Artist One", "First Track"): _match(
+                "spotify:track:first", "First Track", "Artist One",
+            ),
+            ("Artist Two", "Second Track"): _match(
+                "spotify:track:second", "Second Track", "Artist Two",
+            ),
+            ("Artist Three", "Third Track"): _match(
+                "spotify:track:third", "Third Track", "Artist Three",
+            ),
+        })
+        knowledge = MatchCacheKnowledge(MatchCache(tmp_path / "knowledge.json"))
+        publications = FilePublicationStorage(tmp_path / "publications.json")
+        transfer = Transfer(
+            publishing_guards=TEST_PUBLISHING_GUARDS, source=source,
+            spotify=spotify, matching_knowledge=knowledge,
+            publication_storage=publications,
+        )
+        initial = transfer.execute(TransferRequest(source=fixture["reference"]))
+        transfer.approve(initial.playlists[0].spotify_playlist_id)
+
+        source.phase = "refreshed"
+        refreshed = transfer.execute(TransferRequest(source=fixture["reference"]))
+        playlist = refreshed.playlists[0]
+
+        assert spotify.playlists[playlist.spotify_playlist_id]["tracks"] == [
+            "spotify:track:second", "spotify:track:third",
+        ]
+        assert [removal.source_track_id for removal in playlist.source_removals] == [
+            "rb-1"
+        ]
+        report_path = tmp_path / "refresh-report.md"
+        save_report(refreshed, str(report_path))
+        assert "rb-1: Artist One - First Track" in report_path.read_text()
+
+        transfer.approve(playlist.spotify_playlist_id)
+        source.phase = "final"
+        final = transfer.execute(TransferRequest(source=fixture["reference"]))
+
+        assert [removal.source_track_id for removal in final.playlists[0].source_removals] == [
+            "rb-2"
+        ]
+
     def test_missing_rekordbox_track_stops_before_matching_or_publication(self):
         spotify = StatefulSpotify()
         storage = InMemoryStorage()
@@ -1163,7 +1404,7 @@ class TestTransferPublicationLifecycle:
             approved_at=datetime(2026, 8, 1),
         ))
 
-        assert json.loads(path.read_text())["version"] == 2
+        assert json.loads(path.read_text())["version"] == 3
         assert len(FilePublicationStorage(path).mirrors_for_account(
             "spotify-user-1"
         )) == 1


### PR DESCRIPTION
## Summary
- refresh established Mirrors in deduplicated source-relative order
- reuse Approved Matches while staging only new proposals for playlist-scoped Approval
- report genuine source removals and require explicit restore or revoke for Playlist Drift
- preserve unavailable Approved Matches without misclassifying them as source removals

## Validation
- 410 offline tests passed
- Python compilation passed
- git diff validation passed
- parallel Standards and Spec reviews completed; blocking Spec finding resolved and re-reviewed

Closes #23