### PR TITLE
Fix unmatched track Corrections during Approval

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
+- Provisional publication manifests and review CSVs now retain unmatched source
+  tracks with blank Spotify targets, allowing playlist-scoped Approval to apply
+  Corrections without losing source order or rejecting rows left unresolved
 - Label search now handles new Beatport search API response format (`label_id`/`label_name` under `data` key) alongside old format
 - Label scraper no longer imports `click` — pagination errors communicated via `on_page_error` callback, keeping library decoupled from CLI
 - Search result URLs are re-validated before fetching, closing a trust boundary gap

--- a/djsupport/report.py
+++ b/djsupport/report.py
@@ -24,6 +24,20 @@ class MatchedTrack:
 
 
 @dataclass(frozen=True)
+class ReviewTrack:
+    source_track_id: str
+    source_name: str
+    source_artist: str = ""
+    source_title: str = ""
+    source_duration: int = 0
+    spotify_uri: str = ""
+    spotify_name: str = ""
+    spotify_artist: str = ""
+    score: float = 0.0
+    match_type: str = "unmatched"
+
+
+@dataclass(frozen=True)
 class AlternativeCandidate:
     rank: int
     spotify_uri: str
@@ -81,6 +95,7 @@ class PlaylistReport:
     name: str
     path: str
     matched: list[MatchedTrack] = field(default_factory=list)
+    review_items: list[ReviewTrack] = field(default_factory=list)
     unmatched: list[str] = field(default_factory=list)
     alternatives: list[UnmatchedAlternatives] = field(default_factory=list)
     unavailable_approved: list[UnavailableApprovedMatch] = field(default_factory=list)
@@ -370,9 +385,44 @@ def save_review_csv(report: SyncReport, path: str) -> None:
         writer = csv.writer(csv_file)
         writer.writerow([
             "source_track_id", "source_track", "spotify_url", "spotify_track",
-            "score", "match_type",
+            "score", "match_type", "source_artist", "source_title",
+            "source_duration",
         ])
         for playlist in report.playlists:
+            if playlist.review_items:
+                for item in playlist.review_items:
+                    writer.writerow([
+                        item.source_track_id,
+                        item.source_name,
+                        _spotify_url(item.spotify_uri) if item.spotify_uri else "",
+                        (
+                            f"{item.spotify_artist} - {item.spotify_name}"
+                            if item.spotify_uri else ""
+                        ),
+                        f"{item.score:.1f}" if item.spotify_uri else "",
+                        item.match_type,
+                        item.source_artist,
+                        item.source_title,
+                        item.source_duration,
+                    ])
+                continue
+            if playlist.publication_manifest is not None:
+                for item in playlist.publication_manifest.items:
+                    writer.writerow([
+                        item.source_track_id,
+                        item.source_name,
+                        _spotify_url(item.spotify_uri) if item.spotify_uri else "",
+                        (
+                            f"{item.spotify_artist} - {item.spotify_name}"
+                            if item.spotify_uri else ""
+                        ),
+                        f"{item.score:.1f}" if item.spotify_uri else "",
+                        item.match_type,
+                        item.source_artist,
+                        item.source_title,
+                        item.source_duration,
+                    ])
+                continue
             for match in playlist.matched:
                 writer.writerow([
                     match.source_track_id,
@@ -381,4 +431,7 @@ def save_review_csv(report: SyncReport, path: str) -> None:
                     f"{match.spotify_artist} - {match.spotify_name}",
                     f"{match.score:.1f}",
                     match.match_type,
+                    "",
+                    "",
+                    "",
                 ])

--- a/djsupport/report.py
+++ b/djsupport/report.py
@@ -389,25 +389,15 @@ def save_review_csv(report: SyncReport, path: str) -> None:
             "source_duration",
         ])
         for playlist in report.playlists:
-            if playlist.review_items:
-                for item in playlist.review_items:
-                    writer.writerow([
-                        item.source_track_id,
-                        item.source_name,
-                        _spotify_url(item.spotify_uri) if item.spotify_uri else "",
-                        (
-                            f"{item.spotify_artist} - {item.spotify_name}"
-                            if item.spotify_uri else ""
-                        ),
-                        f"{item.score:.1f}" if item.spotify_uri else "",
-                        item.match_type,
-                        item.source_artist,
-                        item.source_title,
-                        item.source_duration,
-                    ])
-                continue
-            if playlist.publication_manifest is not None:
-                for item in playlist.publication_manifest.items:
+            review_items = (
+                playlist.review_items
+                or (
+                    list(playlist.publication_manifest.items)
+                    if playlist.publication_manifest is not None else []
+                )
+            )
+            if review_items:
+                for item in review_items:
                     writer.writerow([
                         item.source_track_id,
                         item.source_name,

--- a/djsupport/transfer.py
+++ b/djsupport/transfer.py
@@ -1548,6 +1548,15 @@ class Transfer:
                     corrected_items.get(item.source_track_id, item)
                     for item in manifest.items
                 )
+                original_proposal_counts = Counter(
+                    item.spotify_uri for item in manifest.items
+                    if item.spotify_uri
+                )
+                unresolved_collision_ids = {
+                    item.source_track_id for item in manifest.items
+                    if original_proposal_counts[item.spotify_uri] > 1
+                    and item.source_track_id not in corrected_items
+                }
                 proposed_counts = Counter(item.spotify_uri for item in reviewed_items)
                 collision_uris = {
                     uri for uri, count in proposed_counts.items() if count > 1
@@ -1556,7 +1565,10 @@ class Transfer:
                 for item in reviewed_items:
                     if not item.spotify_uri:
                         continue
-                    if item.spotify_uri in collision_uris:
+                    if (
+                        item.source_track_id in unresolved_collision_ids
+                        or item.spotify_uri in collision_uris
+                    ):
                         collisions.append(item)
                         continue
                     if remaining[item.spotify_uri] > 0:

--- a/djsupport/transfer.py
+++ b/djsupport/transfer.py
@@ -1645,8 +1645,6 @@ class Transfer:
             for row_number, row in enumerate(reader, start=2):
                 source_track_id = (row.get("source_track_id") or "").strip()
                 spotify_reference = (row.get("spotify_url") or "").strip()
-                if not spotify_reference:
-                    continue
                 if not source_track_id or source_track_id not in manifest_items:
                     raise ValueError(
                         f"Correction row {row_number} has an unknown source_track_id"
@@ -1662,6 +1660,8 @@ class Transfer:
                         f"{source_track_id}"
                     )
                 seen_source_references.add(source_track_id)
+                if not spotify_reference:
+                    continue
                 original = manifest_items[source_track_id]
                 if spotify_reference == original.spotify_uri:
                     continue
@@ -1717,15 +1717,19 @@ class Transfer:
             elif present[item.spotify_uri] and item.spotify_uri not in desired:
                 desired.append(item.spotify_uri)
 
-        first_managed = next(
-            (index for index, uri in enumerate(current_uris) if uri in managed_uris),
-            0,
-        )
-        manual = [uri for uri in current_uris if uri not in managed_uris]
-        insertion = sum(
-            1 for uri in current_uris[:first_managed] if uri not in managed_uris
-        )
-        repaired = [*manual[:insertion], *desired, *manual[insertion:]]
+        manual_by_managed_boundary: dict[int, list[str]] = {}
+        managed_seen = 0
+        for uri in current_uris:
+            if uri in managed_uris:
+                managed_seen += 1
+                continue
+            boundary = min(managed_seen, len(desired))
+            manual_by_managed_boundary.setdefault(boundary, []).append(uri)
+        repaired: list[str] = []
+        for boundary in range(len(desired) + 1):
+            repaired.extend(manual_by_managed_boundary.get(boundary, ()))
+            if boundary < len(desired):
+                repaired.append(desired[boundary])
         if repaired != current_uris:
             self._retry_policy.run(
                 lambda: self._spotify.replace_provisional_playlist_tracks(
@@ -2056,13 +2060,7 @@ class Transfer:
 
                 if result is None or "alternatives" in result:
                     playlist.unmatched.append(track.display)
-                    if track.track_id and not any(
-                        item.source_track_id == track.track_id
-                        and item.source_artist == track.artist
-                        and item.source_title == track.name
-                        and item.source_duration == track.duration
-                        for item in publication_items
-                    ):
+                    if self._is_new_reviewable_source(track, publication_items):
                         publication_items.append(PublicationItem(
                             source_track_id=track.track_id,
                             source_name=track.display,
@@ -2102,13 +2100,7 @@ class Transfer:
                         spotify_uri=result["uri"],
                     )
                     playlist.matched.append(matched_track)
-                    if track.track_id and not any(
-                        item.source_track_id == track.track_id
-                        and item.source_artist == track.artist
-                        and item.source_title == track.name
-                        and item.source_duration == track.duration
-                        for item in publication_items
-                    ):
+                    if self._is_new_reviewable_source(track, publication_items):
                         publication_items.append(PublicationItem(
                             source_track_id=track.track_id,
                             source_name=track.display,
@@ -2358,7 +2350,6 @@ class Transfer:
                     items=tuple(
                         item for item in publication_items
                         if not item.authoritative
-                        and item.spotify_uri not in collision_uris
                     ),
                     mode=request.mode,
                     managed_items=tuple(managed_items_by_uri.values()),
@@ -2469,6 +2460,20 @@ class Transfer:
             )
             for item in items
         ]
+
+    @staticmethod
+    def _is_new_reviewable_source(
+        track: Track, items: list[PublicationItem],
+    ) -> bool:
+        if not track.track_id:
+            return False
+        return not any(
+            item.source_track_id == track.track_id
+            and item.source_artist == track.artist
+            and item.source_title == track.name
+            and item.source_duration == track.duration
+            for item in items
+        )
 
     def _approved_available(self, spotify_uri: str) -> bool:
         try:

--- a/djsupport/transfer.py
+++ b/djsupport/transfer.py
@@ -41,6 +41,7 @@ from djsupport.report import (
     MatchedTrack,
     PlaylistDrift,
     PlaylistReport,
+    ReviewTrack,
     SyncReport,
     SourceRemoval,
     UnmatchedAlternatives,
@@ -49,7 +50,7 @@ from djsupport.report import (
 from djsupport.spotify import MAX_RATE_LIMIT_WAIT, RateLimitError, _parse_retry_after
 
 
-PUBLICATION_MANIFEST_VERSION = 3
+PUBLICATION_MANIFEST_VERSION = 4
 TRANSFER_STATE_VERSION = 1
 EXPENSIVE_BATCH_LOOKUP_THRESHOLD = 100
 SPOTIFY_TRACK_URI = re.compile(r"^spotify:track:([A-Za-z0-9]{22})$")
@@ -387,11 +388,11 @@ class PublicationItem:
     source_name: str
     source_artist: str
     source_title: str
-    spotify_uri: str
-    spotify_name: str
-    spotify_artist: str
-    score: float
-    match_type: str
+    spotify_uri: str = ""
+    spotify_name: str = ""
+    spotify_artist: str = ""
+    score: float = 0.0
+    match_type: str = "unmatched"
     source_duration: int = 0
     authoritative: bool = False
 
@@ -523,7 +524,7 @@ class FilePublicationStorage:
             data = json.loads(self.path.read_text())
         except (json.JSONDecodeError, OSError):
             return
-        if data.get("version") not in (1, 2, PUBLICATION_MANIFEST_VERSION):
+        if data.get("version") not in (1, 2, 3, PUBLICATION_MANIFEST_VERSION):
             return
         self.manifests = data.get("manifests", [])
         self.approvals = data.get("approvals", data.get("reviews", []))
@@ -1553,6 +1554,8 @@ class Transfer:
                 }
                 collisions: list[PublicationItem] = []
                 for item in reviewed_items:
+                    if not item.spotify_uri:
+                        continue
                     if item.spotify_uri in collision_uris:
                         collisions.append(item)
                         continue
@@ -1960,6 +1963,7 @@ class Transfer:
         publication_items = [
             PublicationItem(**item) for item in state.publication_items
         ]
+        playlist.review_items = self._review_tracks(publication_items)
         if state.status == TransferStatus.COMPLETED:
             report.status = "completed"
             if state.spotify_playlist_id:
@@ -2052,6 +2056,20 @@ class Transfer:
 
                 if result is None or "alternatives" in result:
                     playlist.unmatched.append(track.display)
+                    if track.track_id and not any(
+                        item.source_track_id == track.track_id
+                        and item.source_artist == track.artist
+                        and item.source_title == track.name
+                        and item.source_duration == track.duration
+                        for item in publication_items
+                    ):
+                        publication_items.append(PublicationItem(
+                            source_track_id=track.track_id,
+                            source_name=track.display,
+                            source_artist=track.artist,
+                            source_title=track.name,
+                            source_duration=track.duration,
+                        ))
                     candidates = tuple(
                         AlternativeCandidate(
                             rank=rank,
@@ -2084,19 +2102,26 @@ class Transfer:
                         spotify_uri=result["uri"],
                     )
                     playlist.matched.append(matched_track)
-                    publication_items.append(PublicationItem(
-                        source_track_id=track.track_id,
-                        source_name=track.display,
-                        source_artist=track.artist,
-                        source_title=track.name,
-                        spotify_uri=result["uri"],
-                        spotify_name=matched_track.spotify_name,
-                        spotify_artist=matched_track.spotify_artist,
-                        score=matched_track.score,
-                        match_type=matched_track.match_type,
-                        source_duration=track.duration,
-                        authoritative=bool(result.get("authoritative")),
-                    ))
+                    if track.track_id and not any(
+                        item.source_track_id == track.track_id
+                        and item.source_artist == track.artist
+                        and item.source_title == track.name
+                        and item.source_duration == track.duration
+                        for item in publication_items
+                    ):
+                        publication_items.append(PublicationItem(
+                            source_track_id=track.track_id,
+                            source_name=track.display,
+                            source_artist=track.artist,
+                            source_title=track.name,
+                            spotify_uri=result["uri"],
+                            spotify_name=matched_track.spotify_name,
+                            spotify_artist=matched_track.spotify_artist,
+                            score=matched_track.score,
+                            match_type=matched_track.match_type,
+                            source_duration=track.duration,
+                            authoritative=bool(result.get("authoritative")),
+                        ))
 
                 state.next_track_index = index + 1
                 state.matched = [asdict(item) for item in playlist.matched]
@@ -2105,6 +2130,7 @@ class Transfer:
                 state.publication_items = [
                     asdict(item) for item in publication_items
                 ]
+                playlist.review_items = self._review_tracks(publication_items)
                 self._knowledge.checkpoint()
                 if self._pause_requested:
                     state.status = TransferStatus.PAUSED
@@ -2117,6 +2143,8 @@ class Transfer:
 
             source_ids_by_uri: dict[str, set[tuple[str, str, int]]] = {}
             for item in publication_items:
+                if not item.spotify_uri:
+                    continue
                 source_ids_by_uri.setdefault(item.spotify_uri, set()).add(
                     (
                         item.source_artist.casefold(),
@@ -2284,7 +2312,8 @@ class Transfer:
                             snapshot_name,
                             list(dict.fromkeys(
                                 item.spotify_uri for item in publication_items
-                                if item.spotify_uri not in collision_uris
+                                if item.spotify_uri
+                                and item.spotify_uri not in collision_uris
                             )),
                             description,
                             publication_key,
@@ -2309,14 +2338,15 @@ class Transfer:
                             playlist_id,
                             list(dict.fromkeys(
                                 item.spotify_uri for item in publication_items
-                                if item.spotify_uri not in collision_uris
+                                if item.spotify_uri
+                                and item.spotify_uri not in collision_uris
                             )),
                         )
                     )
                 assert snapshot_name is not None
                 managed_items_by_uri: dict[str, PublicationItem] = {}
                 for item in publication_items:
-                    if item.spotify_uri not in collision_uris:
+                    if item.spotify_uri and item.spotify_uri not in collision_uris:
                         managed_items_by_uri.setdefault(item.spotify_uri, item)
                 manifest = PublicationManifest(
                     account_id=state.account_id,
@@ -2421,6 +2451,24 @@ class Transfer:
     def _save_transfer(self, transfer_id: str, state: TransferState) -> None:
         if self._transfer_storage is not None:
             self._transfer_storage.save_transfer(transfer_id, state)
+
+    @staticmethod
+    def _review_tracks(items: list[PublicationItem]) -> list[ReviewTrack]:
+        return [
+            ReviewTrack(
+                source_track_id=item.source_track_id,
+                source_name=item.source_name,
+                source_artist=item.source_artist,
+                source_title=item.source_title,
+                source_duration=item.source_duration,
+                spotify_uri=item.spotify_uri,
+                spotify_name=item.spotify_name,
+                spotify_artist=item.spotify_artist,
+                score=item.score,
+                match_type=item.match_type,
+            )
+            for item in items
+        ]
 
     def _approved_available(self, spotify_uri: str) -> bool:
         try:

--- a/tests/test_transfer.py
+++ b/tests/test_transfer.py
@@ -18,7 +18,7 @@ from djsupport.cli import cli
 from djsupport.cache import MatchCache
 from djsupport.rekordbox import Track
 from djsupport.regression import load_local_regressions
-from djsupport.report import PlaylistReport, SyncReport, save_report
+from djsupport.report import PlaylistReport, SyncReport, save_report, save_review_csv
 from djsupport.spotify import RateLimitError
 from djsupport.transfer import (
     AccountPublishingGuards,
@@ -1817,6 +1817,44 @@ class TestRekordboxBatchExecution:
 
 
 class TestTransferPublicationLifecycle:
+    def test_mixed_publication_retains_one_review_entry_per_source_track(
+        self, tmp_path,
+    ):
+        spotify = StatefulSpotify({
+            ("Known Artist", "Known Track"): _match(
+                "spotify:track:known", "Known Track", "Known Artist",
+            ),
+        })
+        storage = InMemoryStorage()
+
+        report = Transfer(
+            publishing_guards=TEST_PUBLISHING_GUARDS,
+            source=FixtureBeatportSource(FIXTURE), spotify=spotify,
+            matching_knowledge=storage, publication_storage=storage,
+        ).execute(TransferRequest(source="fixture"))
+        manifest = report.playlists[0].publication_manifest
+        review_csv = tmp_path / "review.csv"
+        save_review_csv(report, str(review_csv))
+
+        assert [item.source_track_id for item in manifest.items] == ["bp-1", "bp-2"]
+        assert [item.spotify_uri for item in manifest.items] == [
+            "spotify:track:known", "",
+        ]
+        with review_csv.open(newline="") as csv_file:
+            rows = list(csv.DictReader(csv_file))
+        assert [row["source_track_id"] for row in rows] == ["bp-1", "bp-2"]
+        assert rows[1] == {
+            "source_track_id": "bp-2",
+            "source_track": "New Artist - New Track",
+            "source_artist": "New Artist",
+            "source_title": "New Track",
+            "source_duration": "420",
+            "spotify_url": "",
+            "spotify_track": "",
+            "score": "",
+            "match_type": "unmatched",
+        }
+
     def test_prepared_transfer_is_visible_before_source_intake_and_resumes(self, tmp_path):
         class CountingSource(FixtureBeatportSource):
             consumptions = 0
@@ -2406,10 +2444,49 @@ class TestTransferPublicationLifecycle:
             approved_at=datetime(2026, 8, 1),
         ))
 
-        assert json.loads(path.read_text())["version"] == 3
+        assert json.loads(path.read_text())["version"] == 4
         assert len(FilePublicationStorage(path).mirrors_for_account(
             "spotify-user-1"
         )) == 1
+
+    def test_version_three_publication_without_unmatched_entries_remains_readable(
+        self, tmp_path,
+    ):
+        path = tmp_path / "publication-manifests.json"
+        path.write_text(json.dumps({
+            "version": 3,
+            "manifests": [{
+                "account_id": "spotify-user-1",
+                "spotify_playlist_id": "legacy-playlist",
+                "spotify_playlist_name": "Legacy",
+                "source_label": "Beatport",
+                "source_reference": "legacy-chart",
+                "created_at": "2026-07-31T12:00:00",
+                "mode": "snapshot",
+                "items": [{
+                    "source_track_id": "legacy-1",
+                    "source_name": "Legacy Artist - Legacy Track",
+                    "source_artist": "Legacy Artist",
+                    "source_title": "Legacy Track",
+                    "spotify_uri": "spotify:track:abcdefghijklmnopqrstuv",
+                    "spotify_name": "Legacy Track",
+                    "spotify_artist": "Legacy Artist",
+                    "score": 95.0,
+                    "match_type": "exact",
+                }],
+            }],
+            "approvals": [],
+            "mirrors": [],
+        }))
+
+        manifest = FilePublicationStorage(path).publication_for_playlist(
+            "spotify-user-1", "legacy-playlist",
+        )
+
+        assert manifest is not None
+        assert manifest.items[0].source_duration == 0
+        assert manifest.items[0].authoritative is False
+        assert manifest.managed_items == manifest.items
 
 class TestProvisionalPlaylistApproval:
     def publish(self):
@@ -2489,6 +2566,101 @@ class TestProvisionalPlaylistApproval:
         assert review.corrections == (review.approved[1],)
         assert storage.corrections == [review.approved[1]]
 
+    def test_unmatched_row_can_be_corrected_in_source_order_and_is_idempotent(
+        self, tmp_path,
+    ):
+        spotify = StatefulSpotify({
+            ("Known Artist", "Known Track"): _match(
+                "spotify:track:known", "Known Track", "Known Artist",
+            ),
+        })
+        storage = InMemoryStorage()
+        transfer = Transfer(
+            publishing_guards=TEST_PUBLISHING_GUARDS,
+            source=FixtureBeatportSource(FIXTURE), spotify=spotify,
+            matching_knowledge=storage, publication_storage=storage,
+        )
+        report = transfer.execute(TransferRequest(source="fixture"))
+        playlist_id = report.playlists[0].spotify_playlist_id
+        spotify.playlists[playlist_id]["tracks"] = [
+            "spotify:track:manual-before",
+            "spotify:track:known",
+            "spotify:track:manual-after",
+        ]
+        review_csv = tmp_path / "review.csv"
+        review_csv.write_text(
+            "source_track_id,spotify_url\n"
+            "bp-2,spotify:track:abcdefghijklmnopqrstuv\n"
+        )
+
+        first = transfer.approve(playlist_id, corrections=review_csv)
+        second = transfer.approve(playlist_id, corrections=review_csv)
+
+        assert spotify.playlists[playlist_id]["tracks"] == [
+            "spotify:track:manual-before",
+            "spotify:track:known",
+            "spotify:track:abcdefghijklmnopqrstuv",
+            "spotify:track:manual-after",
+        ]
+        assert [item.source_track_id for item in first.approved] == ["bp-1", "bp-2"]
+        assert first.rejected == ()
+        assert first.corrections == (first.approved[1],)
+        assert second.approved == first.approved
+        assert spotify.playlist_replacements == 1
+        assert storage.corrections == [first.approved[1], second.approved[1]]
+
+    def test_blank_unmatched_row_remains_unresolved_not_rejected(self, tmp_path):
+        spotify = StatefulSpotify({
+            ("Known Artist", "Known Track"): _match(
+                "spotify:track:known", "Known Track", "Known Artist",
+            ),
+        })
+        storage = InMemoryStorage()
+        transfer = Transfer(
+            publishing_guards=TEST_PUBLISHING_GUARDS,
+            source=FixtureBeatportSource(FIXTURE), spotify=spotify,
+            matching_knowledge=storage, publication_storage=storage,
+        )
+        report = transfer.execute(TransferRequest(source="fixture"))
+        playlist_id = report.playlists[0].spotify_playlist_id
+        review_csv = tmp_path / "review.csv"
+        review_csv.write_text("source_track_id,spotify_url\nbp-2,\n")
+
+        outcome = transfer.approve(playlist_id, corrections=review_csv)
+
+        assert [item.source_track_id for item in outcome.approved] == ["bp-1"]
+        assert outcome.rejected == ()
+        assert storage.rejected_matches == []
+
+    def test_preview_reports_unmatched_review_rows_without_publication(
+        self, tmp_path,
+    ):
+        spotify = StatefulSpotify({
+            ("Known Artist", "Known Track"): _match(
+                "spotify:track:known", "Known Track", "Known Artist",
+            ),
+        })
+        storage = InMemoryStorage()
+        transfer = Transfer(
+            publishing_guards=TEST_PUBLISHING_GUARDS,
+            source=FixtureBeatportSource(FIXTURE), spotify=spotify,
+            matching_knowledge=storage, publication_storage=storage,
+        )
+
+        report = transfer.execute(TransferRequest(source="fixture", preview=True))
+        review_csv = tmp_path / "preview.csv"
+        save_review_csv(report, str(review_csv))
+
+        with review_csv.open(newline="") as csv_file:
+            rows = list(csv.DictReader(csv_file))
+        assert [(row["source_track_id"], row["spotify_url"]) for row in rows] == [
+            ("bp-1", "https://open.spotify.com/track/known"), ("bp-2", ""),
+        ]
+        assert storage.publications == []
+        assert spotify.playlists == {"existing": ["spotify:track:untouched"]}
+        with pytest.raises(ValueError, match="No Provisional Playlist"):
+            transfer.approve("preview-only", corrections=review_csv)
+
     def test_unchanged_review_rows_are_ordinary_approvals(self, tmp_path):
         transfer, _, storage, playlist_id = self.publish()
         review_csv = tmp_path / "review.csv"
@@ -2511,6 +2683,7 @@ class TestProvisionalPlaylistApproval:
         ("rows", "message"),
         [
             ([{"source_track_id": "missing", "spotify_url": "spotify:track:abcdefghijklmnopqrstuv"}], "unknown source_track_id"),
+            ([{"source_track_id": "", "spotify_url": "spotify:track:abcdefghijklmnopqrstuv"}], "unknown source_track_id"),
             ([{"source_track_id": "bp-1", "spotify_url": "https://example.com/track/abcdefghijklmnopqrstuv"}], "invalid Spotify track"),
             ([{"source_track_id": "bp-1", "spotify_url": "https://example.com/track/known"}], "invalid Spotify track"),
             ([
@@ -2541,6 +2714,32 @@ class TestProvisionalPlaylistApproval:
 
         assert spotify.playlists[playlist_id]["tracks"] == original
         assert storage.approvals == []
+        assert storage.corrections == []
+
+    def test_unresolvable_correction_fails_before_playlist_or_knowledge_mutation(
+        self, tmp_path,
+    ):
+        transfer, spotify, storage, playlist_id = self.publish()
+        original = list(spotify.playlists[playlist_id]["tracks"])
+        spotify.spotify_track = lambda uri: {
+            "uri": "spotify:track:zyxwvutsrqponmlkjihgfe",
+            "name": "Different Track",
+            "artist": "Different Artist",
+        }
+        review_csv = tmp_path / "review.csv"
+        review_csv.write_text(
+            "source_track_id,spotify_url\n"
+            "bp-2,spotify:track:abcdefghijklmnopqrstuv\n"
+        )
+
+        with pytest.raises(ValueError, match="did not resolve"):
+            transfer.approve(playlist_id, corrections=review_csv)
+
+        assert spotify.playlists[playlist_id]["tracks"] == original
+        assert spotify.playlist_replacements == 0
+        assert storage.approvals == []
+        assert storage.approved_matches == []
+        assert storage.rejected_matches == []
         assert storage.corrections == []
 
     def test_correction_is_durable_approved_knowledge_and_local_regression(

--- a/tests/test_transfer.py
+++ b/tests/test_transfer.py
@@ -371,7 +371,7 @@ class TestProtectedTransferBehavior:
             "title similarity 92", "artist similarity 88",
         )
 
-    def test_match_collision_is_reported_and_not_counted_as_representation(self):
+    def test_match_collision_is_reported_and_retained_for_correction(self, tmp_path):
         shared = _match("spotify:track:shared", "Shared", "Artist")
         spotify = StatefulSpotify({
             ("Known Artist", "Known Track"): shared,
@@ -379,11 +379,12 @@ class TestProtectedTransferBehavior:
         })
         storage = InMemoryStorage()
 
-        report = Transfer(
+        transfer = Transfer(
             publishing_guards=TEST_PUBLISHING_GUARDS,
             source=FixtureBeatportSource(FIXTURE), spotify=spotify,
             matching_knowledge=storage, publication_storage=storage,
-        ).execute(TransferRequest(source="fixture"))
+        )
+        report = transfer.execute(TransferRequest(source="fixture"))
 
         playlist = report.playlists[0]
         assert report.total_matched == 0
@@ -391,7 +392,27 @@ class TestProtectedTransferBehavior:
         assert [item.source_track_id for item in playlist.match_collisions] == [
             "bp-1", "bp-2",
         ]
+        assert [
+            item.source_track_id for item in playlist.publication_manifest.items
+        ] == ["bp-1", "bp-2"]
         assert spotify.playlists[playlist.spotify_playlist_id]["tracks"] == []
+
+        review_csv = tmp_path / "collisions.csv"
+        review_csv.write_text(
+            "source_track_id,spotify_url\n"
+            "bp-1,spotify:track:abcdefghijklmnopqrstuv\n"
+            "bp-2,spotify:track:zyxwvutsrqponmlkjihgfe\n"
+        )
+        outcome = transfer.approve(
+            playlist.spotify_playlist_id, corrections=review_csv,
+        )
+
+        assert outcome.status == ApprovalStatus.APPROVED
+        assert [item.source_track_id for item in outcome.approved] == ["bp-1", "bp-2"]
+        assert spotify.playlists[playlist.spotify_playlist_id]["tracks"] == [
+            "spotify:track:abcdefghijklmnopqrstuv",
+            "spotify:track:zyxwvutsrqponmlkjihgfe",
+        ]
 
     def test_repeated_occurrence_of_same_source_track_is_not_a_collision(self):
         class RepeatedSource:
@@ -2599,8 +2620,8 @@ class TestProvisionalPlaylistApproval:
         assert spotify.playlists[playlist_id]["tracks"] == [
             "spotify:track:manual-before",
             "spotify:track:known",
-            "spotify:track:abcdefghijklmnopqrstuv",
             "spotify:track:manual-after",
+            "spotify:track:abcdefghijklmnopqrstuv",
         ]
         assert [item.source_track_id for item in first.approved] == ["bp-1", "bp-2"]
         assert first.rejected == ()
@@ -2692,6 +2713,10 @@ class TestProvisionalPlaylistApproval:
             ], "repeats source_track_id"),
             ([
                 {"source_track_id": "bp-1", "spotify_url": "spotify:track:known"},
+                {"source_track_id": "bp-1", "spotify_url": "spotify:track:abcdefghijklmnopqrstuv"},
+            ], "repeats source_track_id"),
+            ([
+                {"source_track_id": "bp-1", "spotify_url": ""},
                 {"source_track_id": "bp-1", "spotify_url": "spotify:track:abcdefghijklmnopqrstuv"},
             ], "repeats source_track_id"),
         ],
@@ -2936,8 +2961,8 @@ class TestProvisionalPlaylistApproval:
 
         assert spotify.playlists[playlist_id]["tracks"] == [
             "spotify:track:known",
-            "spotify:track:abcdefghijklmnopqrstuv",
             "spotify:track:manual",
+            "spotify:track:abcdefghijklmnopqrstuv",
         ]
         assert spotify.playlist_replacements == 1
 

--- a/tests/test_transfer.py
+++ b/tests/test_transfer.py
@@ -401,6 +401,19 @@ class TestProtectedTransferBehavior:
         review_csv.write_text(
             "source_track_id,spotify_url\n"
             "bp-1,spotify:track:abcdefghijklmnopqrstuv\n"
+        )
+        partial = transfer.approve(
+            playlist.spotify_playlist_id, corrections=review_csv,
+        )
+
+        assert partial.status == ApprovalStatus.NEEDS_REVIEW
+        assert [item.source_track_id for item in partial.approved] == ["bp-1"]
+        assert [item.source_track_id for item in partial.collisions] == ["bp-2"]
+        assert partial.rejected == ()
+
+        review_csv.write_text(
+            "source_track_id,spotify_url\n"
+            "bp-1,spotify:track:abcdefghijklmnopqrstuv\n"
             "bp-2,spotify:track:zyxwvutsrqponmlkjihgfe\n"
         )
         outcome = transfer.approve(


### PR DESCRIPTION
## Summary
- retain unmatched and colliding source tracks in playlist-scoped review manifests and CSVs
- accept validated Corrections for unmatched rows while preserving source order and user-added tracks
- keep blank and partially colliding rows unresolved, with idempotent Approved Match and local regression promotion
- migrate publication manifests to v4 while reading v1-v3 records with compatible defaults

## Validation
- 456 offline tests passed
- Python compilation passed
- 15 repository privacy tests passed
- diff whitespace validation passed
- final Standards review: 0 findings
- final Spec review: 0 blockers, no scope creep

Closes #62