### PR TITLE
Plan a bounded Rekordbox Batch

### DIFF
--- a/agent.md
+++ b/agent.md
@@ -35,7 +35,7 @@ djsupport/
   cache.py      # Persistent match cache with retry logic
   state.py      # Playlist ID mapping for incremental sync (source-agnostic)
   report.py     # Post-sync terminal + Markdown reports
-  transfer.py   # Durable Transfer orchestration, checkpoints, and publication
+  transfer.py   # Durable Transfer orchestration, read-only Batch planning, checkpoints, and publication
   static/       # Web frontend (index.html with Tailwind CSS)
 tests/          # pytest suite
 docs/           # Plans, reports, and solution docs

--- a/djsupport/transfer.py
+++ b/djsupport/transfer.py
@@ -101,6 +101,55 @@ class TransferRequest:
     mirror_disposition: MirrorDisposition | None = None
     mirror_playlist_id: str | None = None
 
+
+@dataclass(frozen=True)
+class BatchPlanRequest:
+    """An explicit, bounded Rekordbox Batch selection."""
+
+    playlist_references: tuple[str, ...] = ()
+    whole_library: bool = False
+    threshold: int = 80
+    expensive_lookup_threshold: int = 100
+    confirm_expensive: bool = False
+
+
+@dataclass(frozen=True)
+class PlaylistPreflight:
+    name: str
+    reference: str
+    total_tracks: int
+    approved_match_hits: int
+    cache_hits: int
+    expected_uncached_lookups: int
+
+
+@dataclass(frozen=True)
+class BatchPlan:
+    playlists: tuple[PlaylistPreflight, ...]
+    confirmation_required: bool = False
+
+    @property
+    def ready(self) -> bool:
+        return not self.confirmation_required
+
+    @property
+    def total_tracks(self) -> int:
+        return sum(playlist.total_tracks for playlist in self.playlists)
+
+    @property
+    def approved_match_hits(self) -> int:
+        return sum(playlist.approved_match_hits for playlist in self.playlists)
+
+    @property
+    def cache_hits(self) -> int:
+        return sum(playlist.cache_hits for playlist in self.playlists)
+
+    @property
+    def expected_uncached_lookups(self) -> int:
+        return sum(
+            playlist.expected_uncached_lookups for playlist in self.playlists
+        )
+
 class TransferStatus(str, Enum):
     MATCHING = "matching"
     PAUSED = "paused"
@@ -708,6 +757,22 @@ class RekordboxPlaylistSource:
             [tracks[track_id] for track_id in playlist.track_ids],
         )
 
+    def consume_batch(
+        self, references: tuple[str, ...], whole_library: bool,
+    ) -> tuple[SourceSelection, ...]:
+        if references and whole_library:
+            raise ValueError(
+                "Select playlists explicitly or opt into the whole library, not both"
+            )
+        if not references and not whole_library:
+            raise ValueError("A Batch must select at least one playlist explicitly")
+        if not whole_library:
+            return tuple(self.consume(reference) for reference in references)
+        from djsupport.rekordbox import parse_xml
+
+        _, playlists = parse_xml(self._xml_path)
+        return tuple(self.consume(playlist.path) for playlist in playlists)
+
 
 class SpotifyMatcher:
     """Production Spotify matching and Transfer publication adapter."""
@@ -949,6 +1014,45 @@ class Transfer:
     def pause(self) -> None:
         """Request a pause after the current track reaches a safe checkpoint."""
         self._pause_requested = True
+
+    def plan_batch(self, request: BatchPlanRequest) -> BatchPlan:
+        """Plan an explicitly selected Rekordbox Batch without side effects."""
+        selections = self._source.consume_batch(
+            request.playlist_references, request.whole_library,
+        )
+        playlists = []
+        for selection in selections:
+            approved_match_hits = 0
+            cache_hits = 0
+            expected_uncached_lookups = 0
+            for track in selection.tracks:
+                known = self._knowledge.lookup(track, request.threshold)
+                if known is not None and known.get("authoritative"):
+                    approved_match_hits += 1
+                elif known is not None or not self._knowledge.should_retry(
+                    track, request.threshold, 7, False,
+                ):
+                    cache_hits += 1
+                else:
+                    expected_uncached_lookups += 1
+            playlists.append(PlaylistPreflight(
+                name=selection.name,
+                reference=selection.reference,
+                total_tracks=len(selection.tracks),
+                approved_match_hits=approved_match_hits,
+                cache_hits=cache_hits,
+                expected_uncached_lookups=expected_uncached_lookups,
+            ))
+        expected_lookups = sum(
+            playlist.expected_uncached_lookups for playlist in playlists
+        )
+        return BatchPlan(
+            tuple(playlists),
+            confirmation_required=(
+                expected_lookups >= request.expensive_lookup_threshold
+                and not request.confirm_expensive
+            ),
+        )
 
     def abandon(self, transfer_id: str) -> None:
         """Explicitly make a persisted, non-completed Transfer terminal."""

--- a/djsupport/transfer.py
+++ b/djsupport/transfer.py
@@ -779,10 +779,14 @@ class RekordboxPlaylistSource:
             tuple(playlist.path for playlist in playlists)
             if whole_library else references
         )
-        return tuple(
+        selections = tuple(
             self._select(tracks, playlists, reference)
             for reference in selected_references
         )
+        canonical_references = [selection.reference for selection in selections]
+        if len(set(canonical_references)) != len(canonical_references):
+            raise ValueError("A Batch cannot contain a duplicate playlist reference")
+        return selections
 
 
 class SpotifyMatcher:

--- a/djsupport/transfer.py
+++ b/djsupport/transfer.py
@@ -51,6 +51,7 @@ from djsupport.spotify import MAX_RATE_LIMIT_WAIT, RateLimitError, _parse_retry_
 
 PUBLICATION_MANIFEST_VERSION = 3
 TRANSFER_STATE_VERSION = 1
+EXPENSIVE_BATCH_LOOKUP_THRESHOLD = 100
 SPOTIFY_TRACK_URI = re.compile(r"^spotify:track:([A-Za-z0-9]{22})$")
 SPOTIFY_TRACK_URL = re.compile(
     r"^https://open\.spotify\.com/track/([A-Za-z0-9]{22})(?:\?.*)?$"
@@ -109,7 +110,6 @@ class BatchPlanRequest:
     playlist_references: tuple[str, ...] = ()
     whole_library: bool = False
     threshold: int = 80
-    expensive_lookup_threshold: int = 100
     confirm_expensive: bool = False
 
 
@@ -732,6 +732,10 @@ class RekordboxPlaylistSource:
         from djsupport.rekordbox import parse_xml
 
         tracks, playlists = parse_xml(self._xml_path)
+        return self._select(tracks, playlists, reference)
+
+    @staticmethod
+    def _select(tracks, playlists, reference: str) -> SourceSelection:
         selected = [
             playlist for playlist in playlists
             if playlist.path == reference or playlist.name == reference
@@ -766,12 +770,19 @@ class RekordboxPlaylistSource:
             )
         if not references and not whole_library:
             raise ValueError("A Batch must select at least one playlist explicitly")
-        if not whole_library:
-            return tuple(self.consume(reference) for reference in references)
+        if len(set(references)) != len(references):
+            raise ValueError("A Batch cannot contain a duplicate playlist reference")
         from djsupport.rekordbox import parse_xml
 
-        _, playlists = parse_xml(self._xml_path)
-        return tuple(self.consume(playlist.path) for playlist in playlists)
+        tracks, playlists = parse_xml(self._xml_path)
+        selected_references = (
+            tuple(playlist.path for playlist in playlists)
+            if whole_library else references
+        )
+        return tuple(
+            self._select(tracks, playlists, reference)
+            for reference in selected_references
+        )
 
 
 class SpotifyMatcher:
@@ -1049,7 +1060,10 @@ class Transfer:
         return BatchPlan(
             tuple(playlists),
             confirmation_required=(
-                expected_lookups >= request.expensive_lookup_threshold
+                (
+                    request.whole_library
+                    or expected_lookups >= EXPENSIVE_BATCH_LOOKUP_THRESHOLD
+                )
                 and not request.confirm_expensive
             ),
         )

--- a/tests/test_transfer.py
+++ b/tests/test_transfer.py
@@ -1410,11 +1410,10 @@ class TestRekordboxBatchPlanning:
         )
 
         unconfirmed = transfer.plan_batch(BatchPlanRequest(
-            whole_library=True, expensive_lookup_threshold=1,
+            whole_library=True,
         ))
         confirmed = transfer.plan_batch(BatchPlanRequest(
-            whole_library=True, expensive_lookup_threshold=1,
-            confirm_expensive=True,
+            whole_library=True, confirm_expensive=True,
         ))
 
         assert unconfirmed.expected_uncached_lookups == 3
@@ -1423,6 +1422,18 @@ class TestRekordboxBatchPlanning:
         assert confirmed.expected_uncached_lookups == 3
         assert confirmed.confirmation_required is False
         assert confirmed.ready is True
+
+    def test_duplicate_playlist_references_are_not_a_batch_set(self):
+        transfer = Transfer(
+            publishing_guards=TEST_PUBLISHING_GUARDS,
+            source=RekordboxPlaylistSource(REKORDBOX_FIXTURE),
+            spotify=StatefulSpotify(), matching_knowledge=InMemoryStorage(),
+        )
+
+        with pytest.raises(ValueError, match="duplicate playlist"):
+            transfer.plan_batch(BatchPlanRequest(playlist_references=(
+                "My Playlists/Deep", "My Playlists/Deep",
+            )))
 
     def test_positive_and_negative_cache_entries_are_not_expected_lookups(
         self, tmp_path,

--- a/tests/test_transfer.py
+++ b/tests/test_transfer.py
@@ -1432,7 +1432,7 @@ class TestRekordboxBatchPlanning:
 
         with pytest.raises(ValueError, match="duplicate playlist"):
             transfer.plan_batch(BatchPlanRequest(playlist_references=(
-                "My Playlists/Deep", "My Playlists/Deep",
+                "Deep", "My Playlists/Deep",
             )))
 
     def test_positive_and_negative_cache_entries_are_not_expected_lookups(

--- a/tests/test_transfer.py
+++ b/tests/test_transfer.py
@@ -21,6 +21,7 @@ from djsupport.report import PlaylistReport, SyncReport, save_report
 from djsupport.spotify import RateLimitError
 from djsupport.transfer import (
     AccountPublishingGuards,
+    BatchPlanRequest,
     FilePublicationStorage,
     FileTransferStorage,
     MatchCacheKnowledge,
@@ -1342,6 +1343,116 @@ class TestRekordboxMirror:
             ),
             80,
         )["authoritative"] is True
+
+
+class TestRekordboxBatchPlanning:
+    def test_explicit_playlists_are_planned_without_spotify_or_state_mutation(self):
+        spotify = StatefulSpotify()
+        knowledge = InMemoryStorage()
+        knowledge.matches[("Solomun", "Vultora (Original Mix)")] = {
+            **_match("spotify:track:vultora", "Vultora (Original Mix)", "Solomun"),
+            "authoritative": True,
+        }
+        knowledge.matches[(
+            "Eagles & Butterflies", "Sapphire (Joris Voorn Remix)",
+        )] = _match(
+            "spotify:track:sapphire", "Sapphire (Joris Voorn Remix)",
+            "Eagles & Butterflies",
+        )
+        storage = InMemoryStorage()
+        transfer = Transfer(
+            publishing_guards=TEST_PUBLISHING_GUARDS,
+            source=RekordboxPlaylistSource(REKORDBOX_FIXTURE), spotify=spotify,
+            matching_knowledge=knowledge, publication_storage=storage,
+            transfer_storage=storage,
+        )
+
+        plan = transfer.plan_batch(BatchPlanRequest(playlist_references=(
+            "My Playlists/Peak Time", "My Playlists/Deep",
+        )))
+
+        assert [playlist.reference for playlist in plan.playlists] == [
+            "My Playlists/Peak Time", "My Playlists/Deep",
+        ]
+        assert plan.total_tracks == 3
+        assert plan.approved_match_hits == 1
+        assert plan.cache_hits == 1
+        assert plan.expected_uncached_lookups == 1
+        assert spotify.searches == []
+        assert spotify.playlists == {"existing": ["spotify:track:untouched"]}
+        assert storage.publications == []
+        assert storage.playlist_writes == 0
+        assert storage.matches == {}
+        assert knowledge.checkpoints == 0
+
+    def test_omitted_selection_is_not_inferred_as_the_whole_library(self):
+        transfer = Transfer(
+            publishing_guards=TEST_PUBLISHING_GUARDS,
+            source=RekordboxPlaylistSource(REKORDBOX_FIXTURE),
+            spotify=StatefulSpotify(), matching_knowledge=InMemoryStorage(),
+        )
+
+        with pytest.raises(ValueError, match="select at least one playlist"):
+            transfer.plan_batch(BatchPlanRequest())
+
+        whole_library = transfer.plan_batch(BatchPlanRequest(whole_library=True))
+
+        assert [playlist.reference for playlist in whole_library.playlists] == [
+            "My Playlists/Peak Time", "My Playlists/Deep",
+        ]
+        assert whole_library.total_tracks == 3
+
+    def test_expensive_plan_requires_confirmation_without_a_lookup_ceiling(self):
+        transfer = Transfer(
+            publishing_guards=TEST_PUBLISHING_GUARDS,
+            source=RekordboxPlaylistSource(REKORDBOX_FIXTURE),
+            spotify=StatefulSpotify(), matching_knowledge=InMemoryStorage(),
+        )
+
+        unconfirmed = transfer.plan_batch(BatchPlanRequest(
+            whole_library=True, expensive_lookup_threshold=1,
+        ))
+        confirmed = transfer.plan_batch(BatchPlanRequest(
+            whole_library=True, expensive_lookup_threshold=1,
+            confirm_expensive=True,
+        ))
+
+        assert unconfirmed.expected_uncached_lookups == 3
+        assert unconfirmed.confirmation_required is True
+        assert unconfirmed.ready is False
+        assert confirmed.expected_uncached_lookups == 3
+        assert confirmed.confirmation_required is False
+        assert confirmed.ready is True
+
+    def test_positive_and_negative_cache_entries_are_not_expected_lookups(
+        self, tmp_path,
+    ):
+        cache = MatchCache(str(tmp_path / "matching-knowledge.json"))
+        cache.record_approval(
+            "Solomun", "Vultora (Original Mix)", "approved",
+            _match("spotify:track:vultora", "Vultora (Original Mix)", "Solomun"),
+            412,
+        )
+        cache.store(
+            "Eagles & Butterflies", "Sapphire (Joris Voorn Remix)", 80,
+            _match(
+                "spotify:track:sapphire", "Sapphire (Joris Voorn Remix)",
+                "Eagles & Butterflies",
+            ),
+        )
+        cache.store("Âme", "Für Immer", 80, None)
+        transfer = Transfer(
+            publishing_guards=TEST_PUBLISHING_GUARDS,
+            source=RekordboxPlaylistSource(REKORDBOX_FIXTURE),
+            spotify=StatefulSpotify(),
+            matching_knowledge=MatchCacheKnowledge(cache),
+        )
+
+        plan = transfer.plan_batch(BatchPlanRequest(whole_library=True))
+
+        assert plan.approved_match_hits == 1
+        assert plan.cache_hits == 2
+        assert plan.expected_uncached_lookups == 0
 
 
 class TestTransferPublicationLifecycle:


### PR DESCRIPTION
## Summary
- add explicit multi-playlist and whole-library Batch planning through the Transfer seam
- report total tracks, Approved Match hits, cache hits, and expected uncached Spotify lookups
- require confirmation for whole-library or expensive work without imposing a lookup ceiling
- keep planning read-only and reject duplicate canonical playlist selections

## Validation
- 424 offline tests passed
- Python compilation passed
- git diff validation passed
- Standards review passed with no findings
- Spec review passed with no findings

Closes #25