### PR TITLE
Protect displaced Mirrors

### DIFF
--- a/djsupport/report.py
+++ b/djsupport/report.py
@@ -88,6 +88,8 @@ class PlaylistReport:
     source_removals: list[SourceRemoval] = field(default_factory=list)
     playlist_drift: list[PlaylistDrift] = field(default_factory=list)
     drift_choices: tuple[str, ...] = ()
+    mirror_dispositions: tuple[str, ...] = ()
+    mirror_disposition: str | None = None
     action: str = "dry-run"  # "created", "updated", "unchanged", or "dry-run"
     spotify_playlist_id: str | None = None
     publication_manifest: PublicationManifest | None = None
@@ -195,6 +197,8 @@ def save_report(report: SyncReport, path: str) -> None:
     lines.append(f"**Mode:** {mode}  |  **Threshold:** {report.threshold}")
     if report.transfer_id:
         lines.append(f"**Transfer:** {report.transfer_id}  |  **Status:** {report.status}")
+    elif report.status != "completed":
+        lines.append(f"**Status:** {report.status}")
     lines.append("")
 
     for pl in report.playlists:
@@ -287,6 +291,21 @@ def save_report(report: SyncReport, path: str) -> None:
                 )
             lines.append(
                 "Choose explicitly: " + " or ".join(pl.drift_choices)
+            )
+            lines.append("")
+
+        if pl.mirror_dispositions:
+            lines.append("### Orphaned Mirror (decision required)")
+            lines.append("")
+            lines.append(
+                "Choose explicitly: " + ", ".join(pl.mirror_dispositions[:-1])
+                + f", or {pl.mirror_dispositions[-1]}"
+            )
+            lines.append("")
+
+        if pl.mirror_disposition:
+            lines.append(
+                f"**Orphaned Mirror disposition:** {pl.mirror_disposition}"
             )
             lines.append("")
 

--- a/djsupport/transfer.py
+++ b/djsupport/transfer.py
@@ -328,6 +328,8 @@ class SpotifyAdapter(Protocol):
 
     def delete_provisional_snapshot(self, playlist_id: str) -> None: ...
 
+    def delete_playlist(self, playlist_id: str) -> None: ...
+
     def provisional_playlist_track_uris(
         self, playlist_id: str,
     ) -> list[str] | None: ...
@@ -741,6 +743,9 @@ class SpotifyMatcher:
         return None
 
     def delete_provisional_snapshot(self, playlist_id: str) -> None:
+        self._client.current_user_unfollow_playlist(playlist_id)
+
+    def delete_playlist(self, playlist_id: str) -> None:
         self._client.current_user_unfollow_playlist(playlist_id)
 
     def provisional_playlist_track_uris(self, playlist_id: str) -> list[str] | None:
@@ -1220,7 +1225,7 @@ class Transfer:
                         status = "completed"
                     elif request.mirror_disposition == MirrorDisposition.DELETE:
                         self._retry_policy.run(
-                            lambda: self._spotify.delete_provisional_snapshot(
+                            lambda: self._spotify.delete_playlist(
                                 relationship.spotify_playlist_id
                             )
                         )
@@ -1561,10 +1566,19 @@ class Transfer:
                 state.matched = [asdict(item) for item in playlist.matched]
                 state.unmatched = list(playlist.unmatched)
 
+            relink_original_uris: list[str] | None = None
             if request.mode == TransferMode.MIRROR:
                 assert self._publication_storage is not None or request.preview
                 relationship = (
-                    self._publication_storage.mirror_for_source(
+                    self._publication_storage.mirror_for_playlist(
+                        state.account_id, request.mirror_playlist_id,
+                    )
+                    if (
+                        self._publication_storage is not None
+                        and request.mirror_disposition == MirrorDisposition.RELINK
+                        and request.mirror_playlist_id is not None
+                    )
+                    else self._publication_storage.mirror_for_source(
                         state.account_id, self._source.source_label,
                         selection.reference,
                     )
@@ -1597,6 +1611,8 @@ class Transfer:
                             relationship.spotify_playlist_id
                         )
                     )
+                    if request.mirror_disposition == MirrorDisposition.RELINK:
+                        relink_original_uris = list(current_uris or ())
                     current_uri_set = set(current_uris or ())
                     playlist.playlist_drift = [
                         PlaylistDrift(
@@ -1655,6 +1671,7 @@ class Transfer:
             elif not request.preview:
                 playlist_id = state.spotify_playlist_id
                 snapshot_name = state.spotify_playlist_name
+                created_playlist = playlist_id is None
                 if playlist_id is None:
                     if request.mode == TransferMode.MIRROR:
                         snapshot_name = selection.name
@@ -1737,7 +1754,12 @@ class Transfer:
                 try:
                     self._publication_storage.retain_publication(manifest)
                 except Exception:
-                    self._spotify.delete_provisional_snapshot(playlist_id)
+                    if created_playlist:
+                        self._spotify.delete_provisional_snapshot(playlist_id)
+                    elif relink_original_uris is not None:
+                        self._spotify.replace_provisional_playlist_tracks(
+                            playlist_id, relink_original_uris,
+                        )
                     state.spotify_playlist_id = None
                     state.spotify_playlist_name = None
                     state.status = TransferStatus.MATCHING

--- a/djsupport/transfer.py
+++ b/djsupport/transfer.py
@@ -364,6 +364,11 @@ class PublicationStorage(Protocol):
         self, previous: MirrorRelationship, replacement: MirrorRelationship,
     ) -> None: ...
 
+    def retain_relinked_publication(
+        self, previous: MirrorRelationship, replacement: MirrorRelationship,
+        manifest: PublicationManifest,
+    ) -> None: ...
+
     def remove_mirror(self, relationship: MirrorRelationship) -> None: ...
 
 
@@ -513,6 +518,38 @@ class FilePublicationStorage:
             )
         ]
         self.retain_mirror(replacement)
+
+    def retain_relinked_publication(
+        self, previous: MirrorRelationship, replacement: MirrorRelationship,
+        manifest: PublicationManifest,
+    ) -> None:
+        stored_manifest = asdict(manifest)
+        stored_manifest["created_at"] = manifest.created_at.isoformat()
+        next_manifests = [
+            item for item in self.manifests
+            if not (
+                item.get("account_id") == manifest.account_id
+                and item.get("spotify_playlist_id") == manifest.spotify_playlist_id
+            )
+        ]
+        next_manifests.append(stored_manifest)
+        stored_relationship = asdict(replacement)
+        stored_relationship["approved_at"] = replacement.approved_at.isoformat()
+        stored_relationship["orphaned_at"] = None
+        previous_mirrors = self.mirrors
+        self.mirrors = [
+            item for item in self.mirrors
+            if not (
+                item.get("account_id") == previous.account_id
+                and item.get("spotify_playlist_id") == previous.spotify_playlist_id
+            )
+        ]
+        self.mirrors.append(stored_relationship)
+        try:
+            self._save(next_manifests, self.approvals)
+        except Exception:
+            self.mirrors = previous_mirrors
+            raise
 
     def remove_mirror(self, relationship: MirrorRelationship) -> None:
         self.mirrors = [
@@ -1752,7 +1789,24 @@ class Transfer:
                 self._save_transfer(transfer_id, state)
                 assert self._publication_storage is not None
                 try:
-                    self._publication_storage.retain_publication(manifest)
+                    if request.mirror_disposition == MirrorDisposition.RELINK:
+                        assert request.mirror_playlist_id is not None
+                        previous = self._publication_storage.mirror_for_playlist(
+                            state.account_id, request.mirror_playlist_id,
+                        )
+                        assert previous is not None
+                        self._publication_storage.retain_relinked_publication(
+                            previous,
+                            replace(
+                                previous,
+                                source_label=self._source.source_label,
+                                source_reference=selection.reference,
+                                orphaned_at=None,
+                            ),
+                            manifest,
+                        )
+                    else:
+                        self._publication_storage.retain_publication(manifest)
                 except Exception:
                     if created_playlist:
                         self._spotify.delete_provisional_snapshot(playlist_id)
@@ -1765,21 +1819,6 @@ class Transfer:
                     state.status = TransferStatus.MATCHING
                     self._save_transfer(transfer_id, state)
                     raise
-                if request.mirror_disposition == MirrorDisposition.RELINK:
-                    assert request.mirror_playlist_id is not None
-                    previous = self._publication_storage.mirror_for_playlist(
-                        state.account_id, request.mirror_playlist_id,
-                    )
-                    assert previous is not None
-                    self._publication_storage.replace_mirror(
-                        previous,
-                        replace(
-                            previous,
-                            source_label=self._source.source_label,
-                            source_reference=selection.reference,
-                            orphaned_at=None,
-                        ),
-                    )
                 playlist.name = snapshot_name
                 playlist.spotify_playlist_id = playlist_id
                 playlist.publication_manifest = manifest

--- a/djsupport/transfer.py
+++ b/djsupport/transfer.py
@@ -360,10 +360,6 @@ class PublicationStorage(Protocol):
         self, account_id: str, playlist_id: str,
     ) -> MirrorRelationship | None: ...
 
-    def replace_mirror(
-        self, previous: MirrorRelationship, replacement: MirrorRelationship,
-    ) -> None: ...
-
     def retain_relinked_publication(
         self, previous: MirrorRelationship, replacement: MirrorRelationship,
         manifest: PublicationManifest,
@@ -506,18 +502,6 @@ class FilePublicationStorage:
             mirror for mirror in self.mirrors_for_account(account_id)
             if mirror.spotify_playlist_id == playlist_id
         ), None)
-
-    def replace_mirror(
-        self, previous: MirrorRelationship, replacement: MirrorRelationship,
-    ) -> None:
-        self.mirrors = [
-            item for item in self.mirrors
-            if not (
-                item.get("account_id") == previous.account_id
-                and item.get("spotify_playlist_id") == previous.spotify_playlist_id
-            )
-        ]
-        self.retain_mirror(replacement)
 
     def retain_relinked_publication(
         self, previous: MirrorRelationship, replacement: MirrorRelationship,

--- a/djsupport/transfer.py
+++ b/djsupport/transfer.py
@@ -79,6 +79,12 @@ class DriftResolution(str, Enum):
     REVOKE = "revoke"
 
 
+class MirrorDisposition(str, Enum):
+    KEEP = "keep"
+    RELINK = "relink"
+    DELETE = "delete"
+
+
 @dataclass(frozen=True)
 class TransferRequest:
     """Everything an adapter must provide to start one Transfer."""
@@ -92,6 +98,8 @@ class TransferRequest:
     playlist_prefix: str | None = "djsupport"
     transfer_id: str | None = None
     drift_resolution: DriftResolution | None = None
+    mirror_disposition: MirrorDisposition | None = None
+    mirror_playlist_id: str | None = None
 
 class TransferStatus(str, Enum):
     MATCHING = "matching"
@@ -142,6 +150,10 @@ class RetryPolicy:
 
 class PublishingTransferConflict(RuntimeError):
     """Raised when another publishing Transfer owns an account guard."""
+
+
+class SourceNotFound(ValueError):
+    """Raised only when an exact requested source selection does not exist."""
 
 
 class AccountPublishingGuards:
@@ -271,6 +283,7 @@ class MirrorRelationship:
     spotify_playlist_id: str
     spotify_playlist_name: str
     approved_at: datetime
+    orphaned_at: datetime | None = None
 
 
 @dataclass(frozen=True)
@@ -340,6 +353,16 @@ class PublicationStorage(Protocol):
     def mirror_for_source(
         self, account_id: str, source_label: str, source_reference: str,
     ) -> MirrorRelationship | None: ...
+
+    def mirror_for_playlist(
+        self, account_id: str, playlist_id: str,
+    ) -> MirrorRelationship | None: ...
+
+    def replace_mirror(
+        self, previous: MirrorRelationship, replacement: MirrorRelationship,
+    ) -> None: ...
+
+    def remove_mirror(self, relationship: MirrorRelationship) -> None: ...
 
 
 class FilePublicationStorage:
@@ -431,6 +454,10 @@ class FilePublicationStorage:
     def retain_mirror(self, relationship: MirrorRelationship) -> None:
         stored = asdict(relationship)
         stored["approved_at"] = relationship.approved_at.isoformat()
+        stored["orphaned_at"] = (
+            relationship.orphaned_at.isoformat()
+            if relationship.orphaned_at else None
+        )
         self.mirrors = [
             item for item in self.mirrors
             if not (
@@ -447,6 +474,10 @@ class FilePublicationStorage:
             MirrorRelationship(**{
                 **item,
                 "approved_at": datetime.fromisoformat(item["approved_at"]),
+                "orphaned_at": (
+                    datetime.fromisoformat(item["orphaned_at"])
+                    if item.get("orphaned_at") else None
+                ),
             })
             for item in self.mirrors
             if item.get("account_id") == account_id
@@ -460,6 +491,37 @@ class FilePublicationStorage:
             if mirror.source_label == source_label
             and mirror.source_reference == source_reference
         ), None)
+
+    def mirror_for_playlist(
+        self, account_id: str, playlist_id: str,
+    ) -> MirrorRelationship | None:
+        return next((
+            mirror for mirror in self.mirrors_for_account(account_id)
+            if mirror.spotify_playlist_id == playlist_id
+        ), None)
+
+    def replace_mirror(
+        self, previous: MirrorRelationship, replacement: MirrorRelationship,
+    ) -> None:
+        self.mirrors = [
+            item for item in self.mirrors
+            if not (
+                item.get("account_id") == previous.account_id
+                and item.get("spotify_playlist_id") == previous.spotify_playlist_id
+            )
+        ]
+        self.retain_mirror(replacement)
+
+    def remove_mirror(self, relationship: MirrorRelationship) -> None:
+        self.mirrors = [
+            item for item in self.mirrors
+            if not (
+                item.get("account_id") == relationship.account_id
+                and item.get("spotify_playlist_id")
+                == relationship.spotify_playlist_id
+            )
+        ]
+        self._save(self.manifests, self.approvals)
 
 
 class TransferStorage(Protocol):
@@ -603,7 +665,7 @@ class RekordboxPlaylistSource:
             if playlist.path == reference or playlist.name == reference
         ]
         if not selected:
-            raise ValueError(f"Rekordbox playlist not found: {reference}")
+            raise SourceNotFound(f"Rekordbox playlist not found: {reference}")
         if len(selected) > 1:
             raise ValueError(
                 f"Rekordbox playlist name is ambiguous; select its path: {reference}"
@@ -1101,6 +1163,8 @@ class Transfer:
     def execute(self, request: TransferRequest) -> SyncReport:
         """Execute at most one publishing Transfer per Spotify account."""
         if request.preview:
+            if request.mirror_disposition is not None:
+                raise ValueError("Mirror dispositions are not available in Preview")
             return self._execute(request)
         if self._publication_storage is None:
             raise ValueError("Publishing Transfers require publication storage")
@@ -1130,7 +1194,76 @@ class Transfer:
             if self._transfer_storage is not None else None
         )
         if state is None:
-            selection = self._source.consume(request.source)
+            try:
+                selection = self._source.consume(request.source)
+            except SourceNotFound:
+                relationship = (
+                    self._publication_storage.mirror_for_source(
+                        self._spotify.account_id(), self._source.source_label,
+                        request.source,
+                    )
+                    if self._publication_storage is not None else None
+                )
+                if request.mode == TransferMode.MIRROR and relationship is not None:
+                    if not request.preview:
+                        assert self._publication_storage is not None
+                        relationship = replace(
+                            relationship, orphaned_at=datetime.now(),
+                        )
+                        self._publication_storage.retain_mirror(relationship)
+                    action = "disposition required"
+                    status = "orphaned mirror"
+                    if request.mirror_disposition == MirrorDisposition.KEEP:
+                        assert self._publication_storage is not None
+                        self._publication_storage.remove_mirror(relationship)
+                        action = "mirror kept as ordinary playlist"
+                        status = "completed"
+                    elif request.mirror_disposition == MirrorDisposition.DELETE:
+                        self._retry_policy.run(
+                            lambda: self._spotify.delete_provisional_snapshot(
+                                relationship.spotify_playlist_id
+                            )
+                        )
+                        assert self._publication_storage is not None
+                        self._publication_storage.remove_mirror(relationship)
+                        action = "mirror explicitly deleted"
+                        status = "completed"
+                    return SyncReport(
+                        timestamp=datetime.now(), threshold=request.threshold,
+                        dry_run=request.preview,
+                        playlists=[PlaylistReport(
+                            name=relationship.spotify_playlist_name,
+                            path=relationship.source_reference,
+                            action=action,
+                            spotify_playlist_id=relationship.spotify_playlist_id,
+                            mirror_dispositions=tuple(
+                                choice.value for choice in MirrorDisposition
+                            ),
+                            mirror_disposition=(
+                                request.mirror_disposition.value
+                                if request.mirror_disposition else None
+                            ),
+                        )],
+                        cache_enabled=getattr(self._knowledge, "persistent", True),
+                        source_label=self._source.source_label,
+                        transfer_id=transfer_id,
+                        status=status,
+                    )
+                raise
+            relinked_mirror = None
+            if request.mirror_disposition == MirrorDisposition.RELINK:
+                if request.mode != TransferMode.MIRROR or not request.mirror_playlist_id:
+                    raise ValueError(
+                        "Relinking requires Mirror mode and an explicit Spotify playlist ID"
+                    )
+                assert self._publication_storage is not None
+                relinked_mirror = self._publication_storage.mirror_for_playlist(
+                    self._spotify.account_id(), request.mirror_playlist_id,
+                )
+                if relinked_mirror is None:
+                    raise ValueError(
+                        "The Mirror to relink does not belong to this Spotify account"
+                    )
             created_at = datetime.now()
             state = TransferState(
                 status=TransferStatus.MATCHING,
@@ -1148,6 +1281,11 @@ class Transfer:
                         request.drift_resolution.value
                         if request.drift_resolution else None
                     ),
+                    "mirror_disposition": (
+                        request.mirror_disposition.value
+                        if request.mirror_disposition else None
+                    ),
+                    "mirror_playlist_id": request.mirror_playlist_id,
                 },
                 selection={
                     "name": selection.name,
@@ -1160,6 +1298,12 @@ class Transfer:
                 unmatched=[],
                 publication_items=[],
                 alternatives=[],
+                spotify_playlist_id=(
+                    relinked_mirror.spotify_playlist_id if relinked_mirror else None
+                ),
+                spotify_playlist_name=(
+                    relinked_mirror.spotify_playlist_name if relinked_mirror else None
+                ),
             )
             self._save_transfer(transfer_id, state)
         else:
@@ -1178,6 +1322,10 @@ class Transfer:
                     "drift_resolution": (
                         DriftResolution(state.request["drift_resolution"])
                         if state.request.get("drift_resolution") else None
+                    ),
+                    "mirror_disposition": (
+                        MirrorDisposition(state.request["mirror_disposition"])
+                        if state.request.get("mirror_disposition") else None
                     ),
                 },
                 transfer_id=transfer_id,
@@ -1226,9 +1374,12 @@ class Transfer:
                 playlist.name = state.spotify_playlist_name or playlist.name
                 playlist.spotify_playlist_id = state.spotify_playlist_id
                 playlist.action = (
-                    "provisional mirror updated"
-                    if request.mode == TransferMode.MIRROR
-                    else "provisional snapshot created"
+                    state.outcome
+                    or (
+                        "provisional mirror updated"
+                        if request.mode == TransferMode.MIRROR
+                        else "provisional snapshot created"
+                    )
                 )
                 stored_manifest = state.publication_manifest
                 if stored_manifest:
@@ -1548,6 +1699,16 @@ class Transfer:
                         playlist.action = "paused"
                         report.status = "paused"
                         return report
+                elif request.mirror_disposition == MirrorDisposition.RELINK:
+                    self._retry_policy.run(
+                        lambda: self._spotify.replace_provisional_playlist_tracks(
+                            playlist_id,
+                            list(dict.fromkeys(
+                                item.spotify_uri for item in publication_items
+                                if item.spotify_uri not in collision_uris
+                            )),
+                        )
+                    )
                 assert snapshot_name is not None
                 managed_items_by_uri: dict[str, PublicationItem] = {}
                 for item in publication_items:
@@ -1582,11 +1743,32 @@ class Transfer:
                     state.status = TransferStatus.MATCHING
                     self._save_transfer(transfer_id, state)
                     raise
+                if request.mirror_disposition == MirrorDisposition.RELINK:
+                    assert request.mirror_playlist_id is not None
+                    previous = self._publication_storage.mirror_for_playlist(
+                        state.account_id, request.mirror_playlist_id,
+                    )
+                    assert previous is not None
+                    self._publication_storage.replace_mirror(
+                        previous,
+                        replace(
+                            previous,
+                            source_label=self._source.source_label,
+                            source_reference=selection.reference,
+                            orphaned_at=None,
+                        ),
+                    )
                 playlist.name = snapshot_name
                 playlist.spotify_playlist_id = playlist_id
                 playlist.publication_manifest = manifest
+                playlist.mirror_disposition = (
+                    request.mirror_disposition.value
+                    if request.mirror_disposition else None
+                )
                 playlist.action = (
-                    "provisional mirror updated"
+                    "mirror relinked"
+                    if request.mirror_disposition == MirrorDisposition.RELINK
+                    else "provisional mirror updated"
                     if request.mode == TransferMode.MIRROR
                     else "provisional snapshot created"
                 )

--- a/tests/test_transfer.py
+++ b/tests/test_transfer.py
@@ -201,6 +201,10 @@ class InMemoryStorage:
         ]
         self.mirrors.append(replacement)
 
+    def retain_relinked_publication(self, previous, replacement, manifest):
+        self.retain_publication(manifest)
+        self.replace_mirror(previous, replacement)
+
     def remove_mirror(self, relationship):
         self.mirrors = [
             mirror for mirror in self.mirrors
@@ -817,7 +821,7 @@ class TestRekordboxMirror:
                 )
 
         class FailingStorage(InMemoryStorage):
-            def retain_publication(self, manifest):
+            def retain_relinked_publication(self, previous, replacement, manifest):
                 raise OSError("disk full")
 
         spotify = StatefulSpotify({

--- a/tests/test_transfer.py
+++ b/tests/test_transfer.py
@@ -60,6 +60,14 @@ class FixtureBeatportSource:
         return SourceSelection(data["name"], data["reference"], tracks)
 
 
+class MissingRekordboxSource:
+    source_label = "Rekordbox"
+    default_mode = TransferMode.MIRROR
+
+    def consume(self, reference):
+        raise SourceNotFound(f"Rekordbox playlist not found: {reference}")
+
+
 class StatefulSpotify:
     def __init__(self, matches=None) -> None:
         self.matches = matches or {}
@@ -88,6 +96,9 @@ class StatefulSpotify:
         return playlist_id
 
     def delete_provisional_snapshot(self, playlist_id):
+        del self.playlists[playlist_id]
+
+    def delete_playlist(self, playlist_id):
         del self.playlists[playlist_id]
 
     def provisional_playlist_track_uris(self, playlist_id):
@@ -172,6 +183,32 @@ class InMemoryStorage:
             and mirror.source_label == source_label
             and mirror.source_reference == source_reference
         ), None)
+
+    def mirror_for_playlist(self, account_id, playlist_id):
+        return next((
+            mirror for mirror in self.mirrors
+            if mirror.account_id == account_id
+            and mirror.spotify_playlist_id == playlist_id
+        ), None)
+
+    def replace_mirror(self, previous, replacement):
+        self.mirrors = [
+            mirror for mirror in self.mirrors
+            if not (
+                mirror.account_id == previous.account_id
+                and mirror.spotify_playlist_id == previous.spotify_playlist_id
+            )
+        ]
+        self.mirrors.append(replacement)
+
+    def remove_mirror(self, relationship):
+        self.mirrors = [
+            mirror for mirror in self.mirrors
+            if not (
+                mirror.account_id == relationship.account_id
+                and mirror.spotify_playlist_id == relationship.spotify_playlist_id
+            )
+        ]
 
     def approve(self, item):
         self.approved_matches.append(item)
@@ -622,13 +659,6 @@ class TestSnapshotPublication:
 
 class TestRekordboxMirror:
     def test_missing_exact_source_becomes_orphan_without_spotify_deletion(self, tmp_path):
-        class MissingSource:
-            source_label = "Rekordbox"
-            default_mode = TransferMode.MIRROR
-
-            def consume(self, reference):
-                raise SourceNotFound(f"Rekordbox playlist not found: {reference}")
-
         spotify = StatefulSpotify()
         storage = FilePublicationStorage(tmp_path / "publications.json")
         storage.retain_mirror(MirrorRelationship(
@@ -642,7 +672,7 @@ class TestRekordboxMirror:
 
         report = Transfer(
             publishing_guards=TEST_PUBLISHING_GUARDS,
-            source=MissingSource(), spotify=spotify,
+            source=MissingRekordboxSource(), spotify=spotify,
             matching_knowledge=storage, publication_storage=storage,
         ).execute(TransferRequest(source="Folder/Original"))
 
@@ -721,14 +751,105 @@ class TestRekordboxMirror:
             "spotify-user-1", "Rekordbox", "Moved/Renamed",
         ).spotify_playlist_id == "mirror-1"
 
-    def test_keep_disposition_releases_orphan_as_ordinary_playlist(self, tmp_path):
-        class MissingSource:
+    def test_relink_reports_existing_playlist_drift_before_mutating(self, tmp_path):
+        fixture = json.loads(MIRROR_REFRESH_FIXTURE.read_text())
+
+        class MovableSource:
+            source_label = "Rekordbox"
+            default_mode = TransferMode.MIRROR
+            reference = "Original/Playlist"
+
+            def consume(self, reference):
+                item = fixture["initial"][0]
+                return SourceSelection(
+                    "Mirror", reference,
+                    [Track(
+                        track_id=item["track_id"], artist=item["artist"],
+                        name=item["name"], duration=item["duration"], album="",
+                        remixer="", label="", genre="", date_added="",
+                    )],
+                )
+
+        source = MovableSource()
+        spotify = StatefulSpotify({
+            ("Artist One", "First Track"): _match(
+                "spotify:track:first", "First Track", "Artist One",
+            ),
+        })
+        knowledge = MatchCacheKnowledge(MatchCache(tmp_path / "knowledge.json"))
+        storage = FilePublicationStorage(tmp_path / "publications.json")
+        transfer = Transfer(
+            publishing_guards=TEST_PUBLISHING_GUARDS,
+            source=source, spotify=spotify, matching_knowledge=knowledge,
+            publication_storage=storage,
+        )
+        initial = transfer.execute(TransferRequest(source=source.reference))
+        playlist_id = initial.playlists[0].spotify_playlist_id
+        transfer.approve(playlist_id)
+        spotify.playlists[playlist_id]["tracks"] = []
+
+        drifted = transfer.execute(TransferRequest(
+            source="Moved/Renamed",
+            mirror_disposition=MirrorDisposition.RELINK,
+            mirror_playlist_id=playlist_id,
+        ))
+
+        assert drifted.status == "playlist drift"
+        assert drifted.playlists[0].action == "restore or revoke required"
+        assert spotify.playlists[playlist_id]["tracks"] == []
+        assert storage.mirror_for_source(
+            "spotify-user-1", "Rekordbox", "Original/Playlist",
+        ) is not None
+
+    def test_relink_storage_failure_preserves_existing_spotify_mirror(self):
+        class MovedSource:
             source_label = "Rekordbox"
             default_mode = TransferMode.MIRROR
 
             def consume(self, reference):
-                raise SourceNotFound(f"Rekordbox playlist not found: {reference}")
+                return SourceSelection(
+                    "Renamed", reference,
+                    [Track(
+                        track_id="rb-1", artist="Artist One", name="First Track",
+                        duration=301, album="", remixer="", label="", genre="",
+                        date_added="",
+                    )],
+                )
 
+        class FailingStorage(InMemoryStorage):
+            def retain_publication(self, manifest):
+                raise OSError("disk full")
+
+        spotify = StatefulSpotify({
+            ("Artist One", "First Track"): _match(
+                "spotify:track:first", "First Track", "Artist One",
+            ),
+        })
+        spotify.playlists["mirror-1"] = {
+            "name": "Original", "tracks": ["spotify:track:old"],
+            "description": "managed",
+        }
+        storage = FailingStorage()
+        storage.retain_mirror(MirrorRelationship(
+            account_id="spotify-user-1", source_label="Rekordbox",
+            source_reference="Original/Playlist", spotify_playlist_id="mirror-1",
+            spotify_playlist_name="Original", approved_at=datetime(2026, 8, 1),
+        ))
+
+        with pytest.raises(OSError, match="disk full"):
+            Transfer(
+                publishing_guards=TEST_PUBLISHING_GUARDS,
+                source=MovedSource(), spotify=spotify,
+                matching_knowledge=storage, publication_storage=storage,
+            ).execute(TransferRequest(
+                source="Moved/Renamed",
+                mirror_disposition=MirrorDisposition.RELINK,
+                mirror_playlist_id="mirror-1",
+            ))
+
+        assert spotify.playlists["mirror-1"]["tracks"] == ["spotify:track:old"]
+
+    def test_keep_disposition_releases_orphan_as_ordinary_playlist(self, tmp_path):
         spotify = StatefulSpotify()
         storage = FilePublicationStorage(tmp_path / "publications.json")
         storage.retain_mirror(MirrorRelationship(
@@ -739,7 +860,7 @@ class TestRekordboxMirror:
 
         report = Transfer(
             publishing_guards=TEST_PUBLISHING_GUARDS,
-            source=MissingSource(), spotify=spotify,
+            source=MissingRekordboxSource(), spotify=spotify,
             matching_knowledge=InMemoryStorage(), publication_storage=storage,
         ).execute(TransferRequest(
             source="Folder/Original",
@@ -755,13 +876,6 @@ class TestRekordboxMirror:
         ) is None
 
     def test_delete_disposition_is_explicit_and_account_scoped(self, tmp_path):
-        class MissingSource:
-            source_label = "Rekordbox"
-            default_mode = TransferMode.MIRROR
-
-            def consume(self, reference):
-                raise SourceNotFound(f"Rekordbox playlist not found: {reference}")
-
         spotify = StatefulSpotify()
         storage = FilePublicationStorage(tmp_path / "publications.json")
         for account_id, playlist_id in (
@@ -777,7 +891,7 @@ class TestRekordboxMirror:
 
         report = Transfer(
             publishing_guards=TEST_PUBLISHING_GUARDS,
-            source=MissingSource(), spotify=spotify,
+            source=MissingRekordboxSource(), spotify=spotify,
             matching_knowledge=InMemoryStorage(), publication_storage=storage,
         ).execute(TransferRequest(
             source="Folder/Original",
@@ -796,13 +910,6 @@ class TestRekordboxMirror:
         ).spotify_playlist_id == "other-account-mirror"
 
     def test_similar_source_name_never_relinks_without_explicit_identity(self):
-        class MissingSource:
-            source_label = "Rekordbox"
-            default_mode = TransferMode.MIRROR
-
-            def consume(self, reference):
-                raise SourceNotFound(f"Rekordbox playlist not found: {reference}")
-
         storage = InMemoryStorage()
         storage.retain_mirror(MirrorRelationship(
             account_id="spotify-user-1", source_label="Rekordbox",
@@ -816,7 +923,7 @@ class TestRekordboxMirror:
         ):
             Transfer(
                 publishing_guards=TEST_PUBLISHING_GUARDS,
-                source=MissingSource(), spotify=StatefulSpotify(),
+                source=MissingRekordboxSource(), spotify=StatefulSpotify(),
                 matching_knowledge=storage, publication_storage=storage,
             ).execute(TransferRequest(source="Folder/Original Mix"))
 

--- a/tests/test_transfer.py
+++ b/tests/test_transfer.py
@@ -37,6 +37,8 @@ from djsupport.transfer import (
     BeatportLabelSource,
     RekordboxPlaylistSource,
     MirrorRelationship,
+    MirrorDisposition,
+    SourceNotFound,
 )
 
 
@@ -619,6 +621,266 @@ class TestSnapshotPublication:
 
 
 class TestRekordboxMirror:
+    def test_missing_exact_source_becomes_orphan_without_spotify_deletion(self, tmp_path):
+        class MissingSource:
+            source_label = "Rekordbox"
+            default_mode = TransferMode.MIRROR
+
+            def consume(self, reference):
+                raise SourceNotFound(f"Rekordbox playlist not found: {reference}")
+
+        spotify = StatefulSpotify()
+        storage = FilePublicationStorage(tmp_path / "publications.json")
+        storage.retain_mirror(MirrorRelationship(
+            account_id="spotify-user-1",
+            source_label="Rekordbox",
+            source_reference="Folder/Original",
+            spotify_playlist_id="existing",
+            spotify_playlist_name="Original",
+            approved_at=datetime(2026, 8, 1),
+        ))
+
+        report = Transfer(
+            publishing_guards=TEST_PUBLISHING_GUARDS,
+            source=MissingSource(), spotify=spotify,
+            matching_knowledge=storage, publication_storage=storage,
+        ).execute(TransferRequest(source="Folder/Original"))
+
+        assert report.status == "orphaned mirror"
+        assert report.playlists[0].spotify_playlist_id == "existing"
+        assert report.playlists[0].action == "disposition required"
+        assert report.playlists[0].mirror_dispositions == tuple(
+            choice.value for choice in MirrorDisposition
+        )
+        assert spotify.playlists == {
+            "existing": ["spotify:track:untouched"],
+        }
+        orphan = FilePublicationStorage(
+            tmp_path / "publications.json"
+        ).mirror_for_source("spotify-user-1", "Rekordbox", "Folder/Original")
+        assert orphan.orphaned_at is not None
+        report_path = tmp_path / "orphan.md"
+        save_report(report, str(report_path))
+        assert "Orphaned Mirror" in report_path.read_text()
+        assert "keep, relink, or delete" in report_path.read_text()
+
+    def test_renamed_source_can_explicitly_relink_to_existing_mirror(self, tmp_path):
+        fixture = json.loads(MIRROR_REFRESH_FIXTURE.read_text())
+
+        class RenamedSource:
+            source_label = "Rekordbox"
+            default_mode = TransferMode.MIRROR
+
+            def consume(self, reference):
+                assert reference == "Moved/Renamed"
+                item = fixture["initial"][0]
+                return SourceSelection(
+                    "Renamed", reference,
+                    [Track(
+                        track_id=item["track_id"], artist=item["artist"],
+                        name=item["name"], duration=item["duration"], album="",
+                        remixer="", label="", genre="", date_added="",
+                    )],
+                )
+
+        spotify = StatefulSpotify({
+            ("Artist One", "First Track"): _match(
+                "spotify:track:first", "First Track", "Artist One",
+            ),
+        })
+        spotify.playlists["mirror-1"] = {
+            "name": "Original", "tracks": ["spotify:track:old"],
+            "description": "managed",
+        }
+        storage = FilePublicationStorage(tmp_path / "publications.json")
+        storage.retain_mirror(MirrorRelationship(
+            account_id="spotify-user-1", source_label="Rekordbox",
+            source_reference="Original/Playlist",
+            spotify_playlist_id="mirror-1", spotify_playlist_name="Original",
+            approved_at=datetime(2026, 8, 1),
+        ))
+
+        report = Transfer(
+            publishing_guards=TEST_PUBLISHING_GUARDS,
+            source=RenamedSource(), spotify=spotify,
+            matching_knowledge=InMemoryStorage(), publication_storage=storage,
+        ).execute(TransferRequest(
+            source="Moved/Renamed",
+            mirror_disposition=MirrorDisposition.RELINK,
+            mirror_playlist_id="mirror-1",
+        ))
+
+        assert report.playlists[0].spotify_playlist_id == "mirror-1"
+        assert report.playlists[0].action == "mirror relinked"
+        assert report.playlists[0].mirror_disposition == "relink"
+        assert spotify.playlists["mirror-1"]["tracks"] == ["spotify:track:first"]
+        assert storage.mirror_for_source(
+            "spotify-user-1", "Rekordbox", "Original/Playlist",
+        ) is None
+        assert storage.mirror_for_source(
+            "spotify-user-1", "Rekordbox", "Moved/Renamed",
+        ).spotify_playlist_id == "mirror-1"
+
+    def test_keep_disposition_releases_orphan_as_ordinary_playlist(self, tmp_path):
+        class MissingSource:
+            source_label = "Rekordbox"
+            default_mode = TransferMode.MIRROR
+
+            def consume(self, reference):
+                raise SourceNotFound(f"Rekordbox playlist not found: {reference}")
+
+        spotify = StatefulSpotify()
+        storage = FilePublicationStorage(tmp_path / "publications.json")
+        storage.retain_mirror(MirrorRelationship(
+            account_id="spotify-user-1", source_label="Rekordbox",
+            source_reference="Folder/Original", spotify_playlist_id="existing",
+            spotify_playlist_name="Original", approved_at=datetime(2026, 8, 1),
+        ))
+
+        report = Transfer(
+            publishing_guards=TEST_PUBLISHING_GUARDS,
+            source=MissingSource(), spotify=spotify,
+            matching_knowledge=InMemoryStorage(), publication_storage=storage,
+        ).execute(TransferRequest(
+            source="Folder/Original",
+            mirror_disposition=MirrorDisposition.KEEP,
+        ))
+
+        assert report.status == "completed"
+        assert report.playlists[0].action == "mirror kept as ordinary playlist"
+        assert report.playlists[0].mirror_disposition == "keep"
+        assert spotify.playlists == {"existing": ["spotify:track:untouched"]}
+        assert storage.mirror_for_source(
+            "spotify-user-1", "Rekordbox", "Folder/Original",
+        ) is None
+
+    def test_delete_disposition_is_explicit_and_account_scoped(self, tmp_path):
+        class MissingSource:
+            source_label = "Rekordbox"
+            default_mode = TransferMode.MIRROR
+
+            def consume(self, reference):
+                raise SourceNotFound(f"Rekordbox playlist not found: {reference}")
+
+        spotify = StatefulSpotify()
+        storage = FilePublicationStorage(tmp_path / "publications.json")
+        for account_id, playlist_id in (
+            ("spotify-user-1", "existing"),
+            ("spotify-user-2", "other-account-mirror"),
+        ):
+            storage.retain_mirror(MirrorRelationship(
+                account_id=account_id, source_label="Rekordbox",
+                source_reference="Folder/Original",
+                spotify_playlist_id=playlist_id,
+                spotify_playlist_name="Original", approved_at=datetime(2026, 8, 1),
+            ))
+
+        report = Transfer(
+            publishing_guards=TEST_PUBLISHING_GUARDS,
+            source=MissingSource(), spotify=spotify,
+            matching_knowledge=InMemoryStorage(), publication_storage=storage,
+        ).execute(TransferRequest(
+            source="Folder/Original",
+            mirror_disposition=MirrorDisposition.DELETE,
+        ))
+
+        assert report.status == "completed"
+        assert report.playlists[0].action == "mirror explicitly deleted"
+        assert report.playlists[0].mirror_disposition == "delete"
+        assert "existing" not in spotify.playlists
+        assert storage.mirror_for_source(
+            "spotify-user-1", "Rekordbox", "Folder/Original",
+        ) is None
+        assert storage.mirror_for_source(
+            "spotify-user-2", "Rekordbox", "Folder/Original",
+        ).spotify_playlist_id == "other-account-mirror"
+
+    def test_similar_source_name_never_relinks_without_explicit_identity(self):
+        class MissingSource:
+            source_label = "Rekordbox"
+            default_mode = TransferMode.MIRROR
+
+            def consume(self, reference):
+                raise SourceNotFound(f"Rekordbox playlist not found: {reference}")
+
+        storage = InMemoryStorage()
+        storage.retain_mirror(MirrorRelationship(
+            account_id="spotify-user-1", source_label="Rekordbox",
+            source_reference="Folder/Original Mixes",
+            spotify_playlist_id="existing", spotify_playlist_name="Original Mixes",
+            approved_at=datetime(2026, 8, 1),
+        ))
+
+        with pytest.raises(
+            ValueError, match="Rekordbox playlist not found: Folder/Original Mix",
+        ):
+            Transfer(
+                publishing_guards=TEST_PUBLISHING_GUARDS,
+                source=MissingSource(), spotify=StatefulSpotify(),
+                matching_knowledge=storage, publication_storage=storage,
+            ).execute(TransferRequest(source="Folder/Original Mix"))
+
+    def test_identical_source_contents_never_relink_without_explicit_identity(self):
+        track = Track(
+            track_id="rb-1", artist="Artist One", name="First Track",
+            duration=301, album="", remixer="", label="", genre="",
+            date_added="",
+        )
+
+        class MovedSource:
+            source_label = "Rekordbox"
+            default_mode = TransferMode.MIRROR
+
+            def consume(self, reference):
+                return SourceSelection("Renamed", reference, [track])
+
+        spotify = StatefulSpotify({
+            (track.artist, track.name): _match(
+                "spotify:track:first", track.name, track.artist,
+            ),
+        })
+        spotify.playlists["old-mirror"] = {
+            "name": "Original", "tracks": ["spotify:track:first"],
+            "description": "managed",
+        }
+        storage = InMemoryStorage()
+        storage.retain_mirror(MirrorRelationship(
+            account_id="spotify-user-1", source_label="Rekordbox",
+            source_reference="Original/Playlist", spotify_playlist_id="old-mirror",
+            spotify_playlist_name="Original", approved_at=datetime(2026, 8, 1),
+        ))
+
+        report = Transfer(
+            publishing_guards=TEST_PUBLISHING_GUARDS,
+            source=MovedSource(), spotify=spotify,
+            matching_knowledge=storage, publication_storage=storage,
+        ).execute(TransferRequest(source="Moved/Renamed"))
+
+        assert report.playlists[0].spotify_playlist_id != "old-mirror"
+        assert spotify.playlists["old-mirror"]["tracks"] == ["spotify:track:first"]
+
+    def test_source_validation_failure_does_not_orphan_an_existing_mirror(self):
+        class InvalidSource:
+            source_label = "Rekordbox"
+            default_mode = TransferMode.MIRROR
+
+            def consume(self, reference):
+                raise ValueError("Rekordbox playlist has missing track references: 42")
+
+        storage = InMemoryStorage()
+        storage.retain_mirror(MirrorRelationship(
+            account_id="spotify-user-1", source_label="Rekordbox",
+            source_reference="Folder/Original", spotify_playlist_id="existing",
+            spotify_playlist_name="Original", approved_at=datetime(2026, 8, 1),
+        ))
+
+        with pytest.raises(ValueError, match="missing track references"):
+            Transfer(
+                publishing_guards=TEST_PUBLISHING_GUARDS,
+                source=InvalidSource(), spotify=StatefulSpotify(),
+                matching_knowledge=storage, publication_storage=storage,
+            ).execute(TransferRequest(source="Folder/Original"))
+
     def test_refresh_reports_playlist_drift_without_silently_restoring(self, tmp_path):
         fixture = json.loads(MIRROR_REFRESH_FIXTURE.read_text())
 

--- a/tests/test_transfer.py
+++ b/tests/test_transfer.py
@@ -191,7 +191,8 @@ class InMemoryStorage:
             and mirror.spotify_playlist_id == playlist_id
         ), None)
 
-    def replace_mirror(self, previous, replacement):
+    def retain_relinked_publication(self, previous, replacement, manifest):
+        self.retain_publication(manifest)
         self.mirrors = [
             mirror for mirror in self.mirrors
             if not (
@@ -200,10 +201,6 @@ class InMemoryStorage:
             )
         ]
         self.mirrors.append(replacement)
-
-    def retain_relinked_publication(self, previous, replacement, manifest):
-        self.retain_publication(manifest)
-        self.replace_mirror(previous, replacement)
 
     def remove_mirror(self, relationship):
         self.mirrors = [


### PR DESCRIPTION
## Summary
- record missing exact sources as durable Orphaned Mirrors without changing Spotify
- support account-scoped keep, explicit relink, and explicit delete dispositions
- preserve Playlist Drift handling and make relinking transactional across Spotify and local storage
- report Orphaned Mirror choices and selected dispositions

## Validation
- 419 offline tests passed
- Python compilation passed
- git diff validation passed
- Standards review passed with 0 findings
- Spec review passed with 0 findings

Closes #24