### PR TITLE
Add terminal audio-extension fallback search query

### DIFF
--- a/djsupport/matcher.py
+++ b/djsupport/matcher.py
@@ -313,7 +313,11 @@ def _search_candidates(sp, track: Track, threshold: int) -> list[dict]:
     clean_title = _normalize(stripped)
     if clean_artist != track.artist.lower().strip() or clean_title != stripped.lower().strip():
         search(clean_artist, clean_title)
-    extension_match = re.search(r"\.(?:mp3|aiff|wav|flac)$", track.name, re.IGNORECASE)
+    if not all_results:
+        search(track.artist, track.name, plain=True)
+    extension_match = re.search(
+        r"\.(?:mp3|aiff|wav|flac)$", track.name, re.IGNORECASE,
+    )
     if (
         track.artist.strip()
         and extension_match is not None
@@ -321,8 +325,6 @@ def _search_candidates(sp, track: Track, threshold: int) -> list[dict]:
         and _select_best(track, all_results, threshold) is None
     ):
         search(track.artist, track.name[:extension_match.start()])
-    if not all_results:
-        search(track.artist, track.name, plain=True)
     return all_results
 
 

--- a/djsupport/matcher.py
+++ b/djsupport/matcher.py
@@ -288,30 +288,47 @@ def _select_best(track: Track, results: list[dict], threshold: int) -> dict | No
     return None
 
 
-def _search_candidates(sp, track: Track) -> list[dict]:
+def _search_candidates(sp, track: Track, threshold: int) -> list[dict]:
     """Gather candidates through the shared ordered Spotify search strategy."""
     all_results: list[dict] = []
-    all_results.extend(search_track(sp, track.artist, track.name))
+    searched: set[tuple[str, str, bool]] = set()
+
+    def search(artist: str, title: str, *, plain: bool = False) -> None:
+        query = (artist, title, plain)
+        if query in searched:
+            return
+        searched.add(query)
+        all_results.extend(search_track(sp, artist, title, plain=plain))
+
+    search(track.artist, track.name)
     early = _select_best(track, all_results, EARLY_EXIT_THRESHOLD)
     if early is not None and early["match_type"] == "exact":
         return all_results
     stripped = _strip_mix_info(track.name)
     if stripped != track.name:
-        all_results.extend(search_track(sp, track.artist, stripped))
+        search(track.artist, stripped)
     if track.remixer:
-        all_results.extend(search_track(sp, f"{track.artist} {track.remixer}", track.name))
+        search(f"{track.artist} {track.remixer}", track.name)
     clean_artist = _normalize(track.artist)
     clean_title = _normalize(stripped)
     if clean_artist != track.artist.lower().strip() or clean_title != stripped.lower().strip():
-        all_results.extend(search_track(sp, clean_artist, clean_title))
+        search(clean_artist, clean_title)
+    extension_match = re.search(r"\.(?:mp3|aiff|wav|flac)$", track.name, re.IGNORECASE)
+    if (
+        track.artist.strip()
+        and extension_match is not None
+        and track.name[:extension_match.start()]
+        and _select_best(track, all_results, threshold) is None
+    ):
+        search(track.artist, track.name[:extension_match.start()])
     if not all_results:
-        all_results.extend(search_track(sp, track.artist, track.name, plain=True))
+        search(track.artist, track.name, plain=True)
     return all_results
 
 
 def match_track(sp, track: Track, threshold: int = 80) -> dict | None:
     """Try to find a Spotify match for a Rekordbox track."""
-    all_results = _search_candidates(sp, track)
+    all_results = _search_candidates(sp, track, threshold)
 
     return _select_best(track, all_results, threshold)
 
@@ -320,7 +337,7 @@ def match_track_with_alternatives(
     sp, track: Track, threshold: int = 80,
 ) -> dict | None:
     """Return an acceptable match or up to three explained alternatives."""
-    all_results = _search_candidates(sp, track)
+    all_results = _search_candidates(sp, track, threshold)
     match = _select_best(track, all_results, threshold)
     if match is not None:
         return match

--- a/tests/test_matcher.py
+++ b/tests/test_matcher.py
@@ -15,8 +15,10 @@ from djsupport.matcher import (
     _duration_penalty,
     _score_result,
     match_track,
+    match_track_cached,
     match_track_with_alternatives,
 )
+from djsupport.cache import MatchCache
 from djsupport.rekordbox import Track
 
 
@@ -398,6 +400,168 @@ class TestMatchTrack:
         assert result is not None
         assert result["uri"] == "uri:normalized"
         assert sp.search.call_args_list[2].kwargs["q"] == "artist:artist track:track"
+
+
+class TestTerminalAudioExtensionFallback:
+    def test_recovers_signal_without_changing_source_identity_or_version_intent(self):
+        track = make_track(
+            "Signal (Original Mix).aiff", "Known Artist", duration=360,
+        )
+        original_track = Track(**vars(track))
+        recovered = make_spotify_item(
+            "Signal", "Known Artist", "spotify:track:signal", 360000,
+        )
+        sp = MagicMock()
+        sp.search.side_effect = [
+            {"tracks": {"items": []}},
+            {"tracks": {"items": []}},
+            {"tracks": {"items": [recovered]}},
+        ]
+
+        result = match_track(sp, track, threshold=80)
+
+        assert result is not None
+        assert result["uri"] == "spotify:track:signal"
+        assert result["match_type"] == "exact"
+        assert track == original_track
+        assert "(Original Mix)" in track.name
+        assert [call.kwargs["q"] for call in sp.search.call_args_list] == [
+            "artist:Known Artist track:Signal (Original Mix).aiff",
+            "artist:Known Artist track:Signal.aiff",
+            "artist:Known Artist track:Signal (Original Mix)",
+        ]
+
+    @pytest.mark.parametrize("suffix", [".mp3", ".aiff", ".wav", ".flac"])
+    def test_recognized_terminal_suffix_adds_at_most_one_search(self, suffix):
+        sp = MagicMock()
+        sp.search.return_value = {"tracks": {"items": []}}
+
+        match_track(sp, make_track(f"Signal{suffix}", "Known Artist"))
+
+        queries = [call.kwargs["q"] for call in sp.search.call_args_list]
+        assert queries == [
+            f"artist:Known Artist track:Signal{suffix}",
+            "artist:Known Artist track:Signal",
+            f"Known Artist Signal{suffix}",
+        ]
+        assert len(queries) == len(set(queries))
+
+    @pytest.mark.parametrize(
+        "title",
+        [
+            "Signal.aiff Archive",
+            "Signal.ogg",
+            ".aiff",
+        ],
+    )
+    def test_ineligible_title_keeps_existing_two_search_calls(self, title):
+        sp = MagicMock()
+        sp.search.return_value = {"tracks": {"items": []}}
+
+        match_track(sp, make_track(title, "Known Artist"))
+
+        assert sp.search.call_count == 2
+        assert sp.search.call_args_list[-1].kwargs["q"] == f"Known Artist {title}"
+
+    def test_unknown_artist_does_not_receive_extension_fallback(self):
+        sp = MagicMock()
+        sp.search.return_value = {"tracks": {"items": []}}
+
+        match_track(sp, make_track("Signal.aiff", ""))
+
+        assert sp.search.call_count == 2
+
+    def test_candidate_still_has_to_pass_original_scoring_threshold(self):
+        unrelated = make_spotify_item(
+            "Unrelated", "Different Artist", "spotify:track:wrong", 360000,
+        )
+        sp = MagicMock()
+        sp.search.side_effect = [
+            {"tracks": {"items": []}},
+            {"tracks": {"items": []}},
+            {"tracks": {"items": [unrelated]}},
+        ]
+
+        result = match_track(
+            sp,
+            make_track("Signal (Original Mix).aiff", "Known Artist", duration=360),
+            threshold=80,
+        )
+
+        assert result is None
+        assert sp.search.call_count == 3
+
+    def test_acceptable_earlier_result_skips_extension_fallback(self):
+        exact = make_spotify_item(
+            "Signal (Original Mix).aiff", "Known Artist", "spotify:track:exact",
+            360000,
+        )
+        sp = MagicMock()
+        sp.search.return_value = {"tracks": {"items": [exact]}}
+
+        result = match_track(
+            sp,
+            make_track("Signal (Original Mix).aiff", "Known Artist", duration=360),
+        )
+
+        assert result is not None
+        assert result["uri"] == "spotify:track:exact"
+        assert sp.search.call_count == 1
+
+    def test_cache_hits_and_recent_failure_make_zero_search_calls(self, tmp_path):
+        title = "Signal (Original Mix).aiff"
+        scenarios = ("approved", "success", "failure")
+        for scenario in scenarios:
+            cache = MatchCache(str(tmp_path / f"{scenario}.json"))
+            cached_result = make_result(
+                "Signal", "Known Artist", "spotify:track:signal", 360000,
+            )
+            cached_result["score"] = 95.0
+            cached_result["match_type"] = "exact"
+            if scenario == "approved":
+                cache.record_approval(
+                    "Known Artist", title, "approved", cached_result,
+                )
+            elif scenario == "success":
+                cache.store("Known Artist", title, 80, cached_result)
+            else:
+                cache.store("Known Artist", title, 80, None)
+            sp = MagicMock()
+
+            match_track_cached(
+                sp, make_track(title, "Known Artist", duration=360), cache,
+            )
+
+            assert sp.search.call_count == 0, scenario
+
+    def test_retry_eligible_failure_uses_original_cache_identity(self, tmp_path):
+        title = "Signal (Original Mix).aiff"
+        cache = MatchCache(str(tmp_path / "cache.json"))
+        cache.store("Known Artist", title, 80, None)
+        original_key = cache.cache_key("Known Artist", title)
+        recovered = make_spotify_item(
+            "Signal", "Known Artist", "spotify:track:signal", 360000,
+        )
+        sp = MagicMock()
+        sp.search.side_effect = [
+            {"tracks": {"items": []}},
+            {"tracks": {"items": []}},
+            {"tracks": {"items": [recovered]}},
+        ]
+
+        result, source = match_track_cached(
+            sp, make_track(title, "Known Artist", duration=360), cache,
+            force_retry=True,
+        )
+
+        assert result is not None
+        assert source == "retry"
+        assert sp.search.call_count == 3
+        assert set(cache.entries) == {original_key}
+        assert cache.entries[original_key].spotify_uri == "spotify:track:signal"
+        cache.record_approval("Known Artist", title, "approved", result)
+        assert cache.lookup("Known Artist", title, 100) is not None
+        assert cache.lookup("Known Artist", "Signal (Original Mix)", 100) is None
 
 
 class TestEarlyExit:

--- a/tests/test_matcher.py
+++ b/tests/test_matcher.py
@@ -415,6 +415,10 @@ class TestTerminalAudioExtensionFallback:
         sp.search.side_effect = [
             {"tracks": {"items": []}},
             {"tracks": {"items": []}},
+            {"tracks": {"items": [make_spotify_item(
+                "Unrelated", "Different Artist", "spotify:track:wrong",
+                360000,
+            )]}},
             {"tracks": {"items": [recovered]}},
         ]
 
@@ -428,6 +432,7 @@ class TestTerminalAudioExtensionFallback:
         assert [call.kwargs["q"] for call in sp.search.call_args_list] == [
             "artist:Known Artist track:Signal (Original Mix).aiff",
             "artist:Known Artist track:Signal.aiff",
+            "Known Artist Signal (Original Mix).aiff",
             "artist:Known Artist track:Signal (Original Mix)",
         ]
 
@@ -441,10 +446,30 @@ class TestTerminalAudioExtensionFallback:
         queries = [call.kwargs["q"] for call in sp.search.call_args_list]
         assert queries == [
             f"artist:Known Artist track:Signal{suffix}",
-            "artist:Known Artist track:Signal",
             f"Known Artist Signal{suffix}",
+            "artist:Known Artist track:Signal",
         ]
         assert len(queries) == len(set(queries))
+
+    def test_duplicate_extension_free_variant_adds_no_search_call(self):
+        class DuplicateVariantTitle(str):
+            def __getitem__(self, key):
+                if isinstance(key, slice) and key.stop == len("Signal"):
+                    return self
+                return super().__getitem__(key)
+
+        sp = MagicMock()
+        sp.search.return_value = {"tracks": {"items": []}}
+
+        match_track(
+            sp,
+            make_track(DuplicateVariantTitle("Signal.aiff"), "Known Artist"),
+        )
+
+        assert [call.kwargs["q"] for call in sp.search.call_args_list] == [
+            "artist:Known Artist track:Signal.aiff",
+            "Known Artist Signal.aiff",
+        ]
 
     @pytest.mark.parametrize(
         "title",
@@ -479,6 +504,7 @@ class TestTerminalAudioExtensionFallback:
         sp.search.side_effect = [
             {"tracks": {"items": []}},
             {"tracks": {"items": []}},
+            {"tracks": {"items": []}},
             {"tracks": {"items": [unrelated]}},
         ]
 
@@ -489,7 +515,7 @@ class TestTerminalAudioExtensionFallback:
         )
 
         assert result is None
-        assert sp.search.call_count == 3
+        assert sp.search.call_count == 4
 
     def test_acceptable_earlier_result_skips_extension_fallback(self):
         exact = make_spotify_item(
@@ -546,6 +572,7 @@ class TestTerminalAudioExtensionFallback:
         sp.search.side_effect = [
             {"tracks": {"items": []}},
             {"tracks": {"items": []}},
+            {"tracks": {"items": []}},
             {"tracks": {"items": [recovered]}},
         ]
 
@@ -556,7 +583,7 @@ class TestTerminalAudioExtensionFallback:
 
         assert result is not None
         assert source == "retry"
-        assert sp.search.call_count == 3
+        assert sp.search.call_count == 4
         assert set(cache.entries) == {original_key}
         assert cache.entries[original_key].spotify_uri == "spotify:track:signal"
         cache.record_approval("Known Artist", title, "approved", result)

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -161,6 +161,20 @@ class TestSaveReport:
         assert "source-1" in content
         assert "[Artist - Track A](https://open.spotify.com/track/abc123)" in content
 
+    def test_audio_extension_recovery_keeps_original_source_title(self, tmp_path):
+        path = str(tmp_path / "report.md")
+        match = _matched(
+            name="Known Artist - Signal (Original Mix).aiff",
+            spotify_name="Signal",
+            artist="Known Artist",
+        )
+
+        save_report(_report(playlists=[_playlist(matched=[match])]), path)
+
+        content = (tmp_path / "report.md").read_text()
+        assert "Known Artist - Signal (Original Mix).aiff" in content
+        assert "Known Artist - Signal" in content
+
     def test_file_contains_unmatched_tracks(self, tmp_path):
         path = str(tmp_path / "report.md")
         pl = _playlist(unmatched=["Obscure Track"])


### PR DESCRIPTION
Closes #41

## Summary
- add one deduplicated terminal `.mp3`, `.aiff`, `.wav`, or `.flac` search-only fallback for tracks with a known artist
- preserve existing query ordering, early exit, original Track scoring, cache identity, Approved Match identity, and report title
- cover positive, negative, cache, retry, call-count, identity, version-intent, report, and duplicate-query behavior with synthetic offline tests

## Validation
- `pytest`: 448 passed (2 existing zipfile warnings)
- `python3 -m compileall -q djsupport tests`: passed
- `git diff fb576a22d0bd3c14f580aa637f4190c3afbf9772...HEAD --check`: passed
- `pytest -q tests/test_repository_privacy.py`: 15 passed
- Standards review: passed, 0 findings
- Spec review: passed, 0 findings after resolving both initial blockers