### PR TITLE
Execute a resumable Batch with partial outcomes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Added
 
+- Durable Rekordbox Batch execution with independent playlist outcomes,
+  partial-success reporting, safe shared-failure stops, and resumable checkpoints
 - Explicit Corrections from edited review CSV files, with validated stable source
   references and Spotify track URLs/URIs, idempotent playlist repair, Approved
   Match promotion, and local-only matcher regression knowledge

--- a/agent.md
+++ b/agent.md
@@ -35,7 +35,7 @@ djsupport/
   cache.py      # Persistent match cache with retry logic
   state.py      # Playlist ID mapping for incremental sync (source-agnostic)
   report.py     # Post-sync terminal + Markdown reports
-  transfer.py   # Durable Transfer orchestration, read-only Batch planning, checkpoints, and publication
+  transfer.py   # Durable Transfer/Batch orchestration, checkpoints, and publication
   static/       # Web frontend (index.html with Tailwind CSS)
 tests/          # pytest suite
 docs/           # Plans, reports, and solution docs

--- a/djsupport/report.py
+++ b/djsupport/report.py
@@ -91,6 +91,7 @@ class PlaylistReport:
     mirror_dispositions: tuple[str, ...] = ()
     mirror_disposition: str | None = None
     action: str = "dry-run"  # "created", "updated", "unchanged", or "dry-run"
+    outcome: str = "completed"
     spotify_playlist_id: str | None = None
     publication_manifest: PublicationManifest | None = None
     cache_hits: int = 0
@@ -148,7 +149,9 @@ def print_report(report: SyncReport) -> None:
 
     for pl in report.playlists:
         click.echo()
-        click.echo(f"Playlist: {pl.path}  ({pl.action})")
+        click.echo(
+            f"Playlist: {pl.path}  ({pl.action})  |  Outcome: {pl.outcome}"
+        )
         click.echo(f"  Matched:  {len(pl.matched)}/{pl.total} ({pl.match_rate:.1f}%)")
 
         if pl.matched:
@@ -203,6 +206,8 @@ def save_report(report: SyncReport, path: str) -> None:
 
     for pl in report.playlists:
         lines.append(f"## {pl.path}  ({pl.action})")
+        lines.append("")
+        lines.append(f"**Outcome:** {pl.outcome}")
         lines.append("")
         lines.append(f"**Matched:** {len(pl.matched)}/{pl.total} ({pl.match_rate:.1f}%)")
 

--- a/djsupport/transfer.py
+++ b/djsupport/transfer.py
@@ -159,23 +159,66 @@ class TransferStatus(str, Enum):
     ABANDONED = "abandoned"
 
 
+class BatchPhase(str, Enum):
+    PENDING = "pending"
+    PAUSED = "paused"
+    FAILED = "failed"
+    COMPLETED = "completed"
+
+
+class PlaylistOutcome(str, Enum):
+    PENDING = "pending"
+    COMPLETED = "completed"
+    FAILED = "failed"
+    SKIPPED = "skipped"
+
+
+class BatchStatus(str, Enum):
+    MATCHING = "matching"
+    PAUSED = "paused"
+    COMPLETED = "completed"
+    PARTIAL_SUCCESS = "partial success"
+    FAILED = "failed"
+
+
 @dataclass
 class BatchPlaylistState:
     name: str
     reference: str
     transfer_id: str
-    phase: str = "pending"
-    outcome: str = "pending"
+    phase: BatchPhase = BatchPhase.PENDING
+    outcome: PlaylistOutcome = PlaylistOutcome.PENDING
     error: str | None = None
+
+    @classmethod
+    def from_dict(cls, value: dict) -> BatchPlaylistState:
+        return cls(**{
+            **value,
+            "phase": BatchPhase(value.get("phase", BatchPhase.PENDING.value)),
+            "outcome": PlaylistOutcome(
+                value.get("outcome", PlaylistOutcome.PENDING.value)
+            ),
+        })
 
 
 @dataclass
 class BatchState:
-    account_id: str
+    account_id: str | None
     created_at: str
     threshold: int
-    status: str
+    status: BatchStatus
     playlists: list[BatchPlaylistState]
+
+    @classmethod
+    def from_dict(cls, value: dict) -> BatchState:
+        return cls(**{
+            **value,
+            "status": BatchStatus(value["status"]),
+            "playlists": [
+                BatchPlaylistState.from_dict(playlist)
+                for playlist in value["playlists"]
+            ],
+        })
 
 
 class ApprovalStatus(str, Enum):
@@ -650,15 +693,7 @@ class FileTransferStorage:
                     continue
             for transfer_id, state in data.get("batches", {}).items():
                 try:
-                    self.batches[transfer_id] = BatchState(
-                        **{
-                            **state,
-                            "playlists": [
-                                BatchPlaylistState(**playlist)
-                                for playlist in state["playlists"]
-                            ],
-                        }
-                    )
+                    self.batches[transfer_id] = BatchState.from_dict(state)
                 except (KeyError, TypeError, ValueError):
                     continue
 
@@ -1129,25 +1164,48 @@ class Transfer:
         """Execute and durably checkpoint each planned Rekordbox playlist."""
         if self._publication_storage is None:
             raise ValueError("Publishing Transfers require publication storage")
-        account_id = self._spotify.account_id()
-        with self._publishing_guards.acquire(account_id):
-            return self._execute_batch(plan, transfer_id=transfer_id)
-
-    def _execute_batch(
-        self, plan: BatchPlan, *, transfer_id: str | None = None,
-    ) -> SyncReport:
         if not plan.ready:
             raise ValueError("An expensive Batch must be confirmed before execution")
         if self._transfer_storage is None:
             raise ValueError("Batch execution requires durable Transfer storage")
         batch_id = transfer_id or uuid4().hex
+        batch = self._load_or_create_batch(batch_id, plan)
+        try:
+            account_id = self._spotify.account_id()
+        except Exception as exc:
+            if not self._is_shared_failure(exc):
+                raise
+            batch.status = BatchStatus.PAUSED
+            self._transfer_storage.save_batch(batch_id, batch)
+            return self._batch_report(
+                batch_id, batch, [
+                    self._batch_playlist_report(
+                        item, "pending: shared authentication failure",
+                        PlaylistOutcome.PENDING,
+                    )
+                    for item in batch.playlists
+                ],
+                BatchStatus.PAUSED,
+            )
+        if batch.account_id is None:
+            batch.account_id = account_id
+            self._transfer_storage.save_batch(batch_id, batch)
+        elif batch.account_id != account_id:
+            raise ValueError("A Batch cannot resume under another Spotify account")
+        with self._publishing_guards.acquire(account_id):
+            return self._execute_batch(batch_id, batch)
+
+    def _load_or_create_batch(
+        self, batch_id: str, plan: BatchPlan,
+    ) -> BatchState:
+        assert self._transfer_storage is not None
         batch = self._transfer_storage.load_batch(batch_id)
         if batch is None:
             batch = BatchState(
-                account_id=self._spotify.account_id(),
+                account_id=None,
                 created_at=datetime.now().isoformat(),
                 threshold=plan.threshold,
-                status="matching",
+                status=BatchStatus.MATCHING,
                 playlists=[
                     BatchPlaylistState(
                         planned.name, planned.reference, f"{batch_id}:{index}",
@@ -1156,13 +1214,14 @@ class Transfer:
                 ],
             )
             self._transfer_storage.save_batch(batch_id, batch)
-        elif batch.account_id != self._spotify.account_id():
-            raise ValueError("A Batch cannot resume under another Spotify account")
         elif [item.reference for item in batch.playlists] != [
             item.reference for item in plan.playlists
         ]:
             raise ValueError("A resumed Batch must use its original plan")
+        return batch
 
+    def _execute_batch(self, batch_id: str, batch: BatchState) -> SyncReport:
+        assert self._transfer_storage is not None
         playlists: list[PlaylistReport] = []
         for index, item in enumerate(batch.playlists):
             try:
@@ -1175,60 +1234,78 @@ class Transfer:
             except Exception as exc:
                 if not self._is_shared_failure(exc) and not self._is_playlist_failure(exc):
                     raise
-                item.phase = "paused" if self._is_shared_failure(exc) else "failed"
-                item.outcome = "failed"
+                shared_failure = self._is_shared_failure(exc)
+                item.phase = BatchPhase.PAUSED if shared_failure else BatchPhase.FAILED
+                item.outcome = (
+                    PlaylistOutcome.PENDING
+                    if shared_failure else PlaylistOutcome.FAILED
+                )
                 item.error = str(exc)
-                playlists.append(PlaylistReport(
-                    name=item.name,
-                    path=item.reference,
-                    action=str(exc),
-                    outcome="failed",
+                playlists.append(self._batch_playlist_report(
+                    item, str(exc), item.outcome,
                 ))
-                if self._is_shared_failure(exc):
+                if shared_failure:
                     for pending in batch.playlists[index + 1:]:
-                        pending.phase = "pending"
-                        pending.outcome = "skipped"
-                        playlists.append(PlaylistReport(
-                            name=pending.name, path=pending.reference,
-                            action="skipped after shared failure", outcome="skipped",
+                        pending.phase = BatchPhase.PENDING
+                        pending.outcome = PlaylistOutcome.SKIPPED
+                        playlists.append(self._batch_playlist_report(
+                            pending, "skipped after shared failure",
+                            PlaylistOutcome.SKIPPED,
                         ))
-                    batch.status = "paused"
+                    batch.status = BatchStatus.PAUSED
                     self._transfer_storage.save_batch(batch_id, batch)
                     break
             else:
                 if report.status == "paused":
-                    item.phase = "paused"
-                    item.outcome = "pending"
-                    report.playlists[0].outcome = "pending"
+                    item.phase = BatchPhase.PAUSED
+                    item.outcome = PlaylistOutcome.PENDING
+                    report.playlists[0].outcome = PlaylistOutcome.PENDING.value
                     playlists.extend(report.playlists)
                     for pending in batch.playlists[index + 1:]:
-                        pending.phase = "pending"
-                        pending.outcome = "pending"
-                        playlists.append(PlaylistReport(
-                            name=pending.name, path=pending.reference,
-                            action="pending", outcome="pending",
+                        pending.phase = BatchPhase.PENDING
+                        pending.outcome = PlaylistOutcome.PENDING
+                        playlists.append(self._batch_playlist_report(
+                            pending, "pending", PlaylistOutcome.PENDING,
                         ))
-                    batch.status = "paused"
+                    batch.status = BatchStatus.PAUSED
                     self._transfer_storage.save_batch(batch_id, batch)
                     break
-                item.phase = "completed"
-                item.outcome = "completed"
+                item.phase = BatchPhase.COMPLETED
+                item.outcome = PlaylistOutcome.COMPLETED
                 item.error = None
-                report.playlists[0].outcome = item.outcome
+                report.playlists[0].outcome = item.outcome.value
                 playlists.extend(report.playlists)
                 self._transfer_storage.save_batch(batch_id, batch)
-        completed = sum(playlist.outcome == "completed" for playlist in playlists)
-        failed = sum(playlist.outcome == "failed" for playlist in playlists)
-        pending = sum(playlist.outcome == "pending" for playlist in playlists)
-        skipped = sum(playlist.outcome == "skipped" for playlist in playlists)
-        status = (
-            "paused" if pending
-            else "partial success" if completed and (failed or skipped)
-            else "failed" if failed or skipped
-            else "completed"
+        completed = sum(
+            playlist.outcome == PlaylistOutcome.COMPLETED for playlist in playlists
         )
-        batch.status = status
+        failed = sum(
+            playlist.outcome == PlaylistOutcome.FAILED for playlist in playlists
+        )
+        pending = sum(
+            playlist.outcome == PlaylistOutcome.PENDING for playlist in playlists
+        )
+        skipped = sum(
+            playlist.outcome == PlaylistOutcome.SKIPPED for playlist in playlists
+        )
+        status = (
+            BatchStatus.PAUSED if pending and not completed
+            else BatchStatus.PARTIAL_SUCCESS if completed and (failed or pending or skipped)
+            else BatchStatus.FAILED if failed or skipped
+            else BatchStatus.COMPLETED
+        )
+        batch.status = (
+            BatchStatus.PAUSED
+            if any(item.phase == BatchPhase.PAUSED for item in batch.playlists)
+            else status
+        )
         self._transfer_storage.save_batch(batch_id, batch)
+        return self._batch_report(batch_id, batch, playlists, status)
+
+    def _batch_report(
+        self, batch_id: str, batch: BatchState,
+        playlists: list[PlaylistReport], status: BatchStatus,
+    ) -> SyncReport:
         return SyncReport(
             timestamp=datetime.fromisoformat(batch.created_at),
             threshold=batch.threshold, dry_run=False,
@@ -1236,8 +1313,38 @@ class Transfer:
             cache_enabled=getattr(self._knowledge, "persistent", True),
             source_label=self._source.source_label,
             transfer_id=batch_id,
-            status=status,
+            status=status.value,
         )
+
+    def _batch_playlist_report(
+        self, item: BatchPlaylistState, action: str,
+        outcome: PlaylistOutcome,
+    ) -> PlaylistReport:
+        report = PlaylistReport(
+            name=item.name, path=item.reference, action=action,
+            outcome=outcome.value,
+        )
+        state = (
+            self._transfer_storage.load_transfer(item.transfer_id)
+            if self._transfer_storage is not None else None
+        )
+        if state is None:
+            return report
+        report.matched = [MatchedTrack(**matched) for matched in state.matched]
+        report.unmatched = list(state.unmatched)
+        report.alternatives = [
+            UnmatchedAlternatives(
+                source_track_id=alternative["source_track_id"],
+                source_name=alternative["source_name"],
+                candidates=tuple(
+                    AlternativeCandidate(**candidate)
+                    for candidate in alternative["candidates"]
+                ),
+            )
+            for alternative in state.alternatives
+        ]
+        report.spotify_playlist_id = state.spotify_playlist_id
+        return report
 
     @staticmethod
     def _is_shared_failure(exc: Exception) -> bool:

--- a/djsupport/transfer.py
+++ b/djsupport/transfer.py
@@ -1177,15 +1177,30 @@ class Transfer:
                 raise
             batch.status = BatchStatus.PAUSED
             self._transfer_storage.save_batch(batch_id, batch)
-            return self._batch_report(
-                batch_id, batch, [
-                    self._batch_playlist_report(
-                        item, "pending: shared authentication failure",
-                        PlaylistOutcome.PENDING,
-                    )
+            authentication_actions = {
+                PlaylistOutcome.COMPLETED: (
+                    "completed before shared authentication failure"
+                ),
+                PlaylistOutcome.FAILED: "failed before shared authentication failure",
+                PlaylistOutcome.SKIPPED: "skipped after shared failure",
+                PlaylistOutcome.PENDING: "pending: shared authentication failure",
+            }
+            playlists = [
+                self._batch_playlist_report(
+                    item, authentication_actions[item.outcome], item.outcome,
+                )
+                for item in batch.playlists
+            ]
+            report_status = (
+                BatchStatus.PARTIAL_SUCCESS
+                if any(
+                    item.outcome == PlaylistOutcome.COMPLETED
                     for item in batch.playlists
-                ],
-                BatchStatus.PAUSED,
+                )
+                else BatchStatus.PAUSED
+            )
+            return self._batch_report(
+                batch_id, batch, playlists, report_status,
             )
         if batch.account_id is None:
             batch.account_id = account_id

--- a/djsupport/transfer.py
+++ b/djsupport/transfer.py
@@ -127,6 +127,7 @@ class PlaylistPreflight:
 class BatchPlan:
     playlists: tuple[PlaylistPreflight, ...]
     confirmation_required: bool = False
+    threshold: int = 80
 
     @property
     def ready(self) -> bool:
@@ -156,6 +157,25 @@ class TransferStatus(str, Enum):
     RETAINING_PUBLICATION = "retaining publication"
     COMPLETED = "completed"
     ABANDONED = "abandoned"
+
+
+@dataclass
+class BatchPlaylistState:
+    name: str
+    reference: str
+    transfer_id: str
+    phase: str = "pending"
+    outcome: str = "pending"
+    error: str | None = None
+
+
+@dataclass
+class BatchState:
+    account_id: str
+    created_at: str
+    threshold: int
+    status: str
+    playlists: list[BatchPlaylistState]
 
 
 class ApprovalStatus(str, Enum):
@@ -601,6 +621,10 @@ class TransferStorage(Protocol):
 
     def save_transfer(self, transfer_id: str, state: TransferState) -> None: ...
 
+    def load_batch(self, transfer_id: str) -> BatchState | None: ...
+
+    def save_batch(self, transfer_id: str, state: BatchState) -> None: ...
+
 
 class FileTransferStorage:
     """Atomically persisted, versioned state for resumable Transfers."""
@@ -608,6 +632,7 @@ class FileTransferStorage:
     def __init__(self, path: str | Path) -> None:
         self.path = Path(path)
         self.transfers: dict[str, TransferState] = {}
+        self.batches: dict[str, BatchState] = {}
         self._load()
 
     def _load(self) -> None:
@@ -623,22 +648,47 @@ class FileTransferStorage:
                     self.transfers[transfer_id] = TransferState.from_dict(state)
                 except (KeyError, TypeError, ValueError):
                     continue
+            for transfer_id, state in data.get("batches", {}).items():
+                try:
+                    self.batches[transfer_id] = BatchState(
+                        **{
+                            **state,
+                            "playlists": [
+                                BatchPlaylistState(**playlist)
+                                for playlist in state["playlists"]
+                            ],
+                        }
+                    )
+                except (KeyError, TypeError, ValueError):
+                    continue
 
     def load_transfer(self, transfer_id: str) -> TransferState | None:
         return self.transfers.get(transfer_id)
 
     def save_transfer(self, transfer_id: str, state: TransferState) -> None:
-        next_transfers = {**self.transfers, transfer_id: state}
+        self.transfers = {**self.transfers, transfer_id: state}
+        self._save()
+
+    def load_batch(self, transfer_id: str) -> BatchState | None:
+        return self.batches.get(transfer_id)
+
+    def save_batch(self, transfer_id: str, state: BatchState) -> None:
+        self.batches = {**self.batches, transfer_id: state}
+        self._save()
+
+    def _save(self) -> None:
         self.path.parent.mkdir(parents=True, exist_ok=True)
         temporary = self.path.with_suffix(f"{self.path.suffix}.tmp")
         temporary.write_text(json.dumps({
             "version": TRANSFER_STATE_VERSION,
             "transfers": {
-                key: asdict(transfer) for key, transfer in next_transfers.items()
+                key: asdict(transfer) for key, transfer in self.transfers.items()
+            },
+            "batches": {
+                key: asdict(batch) for key, batch in self.batches.items()
             },
         }, indent=2))
         os.replace(temporary, self.path)
-        self.transfers = next_transfers
 
 
 def default_publication_manifest_path() -> Path:
@@ -1070,6 +1120,141 @@ class Transfer:
                 )
                 and not request.confirm_expensive
             ),
+            threshold=request.threshold,
+        )
+
+    def execute_batch(
+        self, plan: BatchPlan, *, transfer_id: str | None = None,
+    ) -> SyncReport:
+        """Execute and durably checkpoint each planned Rekordbox playlist."""
+        if self._publication_storage is None:
+            raise ValueError("Publishing Transfers require publication storage")
+        account_id = self._spotify.account_id()
+        with self._publishing_guards.acquire(account_id):
+            return self._execute_batch(plan, transfer_id=transfer_id)
+
+    def _execute_batch(
+        self, plan: BatchPlan, *, transfer_id: str | None = None,
+    ) -> SyncReport:
+        if not plan.ready:
+            raise ValueError("An expensive Batch must be confirmed before execution")
+        if self._transfer_storage is None:
+            raise ValueError("Batch execution requires durable Transfer storage")
+        batch_id = transfer_id or uuid4().hex
+        batch = self._transfer_storage.load_batch(batch_id)
+        if batch is None:
+            batch = BatchState(
+                account_id=self._spotify.account_id(),
+                created_at=datetime.now().isoformat(),
+                threshold=plan.threshold,
+                status="matching",
+                playlists=[
+                    BatchPlaylistState(
+                        planned.name, planned.reference, f"{batch_id}:{index}",
+                    )
+                    for index, planned in enumerate(plan.playlists)
+                ],
+            )
+            self._transfer_storage.save_batch(batch_id, batch)
+        elif batch.account_id != self._spotify.account_id():
+            raise ValueError("A Batch cannot resume under another Spotify account")
+        elif [item.reference for item in batch.playlists] != [
+            item.reference for item in plan.playlists
+        ]:
+            raise ValueError("A resumed Batch must use its original plan")
+
+        playlists: list[PlaylistReport] = []
+        for index, item in enumerate(batch.playlists):
+            try:
+                report = self._execute(TransferRequest(
+                    source=item.reference,
+                    mode=TransferMode.MIRROR,
+                    threshold=batch.threshold,
+                    transfer_id=item.transfer_id,
+                ))
+            except Exception as exc:
+                if not self._is_shared_failure(exc) and not self._is_playlist_failure(exc):
+                    raise
+                item.phase = "paused" if self._is_shared_failure(exc) else "failed"
+                item.outcome = "failed"
+                item.error = str(exc)
+                playlists.append(PlaylistReport(
+                    name=item.name,
+                    path=item.reference,
+                    action=str(exc),
+                    outcome="failed",
+                ))
+                if self._is_shared_failure(exc):
+                    for pending in batch.playlists[index + 1:]:
+                        pending.phase = "pending"
+                        pending.outcome = "skipped"
+                        playlists.append(PlaylistReport(
+                            name=pending.name, path=pending.reference,
+                            action="skipped after shared failure", outcome="skipped",
+                        ))
+                    batch.status = "paused"
+                    self._transfer_storage.save_batch(batch_id, batch)
+                    break
+            else:
+                if report.status == "paused":
+                    item.phase = "paused"
+                    item.outcome = "pending"
+                    report.playlists[0].outcome = "pending"
+                    playlists.extend(report.playlists)
+                    for pending in batch.playlists[index + 1:]:
+                        pending.phase = "pending"
+                        pending.outcome = "pending"
+                        playlists.append(PlaylistReport(
+                            name=pending.name, path=pending.reference,
+                            action="pending", outcome="pending",
+                        ))
+                    batch.status = "paused"
+                    self._transfer_storage.save_batch(batch_id, batch)
+                    break
+                item.phase = "completed"
+                item.outcome = "completed"
+                item.error = None
+                report.playlists[0].outcome = item.outcome
+                playlists.extend(report.playlists)
+                self._transfer_storage.save_batch(batch_id, batch)
+        completed = sum(playlist.outcome == "completed" for playlist in playlists)
+        failed = sum(playlist.outcome == "failed" for playlist in playlists)
+        pending = sum(playlist.outcome == "pending" for playlist in playlists)
+        skipped = sum(playlist.outcome == "skipped" for playlist in playlists)
+        status = (
+            "paused" if pending
+            else "partial success" if completed and (failed or skipped)
+            else "failed" if failed or skipped
+            else "completed"
+        )
+        batch.status = status
+        self._transfer_storage.save_batch(batch_id, batch)
+        return SyncReport(
+            timestamp=datetime.fromisoformat(batch.created_at),
+            threshold=batch.threshold, dry_run=False,
+            playlists=playlists,
+            cache_enabled=getattr(self._knowledge, "persistent", True),
+            source_label=self._source.source_label,
+            transfer_id=batch_id,
+            status=status,
+        )
+
+    @staticmethod
+    def _is_shared_failure(exc: Exception) -> bool:
+        if isinstance(exc, (RateLimitError, requests.Timeout, requests.ConnectionError)):
+            return True
+        return isinstance(exc, spotipy.SpotifyException) and (
+            exc.http_status in (401, 403, 429)
+            or exc.http_status is None
+            or exc.http_status >= 500
+        )
+
+    @staticmethod
+    def _is_playlist_failure(exc: Exception) -> bool:
+        return isinstance(exc, (ValueError, SourceNotFound)) or (
+            isinstance(exc, spotipy.SpotifyException)
+            and exc.http_status is not None
+            and 400 <= exc.http_status < 500
         )
 
     def abandon(self, transfer_id: str) -> None:

--- a/tests/test_transfer.py
+++ b/tests/test_transfer.py
@@ -1567,9 +1567,9 @@ class TestRekordboxBatchExecution:
 
         report = transfer.execute_batch(plan)
 
-        assert report.status == "failed"
+        assert report.status == "paused"
         assert [playlist.outcome for playlist in report.playlists] == [
-            "failed", "skipped",
+            "pending", "skipped",
         ]
         assert report.playlists[1].action == "skipped after shared failure"
         assert storage.publications == []
@@ -1577,8 +1577,9 @@ class TestRekordboxBatchExecution:
             report.transfer_id
         )
         assert [(item.phase, item.outcome) for item in durable.playlists] == [
-            ("paused", "failed"), ("pending", "skipped"),
+            ("paused", "pending"), ("pending", "skipped"),
         ]
+        assert durable.status == "paused"
 
     def test_resume_after_shared_failure_keeps_completed_publication(self, tmp_path):
         class RecoveringSpotify(StatefulSpotify):
@@ -1620,7 +1621,7 @@ class TestRekordboxBatchExecution:
 
         assert stopped.status == "partial success"
         assert [playlist.outcome for playlist in stopped.playlists] == [
-            "completed", "failed",
+            "completed", "pending",
         ]
         assert len(publications.publications) == 1
         completed_searches = list(spotify.searches)
@@ -1640,6 +1641,65 @@ class TestRekordboxBatchExecution:
             ("Solomun", "Vultora (Original Mix)", 80)
         ) == 1
         assert len(publications.publications) == 2
+
+    def test_authentication_failure_before_account_discovery_is_checkpointed(
+        self, tmp_path,
+    ):
+        class UnauthenticatedSpotify(StatefulSpotify):
+            def account_id(self):
+                raise spotipy.SpotifyException(401, -1, "expired token")
+
+        states = FileTransferStorage(tmp_path / "transfers.json")
+        transfer = Transfer(
+            publishing_guards=TEST_PUBLISHING_GUARDS,
+            source=RekordboxPlaylistSource(REKORDBOX_FIXTURE),
+            spotify=UnauthenticatedSpotify(), matching_knowledge=InMemoryStorage(),
+            publication_storage=InMemoryStorage(), transfer_storage=states,
+        )
+        plan = transfer.plan_batch(BatchPlanRequest(
+            playlist_references=(
+                "My Playlists/Peak Time", "My Playlists/Deep",
+            ),
+        ))
+
+        report = transfer.execute_batch(plan)
+
+        assert report.status == "paused"
+        assert [playlist.outcome for playlist in report.playlists] == [
+            "pending", "pending",
+        ]
+        durable = FileTransferStorage(states.path).load_batch(report.transfer_id)
+        assert durable.status == "paused"
+        assert durable.account_id is None
+
+    def test_failed_playlist_report_retains_completed_matching_progress(self, tmp_path):
+        class SecondTrackFailureSpotify(StatefulSpotify):
+            def match(self, track, threshold):
+                if track.name == "Sapphire (Joris Voorn Remix)":
+                    raise ValueError("playlist-specific bad track")
+                return super().match(track, threshold)
+
+        spotify = SecondTrackFailureSpotify({
+            ("Solomun", "Vultora (Original Mix)"): _match(
+                "spotify:track:vultora", "Vultora (Original Mix)", "Solomun",
+            ),
+        })
+        storage = InMemoryStorage()
+        transfer = Transfer(
+            publishing_guards=TEST_PUBLISHING_GUARDS,
+            source=RekordboxPlaylistSource(REKORDBOX_FIXTURE), spotify=spotify,
+            matching_knowledge=storage, publication_storage=storage,
+            transfer_storage=FileTransferStorage(tmp_path / "transfers.json"),
+        )
+
+        report = transfer.execute_batch(transfer.plan_batch(BatchPlanRequest(
+            playlist_references=("My Playlists/Peak Time",),
+        )))
+
+        assert report.playlists[0].outcome == "failed"
+        assert [match.source_name for match in report.playlists[0].matched] == [
+            "Solomun - Vultora (Original Mix)",
+        ]
 
     def test_paused_batch_reloads_and_resumes_without_repeating_effects(self, tmp_path):
         matches = {

--- a/tests/test_transfer.py
+++ b/tests/test_transfer.py
@@ -1466,6 +1466,243 @@ class TestRekordboxBatchPlanning:
         assert plan.expected_uncached_lookups == 0
 
 
+class TestRekordboxBatchExecution:
+    def test_playlist_failure_preserves_completed_work_and_continues(self, tmp_path):
+        class PlaylistFailureSpotify(StatefulSpotify):
+            def match(self, track, threshold):
+                if track.name == "Für Immer":
+                    raise ValueError("playlist-specific bad track")
+                return super().match(track, threshold)
+
+        spotify = PlaylistFailureSpotify({
+            ("Solomun", "Vultora (Original Mix)"): _match(
+                "spotify:track:vultora", "Vultora (Original Mix)", "Solomun",
+            ),
+            ("Eagles & Butterflies", "Sapphire (Joris Voorn Remix)"): _match(
+                "spotify:track:sapphire", "Sapphire (Joris Voorn Remix)",
+                "Eagles & Butterflies",
+            ),
+        })
+        storage = InMemoryStorage()
+        transfer = Transfer(
+            publishing_guards=TEST_PUBLISHING_GUARDS,
+            source=RekordboxPlaylistSource(REKORDBOX_FIXTURE), spotify=spotify,
+            matching_knowledge=storage, publication_storage=storage,
+            transfer_storage=FileTransferStorage(tmp_path / "transfers.json"),
+        )
+        plan = transfer.plan_batch(BatchPlanRequest(
+            playlist_references=(
+                "My Playlists/Peak Time", "My Playlists/Deep",
+            ),
+        ))
+
+        report = transfer.execute_batch(plan)
+
+        assert report.status == "partial success"
+        assert [playlist.outcome for playlist in report.playlists] == [
+            "completed", "failed",
+        ]
+        assert len(storage.publications) == 1
+        assert spotify.playlists["snapshot-1"]["tracks"] == [
+            "spotify:track:vultora", "spotify:track:sapphire",
+        ]
+
+    def test_playlist_failure_does_not_block_a_later_independent_playlist(
+        self, tmp_path,
+    ):
+        class PlaylistFailureSpotify(StatefulSpotify):
+            def match(self, track, threshold):
+                if track.name == "Für Immer":
+                    raise ValueError("playlist-specific bad track")
+                return super().match(track, threshold)
+
+        spotify = PlaylistFailureSpotify({
+            ("Solomun", "Vultora (Original Mix)"): _match(
+                "spotify:track:vultora", "Vultora (Original Mix)", "Solomun",
+            ),
+            ("Eagles & Butterflies", "Sapphire (Joris Voorn Remix)"): _match(
+                "spotify:track:sapphire", "Sapphire (Joris Voorn Remix)",
+                "Eagles & Butterflies",
+            ),
+        })
+        storage = InMemoryStorage()
+        transfer = Transfer(
+            publishing_guards=TEST_PUBLISHING_GUARDS,
+            source=RekordboxPlaylistSource(REKORDBOX_FIXTURE), spotify=spotify,
+            matching_knowledge=storage, publication_storage=storage,
+            transfer_storage=FileTransferStorage(tmp_path / "transfers.json"),
+        )
+
+        report = transfer.execute_batch(transfer.plan_batch(BatchPlanRequest(
+            playlist_references=(
+                "My Playlists/Deep", "My Playlists/Peak Time",
+            ),
+        )))
+
+        assert [playlist.outcome for playlist in report.playlists] == [
+            "failed", "completed",
+        ]
+        assert spotify.playlists["snapshot-1"]["tracks"] == [
+            "spotify:track:vultora", "spotify:track:sapphire",
+        ]
+
+    def test_shared_failure_stops_and_skips_later_playlists(self, tmp_path):
+        class RateLimitedSpotify(StatefulSpotify):
+            def match(self, track, threshold):
+                raise RateLimitError(3600)
+
+        storage = InMemoryStorage()
+        transfer = Transfer(
+            publishing_guards=TEST_PUBLISHING_GUARDS,
+            source=RekordboxPlaylistSource(REKORDBOX_FIXTURE),
+            spotify=RateLimitedSpotify(), matching_knowledge=storage,
+            publication_storage=storage,
+            transfer_storage=FileTransferStorage(tmp_path / "transfers.json"),
+        )
+        plan = transfer.plan_batch(BatchPlanRequest(
+            playlist_references=(
+                "My Playlists/Peak Time", "My Playlists/Deep",
+            ),
+        ))
+
+        report = transfer.execute_batch(plan)
+
+        assert report.status == "failed"
+        assert [playlist.outcome for playlist in report.playlists] == [
+            "failed", "skipped",
+        ]
+        assert report.playlists[1].action == "skipped after shared failure"
+        assert storage.publications == []
+        durable = FileTransferStorage(tmp_path / "transfers.json").load_batch(
+            report.transfer_id
+        )
+        assert [(item.phase, item.outcome) for item in durable.playlists] == [
+            ("paused", "failed"), ("pending", "skipped"),
+        ]
+
+    def test_resume_after_shared_failure_keeps_completed_publication(self, tmp_path):
+        class RecoveringSpotify(StatefulSpotify):
+            unavailable = True
+
+            def match(self, track, threshold):
+                if track.name == "Für Immer" and self.unavailable:
+                    raise requests.ConnectionError("Spotify unavailable")
+                return super().match(track, threshold)
+
+        spotify = RecoveringSpotify({
+            ("Solomun", "Vultora (Original Mix)"): _match(
+                "spotify:track:vultora", "Vultora (Original Mix)", "Solomun",
+            ),
+            ("Eagles & Butterflies", "Sapphire (Joris Voorn Remix)"): _match(
+                "spotify:track:sapphire", "Sapphire (Joris Voorn Remix)",
+                "Eagles & Butterflies",
+            ),
+            ("Âme", "Für Immer"): _match(
+                "spotify:track:fur-immer", "Für Immer", "Âme",
+            ),
+        })
+        publications = InMemoryStorage()
+        states = FileTransferStorage(tmp_path / "transfers.json")
+        transfer = Transfer(
+            publishing_guards=TEST_PUBLISHING_GUARDS,
+            source=RekordboxPlaylistSource(REKORDBOX_FIXTURE), spotify=spotify,
+            matching_knowledge=InMemoryStorage(), publication_storage=publications,
+            transfer_storage=states,
+            retry_policy=RetryPolicy(max_attempts=1, sleep=lambda _: None),
+        )
+        plan = transfer.plan_batch(BatchPlanRequest(
+            playlist_references=(
+                "My Playlists/Peak Time", "My Playlists/Deep",
+            ),
+        ))
+
+        stopped = transfer.execute_batch(plan)
+
+        assert stopped.status == "partial success"
+        assert [playlist.outcome for playlist in stopped.playlists] == [
+            "completed", "failed",
+        ]
+        assert len(publications.publications) == 1
+        completed_searches = list(spotify.searches)
+
+        spotify.unavailable = False
+        resumed = Transfer(
+            publishing_guards=TEST_PUBLISHING_GUARDS,
+            source=RekordboxPlaylistSource(REKORDBOX_FIXTURE), spotify=spotify,
+            matching_knowledge=InMemoryStorage(), publication_storage=publications,
+            transfer_storage=FileTransferStorage(states.path),
+            retry_policy=RetryPolicy(max_attempts=1, sleep=lambda _: None),
+        ).execute_batch(plan, transfer_id=stopped.transfer_id)
+
+        assert resumed.status == "completed"
+        assert spotify.searches[:2] == completed_searches
+        assert spotify.searches.count(
+            ("Solomun", "Vultora (Original Mix)", 80)
+        ) == 1
+        assert len(publications.publications) == 2
+
+    def test_paused_batch_reloads_and_resumes_without_repeating_effects(self, tmp_path):
+        matches = {
+            ("Solomun", "Vultora (Original Mix)"): _match(
+                "spotify:track:vultora", "Vultora (Original Mix)", "Solomun",
+            ),
+            ("Eagles & Butterflies", "Sapphire (Joris Voorn Remix)"): _match(
+                "spotify:track:sapphire", "Sapphire (Joris Voorn Remix)",
+                "Eagles & Butterflies",
+            ),
+            ("Âme", "Für Immer"): _match(
+                "spotify:track:fur-immer", "Für Immer", "Âme",
+            ),
+        }
+        spotify = StatefulSpotify(matches)
+        publications = InMemoryStorage()
+        state_path = tmp_path / "transfers.json"
+        first = Transfer(
+            publishing_guards=TEST_PUBLISHING_GUARDS,
+            source=RekordboxPlaylistSource(REKORDBOX_FIXTURE), spotify=spotify,
+            matching_knowledge=InMemoryStorage(), publication_storage=publications,
+            transfer_storage=FileTransferStorage(state_path),
+        )
+        plan = first.plan_batch(BatchPlanRequest(
+            playlist_references=(
+                "My Playlists/Peak Time", "My Playlists/Deep",
+            ),
+        ))
+        first.pause()
+
+        paused = first.execute_batch(plan)
+
+        assert paused.status == "paused"
+        assert [playlist.outcome for playlist in paused.playlists] == [
+            "pending", "pending",
+        ]
+        assert spotify.searches == [("Solomun", "Vultora (Original Mix)", 80)]
+
+        resumed = Transfer(
+            publishing_guards=TEST_PUBLISHING_GUARDS,
+            source=RekordboxPlaylistSource(REKORDBOX_FIXTURE), spotify=spotify,
+            matching_knowledge=InMemoryStorage(), publication_storage=publications,
+            transfer_storage=FileTransferStorage(state_path),
+        ).execute_batch(plan, transfer_id=paused.transfer_id)
+
+        assert resumed.status == "completed"
+        assert [playlist.outcome for playlist in resumed.playlists] == [
+            "completed", "completed",
+        ]
+        assert spotify.searches == [
+            ("Solomun", "Vultora (Original Mix)", 80),
+            ("Eagles & Butterflies", "Sapphire (Joris Voorn Remix)", 80),
+            ("Âme", "Für Immer", 80),
+        ]
+        assert len(publications.publications) == 2
+
+        report_path = tmp_path / "batch-report.md"
+        save_report(resumed, str(report_path))
+        text = report_path.read_text()
+        assert "**Outcome:** completed" in text
+        assert "**Status:** completed" in text
+
+
 class TestTransferPublicationLifecycle:
     def test_paused_transfer_reloads_and_resumes_without_repeating_work(self, tmp_path):
         matches = {

--- a/tests/test_transfer.py
+++ b/tests/test_transfer.py
@@ -1584,6 +1584,12 @@ class TestRekordboxBatchExecution:
     def test_resume_after_shared_failure_keeps_completed_publication(self, tmp_path):
         class RecoveringSpotify(StatefulSpotify):
             unavailable = True
+            authentication_unavailable = False
+
+            def account_id(self):
+                if self.authentication_unavailable:
+                    raise spotipy.SpotifyException(401, -1, "expired token")
+                return super().account_id()
 
             def match(self, track, threshold):
                 if track.name == "Für Immer" and self.unavailable:
@@ -1626,6 +1632,22 @@ class TestRekordboxBatchExecution:
         assert len(publications.publications) == 1
         completed_searches = list(spotify.searches)
 
+        spotify.authentication_unavailable = True
+        auth_stopped = Transfer(
+            publishing_guards=TEST_PUBLISHING_GUARDS,
+            source=RekordboxPlaylistSource(REKORDBOX_FIXTURE), spotify=spotify,
+            matching_knowledge=InMemoryStorage(), publication_storage=publications,
+            transfer_storage=FileTransferStorage(states.path),
+            retry_policy=RetryPolicy(max_attempts=1, sleep=lambda _: None),
+        ).execute_batch(plan, transfer_id=stopped.transfer_id)
+
+        assert auth_stopped.status == "partial success"
+        assert [playlist.outcome for playlist in auth_stopped.playlists] == [
+            "completed", "pending",
+        ]
+        assert len(publications.publications) == 1
+
+        spotify.authentication_unavailable = False
         spotify.unavailable = False
         resumed = Transfer(
             publishing_guards=TEST_PUBLISHING_GUARDS,


### PR DESCRIPTION
Closes #26

## Summary
- execute planned Rekordbox Batches through the deep Transfer seam with durable per-playlist phases and outcomes
- preserve completed publication, continue playlist-local failures, and pause safely on shared Spotify failures
- resume without repeating completed searches or publication and report completed, failed, pending, skipped, and partial success

## Validation
- 431 offline tests pass
- Python compilation passes
- git diff --check passes
- parallel Standards and Spec reviews pass with no remaining blocking findings