### PR TITLE
Back up and restore local application data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Added
 
+- Versioned, timestamped local-data backup archives and integrity-checked,
+  preview-first, conflict-aware atomic restore; OAuth credentials and unrelated
+  files are excluded
 - Durable Rekordbox Batch execution with independent playlist outcomes,
   partial-success reporting, safe shared-failure stops, and resumable checkpoints
 - Explicit Corrections from edited review CSV files, with validated stable source

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Sync your Rekordbox playlists to Spotify. Parses a Rekordbox XML library export,
 - **Playlist prefix** — prefix Spotify playlist names (e.g. `djsupport / Deep House`) to keep them organized
 - **Combined playlist** — merge all tracks into a single playlist sorted by date added
 - **Graceful rate limiting** — aborts with a clear message, saves cache, and exits non-zero instead of hanging; resume later to continue where you left off
+- **Local-data backup and restore** — creates versioned archives without OAuth credentials and validates, previews, and conflict-checks restores before changing data
 
 ## Prerequisites
 
@@ -66,6 +67,25 @@ djsupport library show
 ```
 
 ## Usage
+
+### Back up and restore local data
+
+Create one timestamped archive in the private application-data directory:
+
+```bash
+djsupport backup
+```
+
+Validate and preview an archive without changing current data, then apply it:
+
+```bash
+djsupport restore /path/to/djsupport-backup-20260801T123456.zip
+djsupport restore /path/to/djsupport-backup-20260801T123456.zip --apply
+```
+
+If Approval or playlist-state truth conflicts, restore stops without mutation
+and prints the conflict identifier. Resolve it explicitly with
+`--resolve 'CONFLICT_ID=current'` or `--resolve 'CONFLICT_ID=archive'`.
 
 ### List playlists
 

--- a/agent.md
+++ b/agent.md
@@ -36,6 +36,7 @@ djsupport/
   state.py      # Playlist ID mapping for incremental sync (source-agnostic)
   report.py     # Post-sync terminal + Markdown reports
   transfer.py   # Durable Transfer/Batch orchestration, checkpoints, and publication
+  backup.py     # Versioned local-data backup, preview, merge, and atomic restore
   static/       # Web frontend (index.html with Tailwind CSS)
 tests/          # pytest suite
 docs/           # Plans, reports, and solution docs
@@ -57,6 +58,9 @@ djsupport beatport <url>        # Import Beatport chart to Spotify
 djsupport label <url-or-name>  # Import Beatport label to Spotify
 djsupport web                   # Start web UI at localhost:8000
 djsupport web --port 3000       # Custom port
+djsupport backup                # Create a timestamped local-data archive
+djsupport restore <archive>     # Validate and preview an archive
+djsupport restore <archive> --apply  # Apply a conflict-free restore
 
 # Sync flags
 djsupport sync --playlist "My Playlist"  # Sync a single playlist

--- a/djsupport/backup.py
+++ b/djsupport/backup.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import hashlib
 import json
 import os
+import re
 import shutil
 import tempfile
 import zipfile
@@ -15,13 +16,6 @@ from typing import Callable
 
 
 BACKUP_VERSION = 1
-DATA_FILES = (
-    "matching-knowledge.json",
-    "transfers.json",
-    "publication-manifests.transfers.json",
-    "publication-manifests.json",
-    "playlist-state.json",
-)
 SUPPORTED_SCHEMAS = {
     "matching-knowledge.json": (1,),
     "transfers.json": (1,),
@@ -29,6 +23,7 @@ SUPPORTED_SCHEMAS = {
     "publication-manifests.json": (1, 2, 3),
     "playlist-state.json": (1, 2),
 }
+DATA_FILES = tuple(SUPPORTED_SCHEMAS)
 SECRET_KEYS = {
     "access_token", "refresh_token", "client_secret", "client_id",
     "authorization", "password",
@@ -79,7 +74,6 @@ class LocalDataBackup:
     ) -> Path:
         created_at = now or datetime.now()
         destination = Path(destination)
-        destination.mkdir(parents=True, exist_ok=True)
         archive = destination / (
             f"djsupport-backup-{created_at:%Y%m%dT%H%M%S}.zip"
         )
@@ -117,6 +111,7 @@ class LocalDataBackup:
             "created_at": created_at.isoformat(),
             "entries": entries,
         }
+        destination.mkdir(parents=True, exist_ok=True)
         with zipfile.ZipFile(archive, "x", zipfile.ZIP_DEFLATED) as bundle:
             bundle.writestr("backup-manifest.json", json.dumps(manifest, indent=2))
             for path in members:
@@ -127,7 +122,7 @@ class LocalDataBackup:
     def _contains_secret_key(cls, value) -> bool:
         if isinstance(value, dict):
             return any(
-                str(key).casefold() in SECRET_KEYS
+                cls._is_secret_key(str(key))
                 or cls._contains_secret_key(item)
                 for key, item in value.items()
             )
@@ -136,9 +131,24 @@ class LocalDataBackup:
         return False
 
     @staticmethod
+    def _is_secret_key(key: str) -> bool:
+        normalized = re.sub(r"[^a-z0-9]+", "_", key.casefold()).strip("_")
+        return any(
+            normalized == secret or normalized.endswith(f"_{secret}")
+            for secret in SECRET_KEYS
+        )
+
+    @staticmethod
     def _report_contains_secret(path: Path) -> bool:
         text = path.read_text(errors="replace").casefold()
-        return any(f"{key}=" in text or f'"{key}"' in text for key in SECRET_KEYS)
+        key_pattern = "|".join(
+            re.escape(key).replace(r"\_", r"[ _-]?") for key in SECRET_KEYS
+        )
+        return bool(re.search(
+            rf"(?:spotipy[ _-])?(?:{key_pattern})\s*[:=]"
+            rf"|authorization\s*:\s*(?:bearer|basic)\s+",
+            text,
+        ))
 
     def preview(self, archive: str | Path) -> RestorePreview:
         try:
@@ -219,7 +229,14 @@ class LocalDataBackup:
                 elif current_path.read_bytes() == content:
                     merged[path] = content
                 else:
-                    merged[path] = current_path.read_bytes()
+                    holder = {"content": current_path.read_bytes()}
+                    self._resolve_conflict(
+                        holder, "content", content, "report", path,
+                        conflicts, resolutions,
+                    )
+                    merged[path] = holder["content"]
+                    if resolutions.get(f"report:{path}:content") == "archive":
+                        changes.append(f"replace report: {path.removeprefix('reports/')}")
                 continue
             incoming_data = json.loads(content)
             if not current_path.exists():

--- a/djsupport/backup.py
+++ b/djsupport/backup.py
@@ -1,0 +1,362 @@
+"""Versioned backup and conflict-aware restore for local application data."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import shutil
+import tempfile
+import zipfile
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+from typing import Callable
+
+
+BACKUP_VERSION = 1
+DATA_FILES = (
+    "matching-knowledge.json",
+    "transfers.json",
+    "publication-manifests.transfers.json",
+    "publication-manifests.json",
+    "playlist-state.json",
+)
+SUPPORTED_SCHEMAS = {
+    "matching-knowledge.json": (1,),
+    "transfers.json": (1,),
+    "publication-manifests.transfers.json": (1,),
+    "publication-manifests.json": (1, 2, 3),
+    "playlist-state.json": (1, 2),
+}
+SECRET_KEYS = {
+    "access_token", "refresh_token", "client_secret", "client_id",
+    "authorization", "password",
+}
+
+
+@dataclass(frozen=True)
+class RestoreConflict:
+    conflict_id: str
+    kind: str
+    path: str
+    choices: tuple[str, str] = ("current", "archive")
+
+
+@dataclass(frozen=True)
+class RestorePreview:
+    valid: bool
+    contents: tuple[str, ...] = ()
+    changes: tuple[str, ...] = ()
+    conflicts: tuple[RestoreConflict, ...] = ()
+    errors: tuple[str, ...] = ()
+
+
+@dataclass(frozen=True)
+class RestoreResult:
+    restored: bool
+    changes: tuple[str, ...] = ()
+    conflicts: tuple[RestoreConflict, ...] = ()
+    errors: tuple[str, ...] = ()
+
+
+class LocalDataBackup:
+    """Create and restore portable archives at the local-data boundary."""
+
+    def __init__(
+        self, app_data: str | Path, *,
+        replace_file: Callable[[Path, Path], None] | None = None,
+    ) -> None:
+        self.app_data = Path(app_data)
+        self._replace_file = replace_file or self._replace
+
+    @staticmethod
+    def _replace(source: Path, target: Path) -> None:
+        os.replace(source, target)
+
+    def create(
+        self, destination: str | Path, *, now: datetime | None = None,
+    ) -> Path:
+        created_at = now or datetime.now()
+        destination = Path(destination)
+        destination.mkdir(parents=True, exist_ok=True)
+        archive = destination / (
+            f"djsupport-backup-{created_at:%Y%m%dT%H%M%S}.zip"
+        )
+        members = [
+            self.app_data / name for name in DATA_FILES
+            if (self.app_data / name).is_file()
+        ]
+        reports = self.app_data / "reports"
+        if reports.is_dir():
+            members.extend(
+                path for path in reports.rglob("*")
+                if path.is_file() and not path.is_symlink()
+                and path.suffix.casefold() in (".md", ".csv")
+                and not self._report_contains_secret(path)
+            )
+        entries = []
+        for path in members:
+            content = path.read_bytes()
+            relative = path.relative_to(self.app_data).as_posix()
+            schema_version = None
+            if relative in SUPPORTED_SCHEMAS:
+                data = json.loads(content)
+                if self._contains_secret_key(data):
+                    raise ValueError(
+                        f"Credential fields found in application data: {relative}"
+                    )
+                schema_version = data["version"]
+            entries.append({
+                "path": relative,
+                "sha256": hashlib.sha256(content).hexdigest(),
+                "schema_version": schema_version,
+            })
+        manifest = {
+            "version": BACKUP_VERSION,
+            "created_at": created_at.isoformat(),
+            "entries": entries,
+        }
+        with zipfile.ZipFile(archive, "x", zipfile.ZIP_DEFLATED) as bundle:
+            bundle.writestr("backup-manifest.json", json.dumps(manifest, indent=2))
+            for path in members:
+                bundle.write(path, path.relative_to(self.app_data).as_posix())
+        return archive
+
+    @classmethod
+    def _contains_secret_key(cls, value) -> bool:
+        if isinstance(value, dict):
+            return any(
+                str(key).casefold() in SECRET_KEYS
+                or cls._contains_secret_key(item)
+                for key, item in value.items()
+            )
+        if isinstance(value, list):
+            return any(cls._contains_secret_key(item) for item in value)
+        return False
+
+    @staticmethod
+    def _report_contains_secret(path: Path) -> bool:
+        text = path.read_text(errors="replace").casefold()
+        return any(f"{key}=" in text or f'"{key}"' in text for key in SECRET_KEYS)
+
+    def preview(self, archive: str | Path) -> RestorePreview:
+        try:
+            incoming = self._read_archive(Path(archive))
+            merged, changes, conflicts = self._plan(incoming, {})
+            del merged
+            return RestorePreview(
+                True, tuple(sorted(incoming)), tuple(changes), tuple(conflicts),
+            )
+        except (
+            OSError, ValueError, KeyError, json.JSONDecodeError,
+            zipfile.BadZipFile,
+        ) as exc:
+            return RestorePreview(False, errors=(str(exc),))
+
+    def restore(
+        self, archive: str | Path, *, resolutions: dict[str, str] | None = None,
+    ) -> RestoreResult:
+        preview = self.preview(archive)
+        if not preview.valid:
+            return RestoreResult(False, errors=preview.errors)
+        incoming = self._read_archive(Path(archive))
+        merged, changes, conflicts = self._plan(incoming, resolutions or {})
+        unresolved = [
+            conflict for conflict in conflicts
+            if conflict.conflict_id not in (resolutions or {})
+        ]
+        if unresolved:
+            return RestoreResult(False, conflicts=tuple(unresolved))
+        self._commit(merged)
+        return RestoreResult(True, tuple(changes), tuple(conflicts))
+
+    def _read_archive(self, archive: Path) -> dict[str, bytes]:
+        with zipfile.ZipFile(archive) as bundle:
+            names = bundle.namelist()
+            if len(names) != len(set(names)):
+                raise ValueError("Archive contains duplicate entries")
+            if "backup-manifest.json" not in names:
+                raise ValueError("Archive has no backup manifest")
+            manifest = json.loads(bundle.read("backup-manifest.json"))
+            if manifest.get("version") != BACKUP_VERSION:
+                raise ValueError("Unsupported backup schema version")
+            declared = {entry["path"]: entry for entry in manifest["entries"]}
+            if set(names) != {"backup-manifest.json", *declared}:
+                raise ValueError("Archive contents do not match its manifest")
+            incoming = {}
+            for path, entry in declared.items():
+                candidate = Path(path)
+                if candidate.is_absolute() or ".." in candidate.parts:
+                    raise ValueError("Archive contains an unsafe path")
+                if path not in DATA_FILES and not path.startswith("reports/"):
+                    raise ValueError("Archive contains unrelated application data")
+                content = bundle.read(path)
+                if hashlib.sha256(content).hexdigest() != entry["sha256"]:
+                    raise ValueError(f"Integrity check failed for {path}")
+                if path in SUPPORTED_SCHEMAS:
+                    data = json.loads(content)
+                    version = data.get("version")
+                    if version not in SUPPORTED_SCHEMAS[path]:
+                        raise ValueError(f"Unsupported schema version for {path}")
+                    if entry.get("schema_version") != version:
+                        raise ValueError(f"Schema metadata mismatch for {path}")
+                incoming[path] = content
+            return incoming
+
+    def _plan(
+        self, incoming: dict[str, bytes], resolutions: dict[str, str],
+    ) -> tuple[dict[str, bytes], list[str], list[RestoreConflict]]:
+        merged: dict[str, bytes] = {}
+        changes: list[str] = []
+        conflicts: list[RestoreConflict] = []
+        for path, content in incoming.items():
+            current_path = self.app_data / path
+            if path.startswith("reports/"):
+                if not current_path.exists():
+                    merged[path] = content
+                    changes.append(f"add report: {path.removeprefix('reports/')}")
+                elif current_path.read_bytes() == content:
+                    merged[path] = content
+                else:
+                    merged[path] = current_path.read_bytes()
+                continue
+            incoming_data = json.loads(content)
+            if not current_path.exists():
+                merged[path] = content
+                changes.append(f"add {path}")
+                continue
+            current_data = json.loads(current_path.read_bytes())
+            combined = self._merge_json(
+                path, current_data, incoming_data, changes, conflicts, resolutions,
+            )
+            merged[path] = json.dumps(combined, indent=2).encode()
+        return merged, changes, conflicts
+
+    def _merge_json(self, path, current, incoming, changes, conflicts, resolutions):
+        combined = json.loads(json.dumps(current))
+        if path == "matching-knowledge.json":
+            combined.setdefault("entries", {})
+            for key, value in incoming.get("entries", {}).items():
+                existing = combined["entries"].get(key)
+                if existing is None:
+                    combined["entries"][key] = value
+                    changes.append(f"add matching knowledge: {key}")
+                elif existing != value and (
+                    existing.get("approval_status") == "approved"
+                    or value.get("approval_status") == "approved"
+                ):
+                    self._resolve_conflict(
+                        combined["entries"], key, value, "approval", path,
+                        conflicts, resolutions,
+                    )
+            for field in ("local_regressions", "approval_conflicts"):
+                combined.setdefault(field, [])
+                for item in incoming.get(field, []):
+                    if item not in combined[field]:
+                        combined[field].append(item)
+        elif path in ("transfers.json", "publication-manifests.transfers.json"):
+            for field in ("transfers", "batches"):
+                combined.setdefault(field, {})
+                for key, value in incoming.get(field, {}).items():
+                    if key not in combined[field]:
+                        combined[field][key] = value
+                        changes.append(f"add {field[:-1]}: {key}")
+        elif path == "playlist-state.json":
+            combined.setdefault("entries", {})
+            for key, value in incoming.get("entries", {}).items():
+                if key not in combined["entries"]:
+                    combined["entries"][key] = value
+                    changes.append(f"add playlist state: {key}")
+                elif combined["entries"][key] != value:
+                    self._resolve_conflict(
+                        combined["entries"], key, value, "playlist-state", path,
+                        conflicts, resolutions,
+                    )
+        elif path == "publication-manifests.json":
+            for field in ("manifests", "mirrors"):
+                combined.setdefault(field, [])
+                for item in incoming.get(field, []):
+                    identity = self._publication_identity(field, item)
+                    existing = next((
+                        value for value in combined[field]
+                        if self._publication_identity(field, value) == identity
+                    ), None)
+                    if existing is None:
+                        combined[field].append(item)
+                        changes.append(f"add playlist state: {identity}")
+                    elif existing != item:
+                        index = combined[field].index(existing)
+                        self._resolve_conflict(
+                            combined[field], index, item, "playlist-state", path,
+                            conflicts, resolutions, label=str(identity),
+                        )
+            combined.setdefault("approvals", [])
+            for item in incoming.get("approvals", incoming.get("reviews", [])):
+                if item not in combined["approvals"]:
+                    combined["approvals"].append(item)
+        return combined
+
+    @staticmethod
+    def _publication_identity(field: str, item: dict) -> tuple:
+        if field == "manifests":
+            return item.get("account_id"), item.get("spotify_playlist_id")
+        return (
+            item.get("account_id"), item.get("source_label"),
+            item.get("source_reference"),
+        )
+
+    @staticmethod
+    def _resolve_conflict(
+        container, key, incoming, kind, path, conflicts, resolutions, *, label=None,
+    ):
+        conflict_id = f"{kind}:{path}:{label if label is not None else key}"
+        conflict = RestoreConflict(conflict_id, kind, path)
+        conflicts.append(conflict)
+        choice = resolutions.get(conflict_id)
+        if choice not in (None, *conflict.choices):
+            raise ValueError(f"Invalid resolution for {conflict_id}")
+        if choice == "archive":
+            container[key] = incoming
+
+    def _commit(self, merged: dict[str, bytes]) -> None:
+        self.app_data.mkdir(parents=True, exist_ok=True)
+        with tempfile.TemporaryDirectory(
+            prefix="djsupport-restore-", dir=self.app_data.parent,
+        ) as temporary_name:
+            temporary = Path(temporary_name)
+            staged = temporary / "staged"
+            originals = temporary / "originals"
+            existed: dict[str, bool] = {}
+            for path, content in merged.items():
+                stage_path = staged / path
+                stage_path.parent.mkdir(parents=True, exist_ok=True)
+                stage_path.write_bytes(content)
+                target = self.app_data / path
+                existed[path] = target.exists()
+                if target.exists():
+                    original = originals / path
+                    original.parent.mkdir(parents=True, exist_ok=True)
+                    shutil.copy2(target, original)
+            committed: list[str] = []
+            try:
+                for path in sorted(merged):
+                    target = self.app_data / path
+                    target.parent.mkdir(parents=True, exist_ok=True)
+                    self._replace_file(staged / path, target)
+                    committed.append(path)
+            except Exception:
+                for path in reversed(committed):
+                    target = self.app_data / path
+                    if existed[path]:
+                        shutil.copy2(originals / path, target)
+                    else:
+                        target.unlink(missing_ok=True)
+                raise
+
+
+def default_app_data_path() -> Path:
+    """Return the ADR-0001 application-data directory."""
+    from djsupport.transfer import default_matching_knowledge_path
+
+    return default_matching_knowledge_path().parent

--- a/djsupport/cli.py
+++ b/djsupport/cli.py
@@ -150,6 +150,69 @@ def library_show():
         click.echo(f"Status: INVALID ({error})")
 
 
+@cli.command("backup")
+@click.option(
+    "--destination", type=click.Path(file_okay=False), default=None,
+    help="Directory for the timestamped archive (defaults to local app data/backups).",
+)
+def backup_local_data(destination: str | None) -> None:
+    """Create one versioned archive of local djsupport data."""
+    from djsupport.backup import LocalDataBackup, default_app_data_path
+
+    app_data = default_app_data_path()
+    archive = LocalDataBackup(app_data).create(
+        Path(destination) if destination else app_data / "backups"
+    )
+    click.echo(f"Backup created: {archive}")
+
+
+@cli.command("restore")
+@click.argument("archive", type=click.Path(exists=True, dir_okay=False))
+@click.option("--apply", is_flag=True, help="Apply the validated restore preview.")
+@click.option(
+    "--resolve", "resolution_values", multiple=True, metavar="CONFLICT=CHOICE",
+    help="Resolve a listed conflict with current or archive.",
+)
+def restore_local_data(
+    archive: str, apply: bool, resolution_values: tuple[str, ...],
+) -> None:
+    """Validate and preview a backup; use --apply to restore it."""
+    from djsupport.backup import LocalDataBackup, default_app_data_path
+
+    service = LocalDataBackup(default_app_data_path())
+    preview = service.preview(archive)
+    if not preview.valid:
+        raise click.ClickException("; ".join(preview.errors))
+    click.echo("Archive contents:")
+    for path in preview.contents:
+        click.echo(f"  {path}")
+    click.echo("Proposed changes:")
+    for change in preview.changes:
+        click.echo(f"  {change}")
+    for conflict in preview.conflicts:
+        click.echo(
+            f"Conflict {conflict.conflict_id} ({conflict.kind}); "
+            "choose current or archive"
+        )
+    if not apply:
+        click.echo("Preview only; current data was not changed.")
+        return
+    try:
+        resolutions = dict(value.split("=", 1) for value in resolution_values)
+    except ValueError as exc:
+        raise click.UsageError(
+            "Each --resolve value must be CONFLICT=CHOICE."
+        ) from exc
+    result = service.restore(archive, resolutions=resolutions)
+    if not result.restored:
+        if result.errors:
+            raise click.ClickException("; ".join(result.errors))
+        raise click.ClickException(
+            "Unresolved conflicts; current data was not changed."
+        )
+    click.echo("Restore completed.")
+
+
 @cli.command()
 @click.argument("xml_path", required=False, type=click.Path(exists=True, dir_okay=False))
 @click.option("--playlist", "-p", help="Sync only this playlist (by name).")

--- a/tests/test_backup.py
+++ b/tests/test_backup.py
@@ -79,6 +79,38 @@ class TestBackup:
         with zipfile.ZipFile(archive) as bundle:
             assert "reports/linked.md" not in bundle.namelist()
 
+    @pytest.mark.parametrize(
+        "credential",
+        [
+            "Authorization: Bearer spotify-oauth-token",
+            "SPOTIPY_CLIENT_SECRET=spotify-secret",
+            "SPOTIPY_CLIENT_ID=spotify-client-id",
+        ],
+    )
+    def test_excludes_reports_with_common_oauth_credential_forms(
+        self, tmp_path, credential,
+    ):
+        app_data = tmp_path / "app-data"
+        _write_json(app_data / "matching-knowledge.json", {"version": 1})
+        (app_data / "reports").mkdir()
+        (app_data / "reports" / "unsafe.md").write_text(credential)
+
+        archive = LocalDataBackup(app_data).create(tmp_path / "backups")
+
+        with zipfile.ZipFile(archive) as bundle:
+            assert "reports/unsafe.md" not in bundle.namelist()
+
+    def test_refuses_supported_data_with_env_style_oauth_fields(self, tmp_path):
+        app_data = tmp_path / "app-data"
+        _write_json(app_data / "matching-knowledge.json", {
+            "version": 1, "SPOTIPY_CLIENT_SECRET": "never-export",
+        })
+
+        with pytest.raises(ValueError, match="Credential fields"):
+            LocalDataBackup(app_data).create(tmp_path / "backups")
+
+        assert not (tmp_path / "backups").exists()
+
 
 class TestRestorePreview:
     def test_validates_integrity_and_previews_without_mutating(self, tmp_path):
@@ -222,3 +254,21 @@ class TestRestore:
         assert result.restored is True
         restored = json.loads((target / "matching-knowledge.json").read_text())
         assert restored["entries"]["track"]["spotify_uri"] == "incoming"
+
+    def test_differing_reports_are_surfaced_and_never_silently_overwritten(
+        self, tmp_path,
+    ):
+        source = tmp_path / "source"
+        target = tmp_path / "target"
+        for root, text in ((source, "archive report"), (target, "current report")):
+            (root / "reports").mkdir(parents=True)
+            (root / "reports" / "transfer.md").write_text(text)
+        archive = LocalDataBackup(source).create(tmp_path / "backups")
+        service = LocalDataBackup(target)
+
+        preview = service.preview(archive)
+        result = service.restore(archive)
+
+        assert preview.conflicts[0].kind == "report"
+        assert result.restored is False
+        assert (target / "reports" / "transfer.md").read_text() == "current report"

--- a/tests/test_backup.py
+++ b/tests/test_backup.py
@@ -1,0 +1,224 @@
+"""Public-seam behavior tests for local-data backup and restore."""
+
+import json
+import zipfile
+from datetime import datetime
+
+import pytest
+
+from djsupport.backup import LocalDataBackup
+
+
+def _write_json(path, value):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(value))
+
+
+class TestBackup:
+    def test_creates_one_timestamped_archive_with_all_local_data(self, tmp_path):
+        app_data = tmp_path / "app-data"
+        _write_json(app_data / "matching-knowledge.json", {
+            "version": 1, "entries": {"track": {"approval_status": "approved"}},
+        })
+        _write_json(app_data / "transfers.json", {
+            "version": 1, "transfers": {"transfer-1": {}}, "batches": {},
+        })
+        _write_json(app_data / "publication-manifests.json", {
+            "version": 3, "manifests": [{"spotify_playlist_id": "playlist-1"}],
+            "approvals": [], "mirrors": [],
+        })
+        _write_json(app_data / "playlist-state.json", {
+            "version": 2, "entries": {"playlist": {"spotify_id": "playlist-1"}},
+        })
+        (app_data / "reports").mkdir()
+        (app_data / "reports" / "transfer-1.md").write_text("# Transfer report")
+
+        archive = LocalDataBackup(app_data).create(
+            tmp_path / "backups", now=datetime(2026, 8, 1, 12, 34, 56),
+        )
+
+        assert archive.name == "djsupport-backup-20260801T123456.zip"
+        assert list((tmp_path / "backups").iterdir()) == [archive]
+        with zipfile.ZipFile(archive) as bundle:
+            assert set(bundle.namelist()) == {
+                "backup-manifest.json", "matching-knowledge.json",
+                "transfers.json", "publication-manifests.json",
+                "playlist-state.json", "reports/transfer-1.md",
+            }
+
+    def test_excludes_credentials_tokens_secrets_and_unrelated_files(self, tmp_path):
+        app_data = tmp_path / "app-data"
+        _write_json(app_data / "matching-knowledge.json", {"version": 1, "entries": {}})
+        for name in (".env", ".spotipy_cache", "oauth.json", "tokens.json", "notes.txt"):
+            (app_data / name).write_text("CLIENT_SECRET=do-not-export")
+        (app_data / "reports").mkdir()
+        (app_data / "reports" / "credentials.md").write_text(
+            "refresh_token=do-not-export"
+        )
+
+        archive = LocalDataBackup(app_data).create(tmp_path / "backups")
+
+        with zipfile.ZipFile(archive) as bundle:
+            exported = "\n".join(bundle.namelist()) + "\n" + b"\n".join(
+                bundle.read(name) for name in bundle.namelist()
+            ).decode()
+        assert "do-not-export" not in exported
+        assert "oauth" not in exported.casefold()
+        assert "token" not in exported.casefold()
+
+    def test_does_not_follow_report_symlinks_to_secrets(self, tmp_path):
+        app_data = tmp_path / "app-data"
+        _write_json(app_data / "matching-knowledge.json", {"version": 1, "entries": {}})
+        secret = tmp_path / "oauth-secret.md"
+        secret.write_text("refresh_token=never-export")
+        (app_data / "reports").mkdir()
+        (app_data / "reports" / "linked.md").symlink_to(secret)
+
+        archive = LocalDataBackup(app_data).create(tmp_path / "backups")
+
+        with zipfile.ZipFile(archive) as bundle:
+            assert "reports/linked.md" not in bundle.namelist()
+
+
+class TestRestorePreview:
+    def test_validates_integrity_and_previews_without_mutating(self, tmp_path):
+        source = tmp_path / "source"
+        target = tmp_path / "target"
+        _write_json(source / "matching-knowledge.json", {
+            "version": 1, "entries": {"incoming": {"approval_status": None}},
+        })
+        _write_json(target / "matching-knowledge.json", {
+            "version": 1, "entries": {"current": {"approval_status": "approved"}},
+        })
+        archive = LocalDataBackup(source).create(tmp_path / "backups")
+        before = (target / "matching-knowledge.json").read_bytes()
+
+        preview = LocalDataBackup(target).preview(archive)
+
+        assert preview.valid is True
+        assert preview.contents == ("matching-knowledge.json",)
+        assert preview.changes == ("add matching knowledge: incoming",)
+        assert preview.conflicts == ()
+        assert (target / "matching-knowledge.json").read_bytes() == before
+
+    @pytest.mark.parametrize("damage", ["corrupt", "unsupported-backup", "unsupported-data"])
+    def test_rejects_corrupt_or_unsupported_archive(self, tmp_path, damage):
+        source = tmp_path / "source"
+        _write_json(source / "matching-knowledge.json", {"version": 1, "entries": {}})
+        archive = LocalDataBackup(source).create(tmp_path / "backups")
+        if damage == "corrupt":
+            archive.write_bytes(b"not a zip")
+        else:
+            with zipfile.ZipFile(archive, "a") as bundle:
+                if damage == "unsupported-backup":
+                    manifest = json.loads(bundle.read("backup-manifest.json"))
+                    manifest["version"] = 999
+                    bundle.writestr("backup-manifest.json", json.dumps(manifest))
+                else:
+                    bundle.writestr("matching-knowledge.json", json.dumps({"version": 999}))
+
+        preview = LocalDataBackup(tmp_path / "target").preview(archive)
+
+        assert preview.valid is False
+        assert preview.errors
+
+
+class TestRestore:
+    def test_merges_non_conflicting_data_and_preserves_existing_knowledge(self, tmp_path):
+        source = tmp_path / "source"
+        target = tmp_path / "target"
+        _write_json(source / "matching-knowledge.json", {
+            "version": 1, "entries": {"incoming": {"spotify_uri": "new"}},
+            "local_regressions": [], "approval_conflicts": [],
+        })
+        _write_json(target / "matching-knowledge.json", {
+            "version": 1, "entries": {"current": {"spotify_uri": "keep"}},
+            "local_regressions": [], "approval_conflicts": [],
+        })
+        archive = LocalDataBackup(source).create(tmp_path / "backups")
+
+        result = LocalDataBackup(target).restore(archive)
+
+        assert result.restored is True
+        entries = json.loads((target / "matching-knowledge.json").read_text())["entries"]
+        assert entries == {
+            "current": {"spotify_uri": "keep"},
+            "incoming": {"spotify_uri": "new"},
+        }
+
+    @pytest.mark.parametrize("kind", ["approval", "playlist-state"])
+    def test_conflicts_require_resolution_and_leave_current_data_intact(self, tmp_path, kind):
+        source = tmp_path / "source"
+        target = tmp_path / "target"
+        if kind == "approval":
+            filename = "matching-knowledge.json"
+            current = {"version": 1, "entries": {"track": {
+                "approval_status": "approved", "spotify_uri": "current",
+            }}}
+            incoming = {"version": 1, "entries": {"track": {
+                "approval_status": "approved", "spotify_uri": "incoming",
+            }}}
+        else:
+            filename = "playlist-state.json"
+            current = {"version": 2, "entries": {"playlist": {"spotify_id": "current"}}}
+            incoming = {"version": 2, "entries": {"playlist": {"spotify_id": "incoming"}}}
+        _write_json(source / filename, incoming)
+        _write_json(target / filename, current)
+        archive = LocalDataBackup(source).create(tmp_path / "backups")
+        before = (target / filename).read_bytes()
+
+        preview = LocalDataBackup(target).preview(archive)
+        result = LocalDataBackup(target).restore(archive)
+
+        assert preview.conflicts[0].kind == kind
+        assert preview.conflicts[0].choices == ("current", "archive")
+        assert result.restored is False
+        assert result.conflicts == preview.conflicts
+        assert (target / filename).read_bytes() == before
+
+    def test_rolls_back_all_files_when_commit_fails(self, tmp_path):
+        source = tmp_path / "source"
+        target = tmp_path / "target"
+        for root, suffix in ((source, "incoming"), (target, "current")):
+            _write_json(root / "matching-knowledge.json", {
+                "version": 1, "entries": {suffix: {}},
+            })
+            _write_json(root / "transfers.json", {
+                "version": 1, "transfers": {suffix: {}}, "batches": {},
+            })
+        archive = LocalDataBackup(source).create(tmp_path / "backups")
+        before = {path.name: path.read_bytes() for path in target.iterdir()}
+
+        def fail_second_commit(source_path, target_path, count=[0]):
+            count[0] += 1
+            if count[0] == 2:
+                raise OSError("disk failure")
+            source_path.replace(target_path)
+
+        with pytest.raises(OSError, match="disk failure"):
+            LocalDataBackup(target, replace_file=fail_second_commit).restore(archive)
+
+        assert {path.name: path.read_bytes() for path in target.iterdir()} == before
+
+    def test_explicit_archive_resolution_replaces_only_the_named_conflict(self, tmp_path):
+        source = tmp_path / "source"
+        target = tmp_path / "target"
+        current = {"version": 1, "entries": {"track": {
+            "approval_status": "approved", "spotify_uri": "current",
+        }}}
+        incoming = {"version": 1, "entries": {"track": {
+            "approval_status": "approved", "spotify_uri": "incoming",
+        }}}
+        _write_json(source / "matching-knowledge.json", incoming)
+        _write_json(target / "matching-knowledge.json", current)
+        archive = LocalDataBackup(source).create(tmp_path / "backups")
+        service = LocalDataBackup(target)
+        conflict = service.preview(archive).conflicts[0]
+
+        result = service.restore(
+            archive, resolutions={conflict.conflict_id: "archive"},
+        )
+
+        assert result.restored is True
+        restored = json.loads((target / "matching-knowledge.json").read_text())
+        assert restored["entries"]["track"]["spotify_uri"] == "incoming"


### PR DESCRIPTION
## Summary
- add a versioned, timestamped archive for matching knowledge, Transfer history, manifests, reports, and playlist state
- exclude OAuth credentials and unrelated files, validate hashes and schema versions, and preview every restore before mutation
- merge non-conflicting data while surfacing Approval, playlist-state, and report conflicts for explicit resolution
- commit restored files atomically with rollback on failure
- expose simple `djsupport backup` and preview-first `djsupport restore` commands

## Validation
- 447 offline tests passed
- `python3 -m compileall -q djsupport tests`
- `git diff --check main...HEAD`
- Standards review: pass, no blocking findings
- Spec review against #28, parent #13, blocker behavior, and repository docs: pass after resolving both blockers

Closes #28