### PR TITLE
Make web Transfers durable

### DIFF
--- a/djsupport/cli.py
+++ b/djsupport/cli.py
@@ -469,6 +469,7 @@ def beatport(
             retry_days=retry_days,
             playlist_prefix=None if no_prefix else prefix,
             transfer_id=transfer_id,
+            retain_matching_knowledge=not no_cache,
         ))
     except InvalidBeatportURL as e:
         raise click.ClickException(str(e))
@@ -681,6 +682,7 @@ def label(
             retry_days=retry_days,
             playlist_prefix=None if no_prefix else prefix,
             transfer_id=transfer_id,
+            retain_matching_knowledge=not no_cache,
         ))
     except (InvalidLabelURL, LabelParseError) as e:
         raise click.ClickException(str(e))

--- a/djsupport/static/index.html
+++ b/djsupport/static/index.html
@@ -522,6 +522,22 @@
         }
         checkAuth();
 
+        const activeTransferKey = 'djsupport.activeTransfer';
+        const activeTransferId = localStorage.getItem(activeTransferKey);
+        if (activeTransferId) {
+            document.getElementById('input-section').classList.add('hidden');
+            document.getElementById('progress-section').classList.remove('hidden');
+            fetch(`/sync/${activeTransferId}/resume`, { method: 'POST' })
+                .then((response) => {
+                    if (!response.ok) throw new Error('Unable to resume Transfer');
+                    listenProgress(activeTransferId);
+                })
+                .catch(() => {
+                    localStorage.removeItem(activeTransferKey);
+                    showError('Unable to reload the previous Transfer');
+                });
+        }
+
         // URL validation
         urlInput.addEventListener('input', () => {
             const url = urlInput.value.trim();
@@ -579,6 +595,7 @@
                 }
 
                 const data = await res.json();
+                localStorage.setItem(activeTransferKey, data.transfer_id);
                 listenProgress(data.job_id);
             } catch (e) {
                 showError(e.message);
@@ -657,6 +674,7 @@
         }
 
         function showResults(data) {
+            localStorage.removeItem(activeTransferKey);
             document.getElementById('progress-section').classList.add('hidden');
             document.getElementById('results-section').classList.remove('hidden');
 

--- a/djsupport/static/index.html
+++ b/djsupport/static/index.html
@@ -596,7 +596,7 @@
 
                 const data = await res.json();
                 localStorage.setItem(activeTransferKey, data.transfer_id);
-                listenProgress(data.job_id);
+                listenProgress(data.transfer_id);
             } catch (e) {
                 showError(e.message);
             }

--- a/djsupport/transfer.py
+++ b/djsupport/transfer.py
@@ -165,9 +165,10 @@ class TransferProgress:
 
     transfer_id: str
     source: str
-    status: str
+    status: TransferStatus
     current: int
     total: int
+    error: str | None = None
 
 
 class BatchPhase(str, Enum):
@@ -1126,6 +1127,32 @@ class Transfer:
         """Request a pause after the current track reaches a safe checkpoint."""
         self._pause_requested = True
 
+    def prepare(self, request: TransferRequest) -> str:
+        """Durably reserve a Transfer ID before potentially slow source intake."""
+        if self._transfer_storage is None:
+            raise ValueError("Preparation requires durable Transfer storage")
+        if request.mode is None:
+            request = replace(
+                request,
+                mode=getattr(self._source, "default_mode", TransferMode.SNAPSHOT),
+            )
+        transfer_id = request.transfer_id or uuid4().hex
+        state = self._transfer_storage.load_transfer(transfer_id)
+        if state is not None:
+            return transfer_id
+        state = TransferState(
+            status=TransferStatus.MATCHING,
+            source=request.source,
+            account_id=self._spotify.account_id(),
+            request=self._stored_request(request),
+            selection={},
+            created_at=datetime.now().isoformat(),
+            next_track_index=0,
+            matched=[], unmatched=[], publication_items=[], alternatives=[],
+        )
+        self._save_transfer(transfer_id, state)
+        return transfer_id
+
     def progress(self, transfer_id: str) -> TransferProgress:
         """Reload observable progress without consuming or resuming the source."""
         if self._transfer_storage is None:
@@ -1138,10 +1165,32 @@ class Transfer:
         return TransferProgress(
             transfer_id=transfer_id,
             source=state.source,
-            status=state.status.value,
+            status=state.status,
             current=state.next_track_index,
             total=len(state.selection.get("tracks", ())),
+            error=state.outcome if state.status == TransferStatus.PAUSED else None,
         )
+
+    @staticmethod
+    def _stored_request(request: TransferRequest) -> dict:
+        assert request.mode is not None
+        return {
+            "source": request.source,
+            "mode": request.mode.value,
+            "preview": request.preview,
+            "threshold": request.threshold,
+            "retry": request.retry,
+            "retry_days": request.retry_days,
+            "playlist_prefix": request.playlist_prefix,
+            "drift_resolution": (
+                request.drift_resolution.value if request.drift_resolution else None
+            ),
+            "mirror_disposition": (
+                request.mirror_disposition.value
+                if request.mirror_disposition else None
+            ),
+            "mirror_playlist_id": request.mirror_playlist_id,
+        }
 
     def plan_batch(self, request: BatchPlanRequest) -> BatchPlan:
         """Plan an explicitly selected Rekordbox Batch without side effects."""
@@ -1676,7 +1725,32 @@ class Transfer:
             self._transfer_storage.load_transfer(transfer_id)
             if self._transfer_storage is not None else None
         )
-        if state is None:
+        if state is None or not state.selection:
+            prepared_state = state
+            if prepared_state is not None:
+                if prepared_state.source != request.source:
+                    raise ValueError("A resumed Transfer must use its original source")
+                if prepared_state.account_id != self._spotify.account_id():
+                    raise ValueError(
+                        "A Transfer cannot resume under another Spotify account"
+                    )
+                request = TransferRequest(
+                    **{
+                        **prepared_state.request,
+                        "mode": TransferMode(prepared_state.request["mode"]),
+                        "drift_resolution": (
+                            DriftResolution(prepared_state.request["drift_resolution"])
+                            if prepared_state.request.get("drift_resolution") else None
+                        ),
+                        "mirror_disposition": (
+                            MirrorDisposition(
+                                prepared_state.request["mirror_disposition"]
+                            )
+                            if prepared_state.request.get("mirror_disposition") else None
+                        ),
+                    },
+                    transfer_id=transfer_id,
+                )
             try:
                 selection = self._source.consume(request.source)
             except SourceNotFound:
@@ -1732,6 +1806,16 @@ class Transfer:
                         transfer_id=transfer_id,
                         status=status,
                     )
+                if prepared_state is not None:
+                    prepared_state.status = TransferStatus.PAUSED
+                    prepared_state.outcome = "Source selection was not found"
+                    self._save_transfer(transfer_id, prepared_state)
+                raise
+            except Exception as exc:
+                if prepared_state is not None:
+                    prepared_state.status = TransferStatus.PAUSED
+                    prepared_state.outcome = str(exc)
+                    self._save_transfer(transfer_id, prepared_state)
                 raise
             relinked_mirror = None
             if request.mirror_disposition == MirrorDisposition.RELINK:
@@ -1747,29 +1831,15 @@ class Transfer:
                     raise ValueError(
                         "The Mirror to relink does not belong to this Spotify account"
                     )
-            created_at = datetime.now()
+            created_at = (
+                datetime.fromisoformat(prepared_state.created_at)
+                if prepared_state is not None else datetime.now()
+            )
             state = TransferState(
                 status=TransferStatus.MATCHING,
                 source=request.source,
                 account_id=self._spotify.account_id(),
-                request={
-                    "source": request.source,
-                    "mode": request.mode.value,
-                    "preview": request.preview,
-                    "threshold": request.threshold,
-                    "retry": request.retry,
-                    "retry_days": request.retry_days,
-                    "playlist_prefix": request.playlist_prefix,
-                    "drift_resolution": (
-                        request.drift_resolution.value
-                        if request.drift_resolution else None
-                    ),
-                    "mirror_disposition": (
-                        request.mirror_disposition.value
-                        if request.mirror_disposition else None
-                    ),
-                    "mirror_playlist_id": request.mirror_playlist_id,
-                },
+                request=self._stored_request(request),
                 selection={
                     "name": selection.name,
                     "reference": selection.reference,
@@ -2280,6 +2350,7 @@ class Transfer:
             report.status = "completed"
         except (RateLimitError, requests.Timeout, requests.ConnectionError) as exc:
             state.status = TransferStatus.PAUSED
+            state.outcome = str(exc)
             self._save_transfer(transfer_id, state)
             raise exc
         except spotipy.SpotifyException as exc:
@@ -2288,16 +2359,18 @@ class Transfer:
             ):
                 raise
             state.status = TransferStatus.PAUSED
+            state.outcome = str(exc)
             self._save_transfer(transfer_id, state)
             raise
         except KeyboardInterrupt:
             state.status = TransferStatus.PAUSED
             self._save_transfer(transfer_id, state)
             raise
-        except Exception:
+        except Exception as exc:
             # A durable single Transfer remains resumable after adapter or
             # integration failures that are not classified above.
             state.status = TransferStatus.PAUSED
+            state.outcome = str(exc)
             self._save_transfer(transfer_id, state)
             raise
         finally:

--- a/djsupport/transfer.py
+++ b/djsupport/transfer.py
@@ -101,6 +101,7 @@ class TransferRequest:
     drift_resolution: DriftResolution | None = None
     mirror_disposition: MirrorDisposition | None = None
     mirror_playlist_id: str | None = None
+    retain_matching_knowledge: bool = True
 
 
 @dataclass(frozen=True)
@@ -169,6 +170,7 @@ class TransferProgress:
     current: int
     total: int
     error: str | None = None
+    retain_matching_knowledge: bool = True
 
 
 class BatchPhase(str, Enum):
@@ -1139,6 +1141,14 @@ class Transfer:
         transfer_id = request.transfer_id or uuid4().hex
         state = self._transfer_storage.load_transfer(transfer_id)
         if state is not None:
+            if state.source != request.source:
+                raise ValueError("A resumed Transfer must use its original source")
+            if state.account_id != self._spotify.account_id():
+                raise ValueError("A Transfer cannot resume under another Spotify account")
+            if state.status == TransferStatus.PAUSED:
+                state.status = TransferStatus.MATCHING
+                state.outcome = None
+                self._save_transfer(transfer_id, state)
             return transfer_id
         state = TransferState(
             status=TransferStatus.MATCHING,
@@ -1169,6 +1179,9 @@ class Transfer:
             current=state.next_track_index,
             total=len(state.selection.get("tracks", ())),
             error=state.outcome if state.status == TransferStatus.PAUSED else None,
+            retain_matching_knowledge=state.request.get(
+                "retain_matching_knowledge", True,
+            ),
         )
 
     @staticmethod
@@ -1190,6 +1203,7 @@ class Transfer:
                 if request.mirror_disposition else None
             ),
             "mirror_playlist_id": request.mirror_playlist_id,
+            "retain_matching_knowledge": request.retain_matching_knowledge,
         }
 
     def plan_batch(self, request: BatchPlanRequest) -> BatchPlan:

--- a/djsupport/transfer.py
+++ b/djsupport/transfer.py
@@ -159,6 +159,17 @@ class TransferStatus(str, Enum):
     ABANDONED = "abandoned"
 
 
+@dataclass(frozen=True)
+class TransferProgress:
+    """Durable, adapter-facing progress for one Transfer."""
+
+    transfer_id: str
+    source: str
+    status: str
+    current: int
+    total: int
+
+
 class BatchPhase(str, Enum):
     PENDING = "pending"
     PAUSED = "paused"
@@ -1114,6 +1125,23 @@ class Transfer:
     def pause(self) -> None:
         """Request a pause after the current track reaches a safe checkpoint."""
         self._pause_requested = True
+
+    def progress(self, transfer_id: str) -> TransferProgress:
+        """Reload observable progress without consuming or resuming the source."""
+        if self._transfer_storage is None:
+            raise ValueError("Progress requires durable Transfer storage")
+        state = self._transfer_storage.load_transfer(transfer_id)
+        if state is None:
+            raise ValueError(f"Unknown Transfer: {transfer_id}")
+        if state.account_id != self._spotify.account_id():
+            raise ValueError("A Transfer cannot be viewed under another Spotify account")
+        return TransferProgress(
+            transfer_id=transfer_id,
+            source=state.source,
+            status=state.status.value,
+            current=state.next_track_index,
+            total=len(state.selection.get("tracks", ())),
+        )
 
     def plan_batch(self, request: BatchPlanRequest) -> BatchPlan:
         """Plan an explicitly selected Rekordbox Batch without side effects."""
@@ -2263,6 +2291,12 @@ class Transfer:
             self._save_transfer(transfer_id, state)
             raise
         except KeyboardInterrupt:
+            state.status = TransferStatus.PAUSED
+            self._save_transfer(transfer_id, state)
+            raise
+        except Exception:
+            # A durable single Transfer remains resumable after adapter or
+            # integration failures that are not classified above.
             state.status = TransferStatus.PAUSED
             self._save_transfer(transfer_id, state)
             raise

--- a/djsupport/web.py
+++ b/djsupport/web.py
@@ -143,7 +143,10 @@ def create_app(
         url_type = _detect_url_type(progress.source)
         return make_transfer(
             url_type,
-            request or SyncRequest(url=progress.source),
+            request or SyncRequest(
+                url=progress.source,
+                no_cache=not progress.retain_matching_knowledge,
+            ),
         ), progress
 
     @web_app.get("/auth/status")
@@ -193,6 +196,7 @@ def create_app(
             retry_days=request.retry_days,
             playlist_prefix=request.prefix,
             transfer_id=transfer_id,
+            retain_matching_knowledge=not request.no_cache,
         )
         transfer.prepare(transfer_request)
         run_background(_run_transfer, (transfer, transfer_request))
@@ -227,11 +231,15 @@ def create_app(
         require_authenticated()
         transfer, progress = transfer_for(transfer_id)
         if progress.status not in {"completed", "abandoned"}:
+            resume_request = TransferRequest(
+                source=progress.source,
+                transfer_id=transfer_id,
+                retain_matching_knowledge=progress.retain_matching_knowledge,
+            )
+            transfer.prepare(resume_request)
             run_background(
                 _run_transfer,
-                (transfer, TransferRequest(
-                    source=progress.source, transfer_id=transfer_id,
-                )),
+                (transfer, resume_request),
             )
         return {"transfer_id": transfer_id, "status": progress.status}
 

--- a/djsupport/web.py
+++ b/djsupport/web.py
@@ -1,19 +1,17 @@
-"""FastAPI web backend for djsupport."""
+"""Thin FastAPI adapter for durable djsupport Transfers."""
 
 from __future__ import annotations
 
 import asyncio
 import json
 import logging
-import queue
 import threading
-import uuid
 from contextlib import asynccontextmanager
 from html import escape
 from pathlib import Path
-from threading import Lock
-from typing import Any
+from typing import Any, Callable
 from urllib.parse import urlparse
+from uuid import uuid4
 
 from fastapi import FastAPI, HTTPException
 from fastapi.responses import HTMLResponse, RedirectResponse, StreamingResponse
@@ -22,10 +20,25 @@ from pydantic import BaseModel
 from spotipy.oauth2 import SpotifyOAuth
 
 from djsupport.report import SyncReport
-from djsupport.service import ProgressEvent, sync_beatport_chart, sync_beatport_label
-from djsupport.spotify import SCOPES, RateLimitError
+from djsupport.spotify import SCOPES
+from djsupport.transfer import (
+    AccountPublishingGuards,
+    BeatportChartSource,
+    BeatportLabelSource,
+    EphemeralMatchingKnowledge,
+    FilePublicationStorage,
+    FileTransferStorage,
+    MatchCacheKnowledge,
+    SpotifyMatcher,
+    Transfer,
+    TransferMode,
+    TransferRequest,
+    default_matching_knowledge_path,
+    default_publication_manifest_path,
+)
 
 logger = logging.getLogger(__name__)
+STATIC_DIR = Path(__file__).parent / "static"
 
 
 @asynccontextmanager
@@ -34,79 +47,6 @@ async def lifespan(app: FastAPI):
     load_dotenv()
     yield
 
-STATIC_DIR = Path(__file__).parent / "static"
-
-app = FastAPI(title="djsupport", lifespan=lifespan)
-app.mount("/static", StaticFiles(directory=str(STATIC_DIR)), name="static")
-
-
-# ---------------------------------------------------------------------------
-# In-memory job store (single-user, single-job)
-# ---------------------------------------------------------------------------
-
-class SyncJob:
-    def __init__(self, job_id: str, url: str):
-        self.job_id = job_id
-        self.url = url
-        self.progress_queue: queue.Queue[ProgressEvent | None] = queue.Queue(maxsize=500)
-        self.result: dict | None = None
-        self.error: str | None = None
-        self.done = False
-
-
-_current_job: SyncJob | None = None
-_job_lock = Lock()
-
-
-# ---------------------------------------------------------------------------
-# Auth endpoints
-# ---------------------------------------------------------------------------
-
-def _auth_manager() -> SpotifyOAuth:
-    return SpotifyOAuth(scope=SCOPES, open_browser=False)
-
-
-@app.get("/auth/status")
-def auth_status():
-    """Check if a valid Spotify token exists."""
-    mgr = _auth_manager()
-    token = mgr.get_cached_token()
-    if token and not mgr.is_token_expired(token):
-        return {"authenticated": True}
-    if token and mgr.is_token_expired(token):
-        try:
-            refreshed = mgr.refresh_access_token(token["refresh_token"])
-            if refreshed:
-                return {"authenticated": True}
-        except Exception:
-            pass
-    return {"authenticated": False}
-
-
-@app.get("/auth/login")
-def auth_login():
-    """Redirect the user to Spotify's authorization page."""
-    mgr = _auth_manager()
-    auth_url = mgr.get_authorize_url()
-    return RedirectResponse(auth_url)
-
-
-@app.get("/auth/callback")
-def auth_callback(code: str | None = None, error: str | None = None):
-    """Handle the Spotify OAuth callback."""
-    if error:
-        return HTMLResponse(f"<h1>Auth error</h1><p>{escape(error)}</p>", status_code=400)
-    if not code:
-        return HTMLResponse("<h1>Missing code</h1>", status_code=400)
-
-    mgr = _auth_manager()
-    mgr.get_access_token(code)
-    return RedirectResponse("/")
-
-
-# ---------------------------------------------------------------------------
-# Sync endpoints
-# ---------------------------------------------------------------------------
 
 class SyncRequest(BaseModel):
     url: str
@@ -118,160 +58,243 @@ class SyncRequest(BaseModel):
     no_cache: bool = False
 
 
+def _auth_manager() -> SpotifyOAuth:
+    return SpotifyOAuth(scope=SCOPES, open_browser=False)
+
+
 def _detect_url_type(url: str) -> str:
-    """Return 'chart', 'label', or raise ValueError."""
+    """Return ``chart`` or ``label`` for a supported Beatport URL."""
     parsed = urlparse(url)
     if parsed.hostname not in ("beatport.com", "www.beatport.com"):
-        raise ValueError(
-            "URL must be a Beatport chart or label URL "
-            "(e.g. https://www.beatport.com/chart/name/123 "
-            "or https://www.beatport.com/label/name/1)"
-        )
+        raise ValueError(_url_error())
     if "/chart/" in parsed.path:
         return "chart"
     if "/label/" in parsed.path:
         return "label"
-    raise ValueError(
+    raise ValueError(_url_error())
+
+
+def _url_error() -> str:
+    return (
         "URL must be a Beatport chart or label URL "
         "(e.g. https://www.beatport.com/chart/name/123 "
         "or https://www.beatport.com/label/name/1)"
     )
 
 
-@app.post("/sync")
-def start_sync(req: SyncRequest):
-    """Start a sync job. Returns the job ID."""
-    global _current_job
-
-    # Validate URL type
-    try:
-        url_type = _detect_url_type(req.url)
-    except ValueError as e:
-        raise HTTPException(status_code=400, detail=str(e))
-
-    # Check auth
-    mgr = _auth_manager()
-    token = mgr.get_cached_token()
-    if not token or mgr.is_token_expired(token):
-        raise HTTPException(status_code=401, detail="Not authenticated with Spotify")
-
-    with _job_lock:
-        if _current_job is not None and not _current_job.done:
-            raise HTTPException(status_code=409, detail="A sync is already running")
-
-        job_id = uuid.uuid4().hex[:12]
-        job = SyncJob(job_id, req.url)
-        _current_job = job
-
-    # Run sync in background thread
-    thread = threading.Thread(
-        target=_run_sync, args=(job, url_type, req), daemon=True,
-    )
-    thread.start()
-    return {"job_id": job_id, "url_type": url_type}
-
-
-def _run_sync(job: SyncJob, url_type: str, req: SyncRequest) -> None:
-    """Execute the sync in a background thread."""
+def _default_transfer_factory(url_type: str, request: SyncRequest) -> Transfer:
     from djsupport.cache import MatchCache
     from djsupport.spotify import get_client
-    from djsupport.state import PlaylistStateManager
 
-    cache_path = (
-        ".djsupport_beatport_cache.json" if url_type == "chart"
-        else ".djsupport_label_cache.json"
-    )
-    state_path = (
-        ".djsupport_beatport_playlists.json" if url_type == "chart"
-        else ".djsupport_label_playlists.json"
-    )
-
-    cache = None if req.no_cache else MatchCache(cache_path)
+    cache = None if request.no_cache else MatchCache(default_matching_knowledge_path())
     if cache is not None:
         cache.load()
-    state_mgr = PlaylistStateManager(state_path)
-    state_mgr.load()
+    publication_path = default_publication_manifest_path()
+    return Transfer(
+        source=(BeatportChartSource() if url_type == "chart" else BeatportLabelSource()),
+        spotify=SpotifyMatcher(get_client()),
+        publishing_guards=AccountPublishingGuards(),
+        matching_knowledge=(
+            EphemeralMatchingKnowledge() if cache is None else MatchCacheKnowledge(cache)
+        ),
+        publication_storage=(
+            None if request.dry_run else FilePublicationStorage(publication_path)
+        ),
+        transfer_storage=FileTransferStorage(
+            publication_path.with_suffix(".transfers.json")
+        ),
+    )
 
-    def _on_progress(event: ProgressEvent) -> None:
+
+def _thread_runner(target: Callable, args: tuple) -> None:
+    threading.Thread(target=target, args=args, daemon=True).start()
+
+
+def create_app(
+    *,
+    transfer_factory: Callable[[str, SyncRequest], Transfer] | None = None,
+    auth_manager: Callable[[], SpotifyOAuth] | None = None,
+    background_runner: Callable[[Callable, tuple], None] | None = None,
+) -> FastAPI:
+    """Create the web adapter with replaceable external-boundary wiring."""
+    web_app = FastAPI(title="djsupport", lifespan=lifespan)
+    web_app.mount("/static", StaticFiles(directory=str(STATIC_DIR)), name="static")
+    make_transfer = transfer_factory or _default_transfer_factory
+    run_background = background_runner or _thread_runner
+
+    def oauth_manager():
+        return auth_manager() if auth_manager is not None else _auth_manager()
+
+    def transfer_for(transfer_id: str, request: SyncRequest | None = None):
+        probe_request = request or SyncRequest(
+            url="https://www.beatport.com/chart/durable/1"
+        )
+        probe = make_transfer("chart", probe_request)
         try:
-            job.progress_queue.put_nowait(event)
-        except queue.Full:
-            pass  # drop event if consumer is too slow
+            progress = probe.progress(transfer_id)
+        except ValueError as exc:
+            raise HTTPException(status_code=404, detail="Transfer not found") from exc
+        url_type = _detect_url_type(progress.source)
+        return make_transfer(
+            url_type,
+            request or SyncRequest(url=progress.source),
+        ), progress
 
-    sync_kwargs: dict[str, Any] = {
-        "sp": get_client(),
-        "cache": cache,
-        "state_mgr": state_mgr,
-        "on_progress": _on_progress,
-        "threshold": req.threshold,
-        "dry_run": req.dry_run,
-        "prefix": req.prefix,
-        "retry": req.retry,
-        "retry_days": req.retry_days,
-    }
+    @web_app.get("/auth/status")
+    def auth_status():
+        mgr = oauth_manager()
+        token = mgr.get_cached_token()
+        if token and not mgr.is_token_expired(token):
+            return {"authenticated": True}
+        if token and mgr.is_token_expired(token):
+            try:
+                if mgr.refresh_access_token(token["refresh_token"]):
+                    return {"authenticated": True}
+            except Exception:
+                pass
+        return {"authenticated": False}
 
+    @web_app.get("/auth/login")
+    def auth_login():
+        return RedirectResponse(oauth_manager().get_authorize_url())
+
+    @web_app.get("/auth/callback")
+    def auth_callback(code: str | None = None, error: str | None = None):
+        if error:
+            return HTMLResponse(
+                f"<h1>Auth error</h1><p>{escape(error)}</p>", status_code=400,
+            )
+        if not code:
+            return HTMLResponse("<h1>Missing code</h1>", status_code=400)
+        oauth_manager().get_access_token(code)
+        return RedirectResponse("/")
+
+    @web_app.post("/sync")
+    def start_sync(request: SyncRequest):
+        try:
+            url_type = _detect_url_type(request.url)
+        except ValueError as exc:
+            raise HTTPException(status_code=400, detail=str(exc)) from exc
+        mgr = oauth_manager()
+        token = mgr.get_cached_token()
+        if not token or mgr.is_token_expired(token):
+            raise HTTPException(status_code=401, detail="Not authenticated with Spotify")
+        transfer_id = uuid4().hex
+        transfer = make_transfer(url_type, request)
+        transfer_request = TransferRequest(
+            source=request.url,
+            mode=TransferMode.SNAPSHOT,
+            preview=request.dry_run,
+            threshold=request.threshold,
+            retry=request.retry,
+            retry_days=request.retry_days,
+            playlist_prefix=request.prefix,
+            transfer_id=transfer_id,
+        )
+        run_background(_run_transfer, (transfer, transfer_request))
+        return {
+            "job_id": transfer_id,
+            "transfer_id": transfer_id,
+            "url_type": url_type,
+        }
+
+    @web_app.get("/sync/{transfer_id}/progress")
+    async def sync_progress(transfer_id: str):
+        async def event_stream():
+            while True:
+                transfer, progress = transfer_for(transfer_id)
+                data = {
+                    "phase": (
+                        "complete" if progress.status == "completed"
+                        else progress.status
+                    ),
+                    "current": progress.current,
+                    "total": progress.total,
+                    "detail": f"{progress.current}/{progress.total}",
+                }
+                yield f"data: {json.dumps(data)}\n\n"
+                if progress.status in {"completed", "paused", "abandoned"}:
+                    break
+                await asyncio.sleep(0.25)
+        return StreamingResponse(event_stream(), media_type="text/event-stream")
+
+    @web_app.post("/sync/{transfer_id}/resume")
+    def resume_sync(transfer_id: str):
+        mgr = oauth_manager()
+        token = mgr.get_cached_token()
+        if not token or mgr.is_token_expired(token):
+            raise HTTPException(status_code=401, detail="Not authenticated with Spotify")
+        transfer, progress = transfer_for(transfer_id)
+        if progress.status not in {"completed", "abandoned"}:
+            run_background(
+                _run_transfer,
+                (transfer, TransferRequest(
+                    source=progress.source, transfer_id=transfer_id,
+                )),
+            )
+        return {"transfer_id": transfer_id, "status": progress.status}
+
+    @web_app.get("/sync/{transfer_id}/result")
+    def sync_result(transfer_id: str):
+        transfer, progress = transfer_for(transfer_id)
+        if progress.status != "completed":
+            raise HTTPException(status_code=202, detail="Transfer still in progress")
+        report = transfer.execute(TransferRequest(
+            source=progress.source, transfer_id=transfer_id,
+        ))
+        return _report_to_dict(report)
+
+    @web_app.get("/")
+    def index():
+        return HTMLResponse((STATIC_DIR / "index.html").read_text())
+
+    return web_app
+
+
+def _run_transfer(transfer: Transfer, request: TransferRequest) -> None:
     try:
-        if url_type == "chart":
-            report = sync_beatport_chart(job.url, **sync_kwargs)
-        else:
-            report = sync_beatport_label(job.url, **sync_kwargs)
-
-        if cache is not None:
-            cache.save()
-        state_mgr.save()
-
-        job.result = _report_to_dict(report)
-    except RateLimitError as e:
-        if cache is not None:
-            cache.save()
-        job.error = str(e)
-        _on_progress(ProgressEvent(phase="error", detail=str(e)))
-    except Exception as e:
-        logger.exception("Sync failed")
-        job.error = "An unexpected error occurred during sync"
-        _on_progress(ProgressEvent(phase="error", detail=job.error))
-    finally:
-        job.done = True
-        job.progress_queue.put(None)  # sentinel
+        transfer.execute(request)
+    except Exception:
+        logger.exception("Transfer failed")
 
 
 def _report_to_dict(report: SyncReport) -> dict[str, Any]:
-    """Serialize a SyncReport to a JSON-safe dict."""
     playlists = []
-    for pl in report.playlists:
-        matched = [
-            {
-                "source_name": m.source_name,
-                "spotify_name": m.spotify_name,
-                "spotify_artist": m.spotify_artist,
-                "score": m.score,
-                "match_type": m.match_type,
-            }
-            for m in pl.matched
-        ]
+    for playlist in report.playlists:
         playlists.append({
-            "name": pl.name,
-            "path": pl.path,
-            "action": pl.action,
-            "spotify_playlist_id": pl.spotify_playlist_id,
+            "name": playlist.name,
+            "path": playlist.path,
+            "action": playlist.action,
+            "outcome": playlist.outcome,
+            "spotify_playlist_id": playlist.spotify_playlist_id,
             "spotify_url": (
-                f"https://open.spotify.com/playlist/{pl.spotify_playlist_id}"
-                if pl.spotify_playlist_id else None
+                f"https://open.spotify.com/playlist/{playlist.spotify_playlist_id}"
+                if playlist.spotify_playlist_id else None
             ),
-            "matched": matched,
-            "unmatched": pl.unmatched,
-            "total": pl.total,
-            "match_rate": pl.match_rate,
-            "cache_hits": pl.cache_hits,
-            "api_lookups": pl.api_lookups,
-            "retried": pl.retried,
+            "matched": [
+                {
+                    "source_name": match.source_name,
+                    "spotify_name": match.spotify_name,
+                    "spotify_artist": match.spotify_artist,
+                    "score": match.score,
+                    "match_type": match.match_type,
+                }
+                for match in playlist.matched
+            ],
+            "unmatched": playlist.unmatched,
+            "total": playlist.total,
+            "match_rate": playlist.match_rate,
+            "cache_hits": playlist.cache_hits,
+            "api_lookups": playlist.api_lookups,
+            "retried": playlist.retried,
         })
-
     return {
         "timestamp": report.timestamp.isoformat(),
         "threshold": report.threshold,
         "dry_run": report.dry_run,
         "source_label": report.source_label,
+        "transfer_id": report.transfer_id,
+        "status": report.status,
         "playlists": playlists,
         "total_matched": report.total_matched,
         "total_unmatched": report.total_unmatched,
@@ -279,65 +302,4 @@ def _report_to_dict(report: SyncReport) -> dict[str, Any]:
     }
 
 
-@app.get("/sync/{job_id}/progress")
-async def sync_progress(job_id: str):
-    """Stream progress events via SSE."""
-    if _current_job is None or _current_job.job_id != job_id:
-        raise HTTPException(status_code=404, detail="Job not found")
-
-    job = _current_job
-
-    async def event_stream():
-        while True:
-            try:
-                event = await asyncio.get_running_loop().run_in_executor(
-                    None, lambda: job.progress_queue.get(timeout=30)
-                )
-            except queue.Empty:
-                # Send keepalive
-                yield f": keepalive\n\n"
-                continue
-
-            if event is None:  # sentinel — sync done
-                if job.error:
-                    data = json.dumps({"phase": "error", "detail": job.error})
-                else:
-                    data = json.dumps({"phase": "complete", "detail": "Sync complete"})
-                yield f"data: {data}\n\n"
-                break
-
-            data = json.dumps({
-                "phase": event.phase,
-                "current": event.current,
-                "total": event.total,
-                "detail": event.detail,
-            })
-            yield f"data: {data}\n\n"
-
-    return StreamingResponse(event_stream(), media_type="text/event-stream")
-
-
-@app.get("/sync/{job_id}/result")
-def sync_result(job_id: str):
-    """Get the final sync result."""
-    if _current_job is None or _current_job.job_id != job_id:
-        raise HTTPException(status_code=404, detail="Job not found")
-
-    if not _current_job.done:
-        raise HTTPException(status_code=202, detail="Sync still in progress")
-
-    if _current_job.error:
-        return {"error": _current_job.error}
-
-    return _current_job.result
-
-
-# ---------------------------------------------------------------------------
-# Serve frontend
-# ---------------------------------------------------------------------------
-
-@app.get("/")
-def index():
-    """Serve the frontend."""
-    index_path = STATIC_DIR / "index.html"
-    return HTMLResponse(index_path.read_text())
+app = create_app()

--- a/djsupport/web.py
+++ b/djsupport/web.py
@@ -125,6 +125,12 @@ def create_app(
     def oauth_manager():
         return auth_manager() if auth_manager is not None else _auth_manager()
 
+    def require_authenticated() -> None:
+        mgr = oauth_manager()
+        token = mgr.get_cached_token()
+        if not token or mgr.is_token_expired(token):
+            raise HTTPException(status_code=401, detail="Not authenticated with Spotify")
+
     def transfer_for(transfer_id: str, request: SyncRequest | None = None):
         probe_request = request or SyncRequest(
             url="https://www.beatport.com/chart/durable/1"
@@ -175,10 +181,7 @@ def create_app(
             url_type = _detect_url_type(request.url)
         except ValueError as exc:
             raise HTTPException(status_code=400, detail=str(exc)) from exc
-        mgr = oauth_manager()
-        token = mgr.get_cached_token()
-        if not token or mgr.is_token_expired(token):
-            raise HTTPException(status_code=401, detail="Not authenticated with Spotify")
+        require_authenticated()
         transfer_id = uuid4().hex
         transfer = make_transfer(url_type, request)
         transfer_request = TransferRequest(
@@ -191,9 +194,9 @@ def create_app(
             playlist_prefix=request.prefix,
             transfer_id=transfer_id,
         )
+        transfer.prepare(transfer_request)
         run_background(_run_transfer, (transfer, transfer_request))
         return {
-            "job_id": transfer_id,
             "transfer_id": transfer_id,
             "url_type": url_type,
         }
@@ -206,11 +209,12 @@ def create_app(
                 data = {
                     "phase": (
                         "complete" if progress.status == "completed"
+                        else "error" if progress.error
                         else progress.status
                     ),
                     "current": progress.current,
                     "total": progress.total,
-                    "detail": f"{progress.current}/{progress.total}",
+                    "detail": progress.error or f"{progress.current}/{progress.total}",
                 }
                 yield f"data: {json.dumps(data)}\n\n"
                 if progress.status in {"completed", "paused", "abandoned"}:
@@ -220,10 +224,7 @@ def create_app(
 
     @web_app.post("/sync/{transfer_id}/resume")
     def resume_sync(transfer_id: str):
-        mgr = oauth_manager()
-        token = mgr.get_cached_token()
-        if not token or mgr.is_token_expired(token):
-            raise HTTPException(status_code=401, detail="Not authenticated with Spotify")
+        require_authenticated()
         transfer, progress = transfer_for(transfer_id)
         if progress.status not in {"completed", "abandoned"}:
             run_background(
@@ -237,6 +238,8 @@ def create_app(
     @web_app.get("/sync/{transfer_id}/result")
     def sync_result(transfer_id: str):
         transfer, progress = transfer_for(transfer_id)
+        if progress.error:
+            return {"error": progress.error, "transfer_id": transfer_id}
         if progress.status != "completed":
             raise HTTPException(status_code=202, detail="Transfer still in progress")
         report = transfer.execute(TransferRequest(

--- a/tests/test_transfer.py
+++ b/tests/test_transfer.py
@@ -1786,6 +1786,37 @@ class TestRekordboxBatchExecution:
 
 
 class TestTransferPublicationLifecycle:
+    def test_progress_reloads_from_durable_state_without_resuming_work(self, tmp_path):
+        spotify = StatefulSpotify({
+            ("Known Artist", "Known Track"): _match(
+                "spotify:track:known", "Known Track", "Known Artist",
+            ),
+        })
+        state_path = tmp_path / "transfers.json"
+        transfer = Transfer(
+            publishing_guards=TEST_PUBLISHING_GUARDS,
+            source=FixtureBeatportSource(FIXTURE), spotify=spotify,
+            matching_knowledge=InMemoryStorage(),
+            publication_storage=InMemoryStorage(),
+            transfer_storage=FileTransferStorage(state_path),
+        )
+        transfer.pause()
+        paused = transfer.execute(TransferRequest(source="fixture"))
+
+        progress = Transfer(
+            publishing_guards=TEST_PUBLISHING_GUARDS,
+            source=FixtureBeatportSource(FIXTURE), spotify=spotify,
+            matching_knowledge=InMemoryStorage(),
+            publication_storage=InMemoryStorage(),
+            transfer_storage=FileTransferStorage(state_path),
+        ).progress(paused.transfer_id)
+
+        assert progress.status == "paused"
+        assert progress.current == 1
+        assert progress.total == 2
+        assert progress.source == "fixture"
+        assert spotify.searches == [("Known Artist", "Known Track", 80)]
+
     def test_paused_transfer_reloads_and_resumes_without_repeating_work(self, tmp_path):
         matches = {
             ("Known Artist", "Known Track"): _match(

--- a/tests/test_transfer.py
+++ b/tests/test_transfer.py
@@ -1822,17 +1822,21 @@ class TestTransferPublicationLifecycle:
     def test_failure_is_a_durable_observable_outcome(self, tmp_path):
         class FailingSource:
             source_label = "Beatport"
+            recovered = False
 
             def consume(self, reference):
-                raise ValueError("fixture intake failed")
+                if not self.recovered:
+                    raise ValueError("fixture intake failed")
+                return SourceSelection("Recovered", reference, [])
 
         state_path = tmp_path / "transfers.json"
         request = TransferRequest(
             source="fixture", preview=True, transfer_id="failed-transfer",
         )
+        source = FailingSource()
         transfer = Transfer(
             publishing_guards=TEST_PUBLISHING_GUARDS,
-            source=FailingSource(), spotify=StatefulSpotify(),
+            source=source, spotify=StatefulSpotify(),
             matching_knowledge=InMemoryStorage(),
             transfer_storage=FileTransferStorage(state_path),
         )
@@ -1849,6 +1853,15 @@ class TestTransferPublicationLifecycle:
 
         assert progress.status == "paused"
         assert progress.error == "fixture intake failed"
+
+        source.recovered = True
+        transfer.prepare(request)
+        resumed_progress = transfer.progress("failed-transfer")
+        resumed = transfer.execute(request)
+
+        assert resumed_progress.status == "matching"
+        assert resumed_progress.error is None
+        assert resumed.status == "completed"
 
     def test_progress_reloads_from_durable_state_without_resuming_work(self, tmp_path):
         spotify = StatefulSpotify({

--- a/tests/test_transfer.py
+++ b/tests/test_transfer.py
@@ -1786,6 +1786,70 @@ class TestRekordboxBatchExecution:
 
 
 class TestTransferPublicationLifecycle:
+    def test_prepared_transfer_is_visible_before_source_intake_and_resumes(self, tmp_path):
+        class CountingSource(FixtureBeatportSource):
+            consumptions = 0
+
+            def consume(self, reference):
+                self.consumptions += 1
+                return super().consume(reference)
+
+        source = CountingSource(FIXTURE)
+        spotify = StatefulSpotify()
+        state_path = tmp_path / "transfers.json"
+        request = TransferRequest(
+            source="fixture", preview=True, transfer_id="prepared-transfer",
+        )
+        Transfer(
+            publishing_guards=TEST_PUBLISHING_GUARDS,
+            source=source, spotify=spotify, matching_knowledge=InMemoryStorage(),
+            transfer_storage=FileTransferStorage(state_path),
+        ).prepare(request)
+
+        reloaded = Transfer(
+            publishing_guards=TEST_PUBLISHING_GUARDS,
+            source=source, spotify=spotify, matching_knowledge=InMemoryStorage(),
+            transfer_storage=FileTransferStorage(state_path),
+        )
+        progress = reloaded.progress("prepared-transfer")
+        report = reloaded.execute(request)
+
+        assert progress.status == "matching"
+        assert (progress.current, progress.total) == (0, 0)
+        assert source.consumptions == 1
+        assert report.status == "completed"
+
+    def test_failure_is_a_durable_observable_outcome(self, tmp_path):
+        class FailingSource:
+            source_label = "Beatport"
+
+            def consume(self, reference):
+                raise ValueError("fixture intake failed")
+
+        state_path = tmp_path / "transfers.json"
+        request = TransferRequest(
+            source="fixture", preview=True, transfer_id="failed-transfer",
+        )
+        transfer = Transfer(
+            publishing_guards=TEST_PUBLISHING_GUARDS,
+            source=FailingSource(), spotify=StatefulSpotify(),
+            matching_knowledge=InMemoryStorage(),
+            transfer_storage=FileTransferStorage(state_path),
+        )
+        transfer.prepare(request)
+        with pytest.raises(ValueError, match="fixture intake failed"):
+            transfer.execute(request)
+
+        progress = Transfer(
+            publishing_guards=TEST_PUBLISHING_GUARDS,
+            source=FailingSource(), spotify=StatefulSpotify(),
+            matching_knowledge=InMemoryStorage(),
+            transfer_storage=FileTransferStorage(state_path),
+        ).progress("failed-transfer")
+
+        assert progress.status == "paused"
+        assert progress.error == "fixture intake failed"
+
     def test_progress_reloads_from_durable_state_without_resuming_work(self, tmp_path):
         spotify = StatefulSpotify({
             ("Known Artist", "Known Track"): _match(

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -143,10 +143,13 @@ class TestSyncEndpoints:
         mgr = MagicMock()
         mgr.get_cached_token.return_value = {"access_token": "tok"}
         mgr.is_token_expired.return_value = False
+        pending_background_work = []
         first_app = create_app(
             transfer_factory=factory,
             auth_manager=lambda: mgr,
-            background_runner=lambda target, args: target(*args),
+            background_runner=lambda target, args: pending_background_work.append(
+                (target, args)
+            ),
         )
         res = TestClient(first_app).post(
             "/sync", json={"url": "https://www.beatport.com/chart/test/123"},
@@ -155,11 +158,22 @@ class TestSyncEndpoints:
         data = res.json()
         assert "transfer_id" in data
         assert data["url_type"] == "chart"
+        assert len(pending_background_work) == 1
+
+        prepared = TestClient(first_app).get(
+            f"/sync/{data['transfer_id']}/result",
+        )
+        assert prepared.status_code == 202
+
         restarted_app = create_app(
             transfer_factory=factory,
             auth_manager=lambda: mgr,
             background_runner=lambda target, args: target(*args),
         )
+        resumed = TestClient(restarted_app).post(
+            f"/sync/{data['transfer_id']}/resume",
+        )
+        assert resumed.status_code == 200
         result = TestClient(restarted_app).get(
             f"/sync/{data['transfer_id']}/result",
         )
@@ -193,6 +207,57 @@ class TestSyncEndpoints:
         request = transfer.execute.call_args.args[0]
         assert request.source == "https://www.beatport.com/label/test/1"
         assert request.mode.value == "snapshot"
+
+    def test_failed_outcome_reloads_after_restart(self, tmp_path):
+        class FailingSource:
+            source_label = "Beatport"
+
+            def consume(self, reference):
+                raise ValueError("fixture chart is invalid")
+
+        spotify = MagicMock()
+        spotify.account_id.return_value = "spotify-user-1"
+
+        class Knowledge:
+            persistent = False
+            def lookup(self, track, threshold): return None
+            def should_retry(self, track, threshold, retry_days, force): return True
+            def retain(self, track, threshold, result): pass
+            def checkpoint(self): pass
+
+        def factory(_kind, _request):
+            return Transfer(
+                source=FailingSource(), spotify=spotify,
+                matching_knowledge=Knowledge(),
+                publishing_guards=AccountPublishingGuards(tmp_path / "locks"),
+                publication_storage=FilePublicationStorage(
+                    tmp_path / "publications.json"
+                ),
+                transfer_storage=FileTransferStorage(tmp_path / "transfers.json"),
+            )
+
+        mgr = MagicMock()
+        mgr.get_cached_token.return_value = {"access_token": "tok"}
+        mgr.is_token_expired.return_value = False
+        failed_app = create_app(
+            transfer_factory=factory, auth_manager=lambda: mgr,
+            background_runner=lambda target, args: target(*args),
+        )
+        started = TestClient(failed_app).post(
+            "/sync", json={"url": "https://www.beatport.com/chart/test/123"},
+        )
+        transfer_id = started.json()["transfer_id"]
+
+        restarted = create_app(
+            transfer_factory=factory, auth_manager=lambda: mgr,
+            background_runner=lambda target, args: target(*args),
+        )
+        result = TestClient(restarted).get(f"/sync/{transfer_id}/result")
+
+        assert result.status_code == 200
+        assert result.json() == {
+            "error": "fixture chart is invalid", "transfer_id": transfer_id,
+        }
 
 
 class TestURLDetection:

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -128,8 +128,10 @@ class TestSyncEndpoints:
 
         spotify = FixtureSpotify()
         state_path = tmp_path / "transfers.json"
+        factory_requests = []
 
-        def factory(_kind, _request):
+        def factory(_kind, factory_request):
+            factory_requests.append(factory_request)
             return Transfer(
                 source=FixtureSource(), spotify=spotify,
                 matching_knowledge=Knowledge(),
@@ -152,7 +154,10 @@ class TestSyncEndpoints:
             ),
         )
         res = TestClient(first_app).post(
-            "/sync", json={"url": "https://www.beatport.com/chart/test/123"},
+            "/sync", json={
+                "url": "https://www.beatport.com/chart/test/123",
+                "no_cache": True,
+            },
         )
         assert res.status_code == 200
         data = res.json()
@@ -184,6 +189,7 @@ class TestSyncEndpoints:
         assert spotify.playlists["snapshot-1"] == [
             "spotify:track:bp-1", "spotify:track:bp-2",
         ]
+        assert factory_requests[-1].no_cache is True
 
     def test_label_flow_enters_the_same_transfer_interface(self):
         transfer = MagicMock()

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -1,21 +1,24 @@
 """Tests for the FastAPI web backend."""
 
 import json
+from datetime import datetime
+from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
 from fastapi.testclient import TestClient
 
-from djsupport.web import app, _current_job, _job_lock, SyncJob
-
-
-@pytest.fixture(autouse=True)
-def reset_job_state():
-    """Reset the global job state before each test."""
-    import djsupport.web as web_mod
-    web_mod._current_job = None
-    yield
-    web_mod._current_job = None
+from djsupport.report import PlaylistReport, SyncReport
+from djsupport.rekordbox import Track
+from djsupport.transfer import (
+    AccountPublishingGuards,
+    FilePublicationStorage,
+    FileTransferStorage,
+    SourceSelection,
+    Transfer,
+    TransferProgress,
+)
+from djsupport.web import app, create_app
 
 
 client = TestClient(app)
@@ -79,82 +82,117 @@ class TestSyncEndpoints:
         res = client.post("/sync", json={"url": "https://www.beatport.com/chart/test/123"})
         assert res.status_code == 401
 
-    @patch("djsupport.web._run_sync")
-    @patch("djsupport.web._auth_manager")
-    def test_sync_starts_job(self, mock_mgr_fn, mock_run):
+    def test_chart_flow_reloads_durable_outcome_after_app_restart(self, tmp_path):
+        class FixtureSource:
+            source_label = "Beatport"
+
+            def consume(self, reference):
+                data = json.loads(
+                    (Path(__file__).parent / "fixtures/beatport_chart.json").read_text()
+                )
+                return SourceSelection(data["name"], reference, [
+                    Track(
+                        track_id=item["track_id"], artist=item["artist"],
+                        name=item["name"], album="", remixer="", label="",
+                        genre="", date_added="",
+                    )
+                    for item in data["tracks"]
+                ])
+
+        class FixtureSpotify:
+            def __init__(self):
+                self.playlists = {}
+
+            def account_id(self):
+                return "spotify-user-1"
+
+            def match(self, track, threshold):
+                return {
+                    "uri": f"spotify:track:{track.track_id}", "name": track.name,
+                    "artist": track.artist, "score": 96.0, "match_type": "exact",
+                }
+
+            def publish_provisional_snapshot(
+                self, name, track_uris, description, publication_key,
+            ):
+                self.playlists["snapshot-1"] = list(track_uris)
+                return "snapshot-1"
+
+        class Knowledge:
+            persistent = False
+
+            def lookup(self, track, threshold): return None
+            def should_retry(self, track, threshold, retry_days, force): return True
+            def retain(self, track, threshold, result): pass
+            def checkpoint(self): pass
+
+        spotify = FixtureSpotify()
+        state_path = tmp_path / "transfers.json"
+
+        def factory(_kind, _request):
+            return Transfer(
+                source=FixtureSource(), spotify=spotify,
+                matching_knowledge=Knowledge(),
+                publishing_guards=AccountPublishingGuards(tmp_path / "locks"),
+                publication_storage=FilePublicationStorage(
+                    tmp_path / "publications.json"
+                ),
+                transfer_storage=FileTransferStorage(state_path),
+            )
+
         mgr = MagicMock()
         mgr.get_cached_token.return_value = {"access_token": "tok"}
         mgr.is_token_expired.return_value = False
-        mock_mgr_fn.return_value = mgr
-
-        res = client.post("/sync", json={"url": "https://www.beatport.com/chart/test/123"})
+        first_app = create_app(
+            transfer_factory=factory,
+            auth_manager=lambda: mgr,
+            background_runner=lambda target, args: target(*args),
+        )
+        res = TestClient(first_app).post(
+            "/sync", json={"url": "https://www.beatport.com/chart/test/123"},
+        )
         assert res.status_code == 200
         data = res.json()
-        assert "job_id" in data
+        assert "transfer_id" in data
         assert data["url_type"] == "chart"
+        restarted_app = create_app(
+            transfer_factory=factory,
+            auth_manager=lambda: mgr,
+            background_runner=lambda target, args: target(*args),
+        )
+        result = TestClient(restarted_app).get(
+            f"/sync/{data['transfer_id']}/result",
+        )
+        assert result.status_code == 200
+        assert result.json()["playlists"][0]["spotify_playlist_id"] == "snapshot-1"
+        assert result.json()["status"] == "completed"
+        assert result.json()["total_matched"] == 2
+        assert spotify.playlists["snapshot-1"] == [
+            "spotify:track:bp-1", "spotify:track:bp-2",
+        ]
 
-    @patch("djsupport.web._run_sync")
-    @patch("djsupport.web._auth_manager")
-    def test_sync_detects_label_url(self, mock_mgr_fn, mock_run):
+    def test_label_flow_enters_the_same_transfer_interface(self):
+        transfer = MagicMock()
+        transfer.execute.return_value = SyncReport(
+            timestamp=datetime(2026, 8, 1), threshold=80, dry_run=False,
+            playlists=[], source_label="Beatport label", transfer_id="label-transfer",
+        )
         mgr = MagicMock()
         mgr.get_cached_token.return_value = {"access_token": "tok"}
         mgr.is_token_expired.return_value = False
-        mock_mgr_fn.return_value = mgr
-
-        res = client.post("/sync", json={"url": "https://www.beatport.com/label/test/1"})
+        label_app = create_app(
+            transfer_factory=lambda kind, request: transfer,
+            auth_manager=lambda: mgr,
+            background_runner=lambda target, args: target(*args),
+        )
+        res = TestClient(label_app).post(
+            "/sync", json={"url": "https://www.beatport.com/label/test/1"},
+        )
         assert res.status_code == 200
         assert res.json()["url_type"] == "label"
-
-    @patch("djsupport.web._run_sync")
-    @patch("djsupport.web._auth_manager")
-    def test_sync_409_on_concurrent(self, mock_mgr_fn, mock_run):
-        mgr = MagicMock()
-        mgr.get_cached_token.return_value = {"access_token": "tok"}
-        mgr.is_token_expired.return_value = False
-        mock_mgr_fn.return_value = mgr
-
-        # Start first job
-        res1 = client.post("/sync", json={"url": "https://www.beatport.com/chart/test/123"})
-        assert res1.status_code == 200
-
-        # Second job should be rejected
-        res2 = client.post("/sync", json={"url": "https://www.beatport.com/chart/test/456"})
-        assert res2.status_code == 409
-
-    def test_result_404_unknown_job(self):
-        res = client.get("/sync/nonexistent/result")
-        assert res.status_code == 404
-
-    def test_result_202_while_running(self):
-        import djsupport.web as web_mod
-        job = SyncJob("test123", "https://example.com")
-        job.done = False
-        web_mod._current_job = job
-
-        res = client.get("/sync/test123/result")
-        assert res.status_code == 202
-
-    def test_result_returns_data_when_done(self):
-        import djsupport.web as web_mod
-        job = SyncJob("test456", "https://example.com")
-        job.done = True
-        job.result = {"playlists": [], "total_matched": 5}
-        web_mod._current_job = job
-
-        res = client.get("/sync/test456/result")
-        assert res.status_code == 200
-        assert res.json()["total_matched"] == 5
-
-    def test_result_returns_error_when_failed(self):
-        import djsupport.web as web_mod
-        job = SyncJob("test789", "https://example.com")
-        job.done = True
-        job.error = "Rate limit exceeded"
-        web_mod._current_job = job
-
-        res = client.get("/sync/test789/result")
-        assert res.status_code == 200
-        assert res.json()["error"] == "Rate limit exceeded"
+        request = transfer.execute.call_args.args[0]
+        assert request.source == "https://www.beatport.com/label/test/1"
+        assert request.mode.value == "snapshot"
 
 
 class TestURLDetection:
@@ -177,4 +215,5 @@ class TestIndexPage:
         res = client.get("/")
         assert res.status_code == 200
         assert "djsupport" in res.text
+        assert "djsupport.activeTransfer" in res.text
         assert "text/html" in res.headers["content-type"]


### PR DESCRIPTION
Closes #27

## Summary
- route Beatport chart and label web flows through the public Transfer interface
- persist Transfer identity before source intake and reload progress, failures, and final outcomes from durable state
- resume active work after browser refresh or process restart while preserving no-cache and account-scoped behavior
- replace private in-memory web job tests with offline public-seam behavior tests

## Validation
- 430 tests passed offline
- `python3 -m compileall -q djsupport tests`
- `git diff --check main...HEAD`
- parallel Standards and Spec reviews: clean