### PR TITLE
Migrate 0.3.0 local data safely

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Added
 
+- Explicit, preview-first migration of known 0.3.0 working-directory cache and
+  playlist-state files into versioned application data, with verified backup,
+  atomic rollback, privacy-safe aggregate reporting, and idempotent apply
 - Versioned, timestamped local-data backup archives and integrity-checked,
   preview-first, conflict-aware atomic restore; OAuth credentials and unrelated
   files are excluded

--- a/README.md
+++ b/README.md
@@ -87,6 +87,27 @@ If Approval or playlist-state truth conflicts, restore stops without mutation
 and prints the conflict identifier. Resolve it explicitly with
 `--resolve 'CONFLICT_ID=current'` or `--resolve 'CONFLICT_ID=archive'`.
 
+### Upgrade from 0.3.0
+
+Migration is explicit and preview-first. Select the single working directory
+that contains your old 0.3.0 files, review the aggregate-only report, and then
+apply the same migration:
+
+```bash
+djsupport migrate-0-3 /path/to/old-working-directory
+djsupport migrate-0-3 /path/to/old-working-directory --apply
+```
+
+Apply first creates and verifies a current-format backup. Legacy cache entries
+remain non-authoritative retained proposals; current matching knowledge wins
+conflicts. Rekordbox relationships require an explicit future relink because
+0.3.0 did not retain safe Spotify account ownership. Beatport relationships are
+kept only as unmanaged historical Snapshots. No Spotify request is made, and
+the legacy directory is never changed or deleted. Repeating apply is safe.
+
+See [upgrade guidance](docs/upgrading.md) and
+[backup and restore details](docs/backup-and-restore.md).
+
 ### List playlists
 
 Preview what playlists are available in your Rekordbox export:

--- a/agent.md
+++ b/agent.md
@@ -36,6 +36,7 @@ djsupport/
   report.py     # Transfer outcome terminal, Markdown, and Correction CSV reports
   transfer.py   # Durable Transfer/Batch orchestration, checkpoints, and publication
   backup.py     # Versioned local-data backup, preview, merge, and atomic restore
+  migration.py  # Explicit preview/apply migration of known 0.3.0 local data
   static/       # Web frontend (index.html with Tailwind CSS)
 tests/          # pytest suite
 docs/           # Plans, reports, and solution docs
@@ -61,6 +62,8 @@ djsupport web --port 3000       # Custom port
 djsupport backup                # Create a timestamped local-data archive
 djsupport restore <archive>     # Validate and preview an archive
 djsupport restore <archive> --apply  # Apply a conflict-free restore
+djsupport migrate-0-3 <directory>    # Preview 0.3.0 local-data migration
+djsupport migrate-0-3 <directory> --apply  # Back up, verify, and apply migration
 
 # Rekordbox Transfer flags
 djsupport sync --playlist "My Playlist"  # Select a playlist (repeat for a Batch)

--- a/djsupport/backup.py
+++ b/djsupport/backup.py
@@ -20,8 +20,9 @@ SUPPORTED_SCHEMAS = {
     "matching-knowledge.json": (1,),
     "transfers.json": (1,),
     "publication-manifests.transfers.json": (1,),
-    "publication-manifests.json": (1, 2, 3),
+    "publication-manifests.json": (1, 2, 3, 4),
     "playlist-state.json": (1, 2),
+    "legacy-migration.json": (1,),
 }
 DATA_FILES = tuple(SUPPORTED_SCHEMAS)
 SECRET_KEYS = {
@@ -312,6 +313,33 @@ class LocalDataBackup:
             for item in incoming.get("approvals", incoming.get("reviews", [])):
                 if item not in combined["approvals"]:
                     combined["approvals"].append(item)
+        elif path == "legacy-migration.json":
+            for field in ("relink_candidates", "historical_snapshots"):
+                combined.setdefault(field, [])
+                for item in incoming.get(field, []):
+                    identity = (
+                        item.get("legacy_key"), item.get("source_label"),
+                        item.get("spotify_playlist_id"),
+                    )
+                    existing = next((
+                        value for value in combined[field]
+                        if (
+                            value.get("legacy_key"), value.get("source_label"),
+                            value.get("spotify_playlist_id"),
+                        ) == identity
+                    ), None)
+                    if existing is None:
+                        combined[field].append(item)
+                        changes.append(f"add legacy migration record: {field}")
+                    elif existing != item:
+                        safe_identity = hashlib.sha256(
+                            repr(identity).encode()
+                        ).hexdigest()[:12]
+                        self._resolve_conflict(
+                            combined[field], combined[field].index(existing), item,
+                            "migration", path, conflicts, resolutions,
+                            label=f"{field}:{safe_identity}",
+                        )
         return combined
 
     @staticmethod

--- a/djsupport/cli.py
+++ b/djsupport/cli.py
@@ -162,6 +162,35 @@ def restore_local_data(
     click.echo("Restore completed.")
 
 
+@cli.command("migrate-0-3")
+@click.argument(
+    "legacy_directory", type=click.Path(exists=True, file_okay=False),
+)
+@click.option("--apply", is_flag=True, help="Apply the validated migration preview.")
+def migrate_0_3(legacy_directory: str, apply: bool) -> None:
+    """Preview migration of one explicitly selected 0.3.0 data directory."""
+    from djsupport.backup import default_app_data_path
+    from djsupport.migration import LegacyMigration
+
+    report = LegacyMigration(default_app_data_path()).preview(legacy_directory)
+    if not report.valid:
+        raise click.ClickException("; ".join(report.errors))
+    click.echo(f"Detected files: {report.detected_files}")
+    click.echo(f"Cache records: {report.cache_records}")
+    click.echo(f"Proposed cache imports: {report.proposed_cache_imports}")
+    click.echo(f"Conflicts: {report.conflicts}")
+    click.echo(f"Skipped: {report.skipped}")
+    click.echo(f"Relink required: {report.relink_required}")
+    click.echo(f"Historical Snapshots: {report.historical_snapshots}")
+    if not apply:
+        click.echo("Preview only; current and legacy data were not changed.")
+        return
+    result = LegacyMigration(default_app_data_path()).apply(legacy_directory)
+    if not result.applied:
+        raise click.ClickException("; ".join(result.errors))
+    click.echo("Migration completed; legacy files were left unchanged.")
+
+
 @cli.command()
 @click.argument("xml_path", required=False, type=click.Path(exists=True, dir_okay=False))
 @click.option(

--- a/djsupport/cli.py
+++ b/djsupport/cli.py
@@ -164,7 +164,7 @@ def restore_local_data(
 
 @cli.command("migrate-0-3")
 @click.argument(
-    "legacy_directory", type=click.Path(exists=True, file_okay=False),
+    "legacy_directory", type=click.Path(),
 )
 @click.option("--apply", is_flag=True, help="Apply the validated migration preview.")
 def migrate_0_3(legacy_directory: str, apply: bool) -> None:

--- a/djsupport/migration.py
+++ b/djsupport/migration.py
@@ -259,7 +259,11 @@ class LegacyMigration:
                 not isinstance(entry["matched"], bool)
                 or not isinstance(entry["timestamp"], str)
                 or not isinstance(entry["threshold"], int)
+                or isinstance(entry["threshold"], bool)
                 or not 0 <= entry["threshold"] <= 100
+                or entry.get("match_type") not in (
+                    None, "exact", "fallback_version",
+                )
             ):
                 raise ValueError("invalid cache entry")
             datetime.fromisoformat(entry["timestamp"])
@@ -306,6 +310,11 @@ class LegacyMigration:
                 raise ValueError("invalid playlist-state entry")
             if entry["source_type"] != expected_source:
                 raise ValueError("playlist-state source type is ambiguous")
+            if not (
+                entry["prefix_used"] is None
+                or isinstance(entry["prefix_used"], str)
+            ):
+                raise ValueError("invalid playlist-state prefix")
             datetime.fromisoformat(entry["last_synced"])
         return data["entries"]
 

--- a/djsupport/migration.py
+++ b/djsupport/migration.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import os
+import re
 import shutil
 import tempfile
 from dataclasses import dataclass
@@ -22,6 +23,10 @@ LEGACY_STATE_FILES = (
     ".djsupport_playlists.json",
     ".djsupport_beatport_playlists.json",
 )
+MIGRATION_VERSION = 1
+MATCHING_KNOWLEDGE_VERSION = 1
+SUPPORTED_PUBLICATION_VERSIONS = (1, 2, 3, 4)
+SPOTIFY_TRACK_URI = re.compile(r"^spotify:track:[A-Za-z0-9]{22}$")
 CACHE_FIELDS = {
     "spotify_uri", "spotify_name", "spotify_artist", "score", "matched",
     "timestamp", "threshold", "match_type",
@@ -110,9 +115,12 @@ class LegacyMigration:
         raise OSError("could not allocate backup name")
 
     def _plan(self, legacy: Path) -> tuple[MigrationReport, dict[str, bytes]]:
+        if not legacy.is_dir():
+            raise ValueError("Selected legacy directory is unavailable")
         detected = cache_records = conflicts = skipped = relinks = snapshots = 0
         errors: list[str] = []
         incoming_cache: dict[str, dict] = {}
+        ambiguous_cache_keys: set[str] = set()
         relink_candidates: list[dict] = []
         historical_snapshots: list[dict] = []
 
@@ -131,20 +139,35 @@ class LegacyMigration:
                     elif previous != entry:
                         conflicts += 1
                         skipped += 1
+                        ambiguous_cache_keys.add(key)
             except (OSError, ValueError, TypeError, json.JSONDecodeError):
                 errors.append(f"{name}: malformed or unsupported")
 
+        publication_accounts = self._read_publication_accounts()
         for name in LEGACY_STATE_FILES:
             path = legacy / name
             if not path.is_file() or path.is_symlink():
                 continue
             detected += 1
             try:
-                entries = self._read_state(path)
+                expected_source = (
+                    "rekordbox" if name == ".djsupport_playlists.json"
+                    else "beatport"
+                )
+                entries = self._read_state(path, expected_source)
                 for key, entry in entries.items():
+                    account_id = None
+                    if expected_source == "rekordbox":
+                        accounts = publication_accounts.get((
+                            entry["spotify_id"], entry["source_path"],
+                        ), set())
+                        if len(accounts) == 1:
+                            account_id = next(iter(accounts))
+                        elif len(accounts) > 1:
+                            conflicts += 1
                     record = {
                         "legacy_key": key,
-                        "account_id": None,
+                        "account_id": account_id,
                         "spotify_playlist_id": entry["spotify_id"],
                         "spotify_name": entry["spotify_name"],
                         "source_reference": entry["source_path"],
@@ -168,6 +191,8 @@ class LegacyMigration:
         current = self._read_current_matching()
         proposed = 0
         for key, entry in incoming_cache.items():
+            if key in ambiguous_cache_keys:
+                continue
             legacy_entry = {**entry, "approval_status": None, "source_duration": 0}
             existing = current["entries"].get(key)
             if existing is None:
@@ -230,13 +255,34 @@ class LegacyMigration:
                 raise ValueError("invalid cache entry")
             if set(entry) not in (CACHE_FIELDS, CACHE_FIELDS - {"match_type"}):
                 raise ValueError("invalid cache entry shape")
-            if not isinstance(entry["matched"], bool):
+            if (
+                not isinstance(entry["matched"], bool)
+                or not isinstance(entry["timestamp"], str)
+                or not isinstance(entry["threshold"], int)
+                or not 0 <= entry["threshold"] <= 100
+            ):
                 raise ValueError("invalid cache entry")
+            datetime.fromisoformat(entry["timestamp"])
+            if entry["matched"]:
+                if (
+                    not isinstance(entry["spotify_uri"], str)
+                    or not SPOTIFY_TRACK_URI.fullmatch(entry["spotify_uri"])
+                    or not isinstance(entry["spotify_name"], str)
+                    or not isinstance(entry["spotify_artist"], str)
+                    or not isinstance(entry["score"], (int, float))
+                    or isinstance(entry["score"], bool)
+                    or not 0 <= entry["score"] <= 100
+                ):
+                    raise ValueError("invalid matched cache entry")
+            elif any(entry[field] is not None for field in (
+                "spotify_uri", "spotify_name", "spotify_artist", "score",
+            )):
+                raise ValueError("invalid unmatched cache entry")
             entry.setdefault("match_type", None)
         return data["entries"]
 
     @staticmethod
-    def _read_state(path: Path) -> dict[str, dict]:
+    def _read_state(path: Path, expected_source: str) -> dict[str, dict]:
         data = json.loads(path.read_text())
         if (
             not isinstance(data, dict) or set(data) != {"version", "entries"}
@@ -258,17 +304,24 @@ class LegacyMigration:
                 "source_type",
             )):
                 raise ValueError("invalid playlist-state entry")
+            if entry["source_type"] != expected_source:
+                raise ValueError("playlist-state source type is ambiguous")
+            datetime.fromisoformat(entry["last_synced"])
         return data["entries"]
 
     def _read_current_matching(self) -> dict:
         path = self.app_data / "matching-knowledge.json"
         if not path.exists():
             return {
-                "version": 1, "entries": {}, "local_regressions": [],
+                "version": MATCHING_KNOWLEDGE_VERSION, "entries": {},
+                "local_regressions": [],
                 "approval_conflicts": [],
             }
         data = json.loads(path.read_text())
-        if data.get("version") != 1 or not isinstance(data.get("entries"), dict):
+        if (
+            data.get("version") != MATCHING_KNOWLEDGE_VERSION
+            or not isinstance(data.get("entries"), dict)
+        ):
             raise ValueError("Current matching knowledge is unsupported or malformed")
         return data
 
@@ -276,13 +329,43 @@ class LegacyMigration:
         path = self.app_data / "legacy-migration.json"
         if not path.exists():
             return {
-                "version": 1, "relink_candidates": [],
+                "version": MIGRATION_VERSION, "relink_candidates": [],
                 "historical_snapshots": [],
             }
         data = json.loads(path.read_text())
-        if data.get("version") != 1:
+        if (
+            not isinstance(data, dict)
+            or set(data) != {
+                "version", "relink_candidates", "historical_snapshots",
+            }
+            or data.get("version") != MIGRATION_VERSION
+            or not isinstance(data["relink_candidates"], list)
+            or not isinstance(data["historical_snapshots"], list)
+        ):
             raise ValueError("Current migration records are unsupported")
         return data
+
+    def _read_publication_accounts(self) -> dict[tuple[str, str], set[str]]:
+        path = self.app_data / "publication-manifests.json"
+        if not path.exists():
+            return {}
+        data = json.loads(path.read_text())
+        if (
+            data.get("version") not in SUPPORTED_PUBLICATION_VERSIONS
+            or not isinstance(data.get("manifests", []), list)
+            or not isinstance(data.get("mirrors", []), list)
+        ):
+            raise ValueError("Current publication state is unsupported or malformed")
+        accounts: dict[tuple[str, str], set[str]] = {}
+        for item in [*data.get("manifests", []), *data.get("mirrors", [])]:
+            account = item.get("account_id")
+            playlist = item.get("spotify_playlist_id")
+            reference = item.get("source_reference")
+            if all(isinstance(value, str) and value for value in (
+                account, playlist, reference,
+            )):
+                accounts.setdefault((playlist, reference), set()).add(account)
+        return accounts
 
     def _commit(self, writes: dict[str, bytes]) -> None:
         self.app_data.mkdir(parents=True, exist_ok=True)
@@ -310,7 +393,9 @@ class LegacyMigration:
                 for name in reversed(committed):
                     target = self.app_data / name
                     if existed[name]:
-                        shutil.copy2(originals / name, target)
+                        rollback = staged / f"{name}.rollback"
+                        shutil.copy2(originals / name, rollback)
+                        os.replace(rollback, target)
                     else:
                         target.unlink(missing_ok=True)
                 raise

--- a/djsupport/migration.py
+++ b/djsupport/migration.py
@@ -1,0 +1,316 @@
+"""Explicit, privacy-safe migration of DJ Support 0.3.0 local data."""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import tempfile
+from dataclasses import dataclass
+from datetime import datetime, timedelta
+from pathlib import Path
+from typing import Callable
+
+from djsupport.backup import LocalDataBackup
+
+
+LEGACY_CACHE_FILES = (
+    ".djsupport_cache.json",
+    ".djsupport_beatport_cache.json",
+)
+LEGACY_STATE_FILES = (
+    ".djsupport_playlists.json",
+    ".djsupport_beatport_playlists.json",
+)
+CACHE_FIELDS = {
+    "spotify_uri", "spotify_name", "spotify_artist", "score", "matched",
+    "timestamp", "threshold", "match_type",
+}
+STATE_FIELDS = {
+    "spotify_id", "spotify_name", "source_path", "last_synced",
+    "prefix_used", "source_type",
+}
+
+
+@dataclass(frozen=True)
+class MigrationReport:
+    valid: bool
+    detected_files: int = 0
+    cache_records: int = 0
+    proposed_cache_imports: int = 0
+    conflicts: int = 0
+    skipped: int = 0
+    relink_required: int = 0
+    historical_snapshots: int = 0
+    errors: tuple[str, ...] = ()
+
+
+@dataclass(frozen=True)
+class MigrationResult:
+    applied: bool
+    report: MigrationReport
+    errors: tuple[str, ...] = ()
+
+
+class LegacyMigration:
+    """Inspect and apply one explicitly selected legacy directory."""
+
+    def __init__(
+        self, app_data: str | Path, *,
+        replace_file: Callable[[Path, Path], None] | None = None,
+    ) -> None:
+        self.app_data = Path(app_data)
+        self._replace_file = replace_file or self._replace
+
+    @staticmethod
+    def _replace(source: Path, target: Path) -> None:
+        os.replace(source, target)
+
+    def preview(self, legacy_directory: str | Path) -> MigrationReport:
+        try:
+            report, _ = self._plan(Path(legacy_directory))
+            return report
+        except (OSError, ValueError, TypeError, json.JSONDecodeError) as exc:
+            return MigrationReport(False, errors=(str(exc),))
+
+    def apply(self, legacy_directory: str | Path) -> MigrationResult:
+        archive: Path | None = None
+        try:
+            report, writes = self._plan(Path(legacy_directory))
+            if not report.valid:
+                return MigrationResult(False, report, report.errors)
+            archive = self._create_backup()
+            verification = LocalDataBackup(self.app_data).preview(archive)
+            if not verification.valid:
+                raise ValueError("current-format backup verification failed")
+            self._commit(writes)
+            return MigrationResult(True, report)
+        except (OSError, ValueError, TypeError, json.JSONDecodeError) as exc:
+            if archive is not None:
+                archive.unlink(missing_ok=True)
+            report = locals().get("report", MigrationReport(False))
+            return MigrationResult(False, report, (self._safe_error(exc),))
+
+    @staticmethod
+    def _safe_error(exc: Exception) -> str:
+        if isinstance(exc, OSError):
+            return "Migration storage operation failed; current data was unchanged"
+        return str(exc)
+
+    def _create_backup(self) -> Path:
+        backup = LocalDataBackup(self.app_data)
+        now = datetime.now()
+        for offset in range(60):
+            try:
+                return backup.create(
+                    self.app_data / "backups", now=now + timedelta(seconds=offset),
+                )
+            except FileExistsError:
+                continue
+        raise OSError("could not allocate backup name")
+
+    def _plan(self, legacy: Path) -> tuple[MigrationReport, dict[str, bytes]]:
+        detected = cache_records = conflicts = skipped = relinks = snapshots = 0
+        errors: list[str] = []
+        incoming_cache: dict[str, dict] = {}
+        relink_candidates: list[dict] = []
+        historical_snapshots: list[dict] = []
+
+        for name in LEGACY_CACHE_FILES:
+            path = legacy / name
+            if not path.is_file() or path.is_symlink():
+                continue
+            detected += 1
+            try:
+                entries = self._read_cache(path)
+                cache_records += len(entries)
+                for key, entry in entries.items():
+                    previous = incoming_cache.get(key)
+                    if previous is None:
+                        incoming_cache[key] = entry
+                    elif previous != entry:
+                        conflicts += 1
+                        skipped += 1
+            except (OSError, ValueError, TypeError, json.JSONDecodeError):
+                errors.append(f"{name}: malformed or unsupported")
+
+        for name in LEGACY_STATE_FILES:
+            path = legacy / name
+            if not path.is_file() or path.is_symlink():
+                continue
+            detected += 1
+            try:
+                entries = self._read_state(path)
+                for key, entry in entries.items():
+                    record = {
+                        "legacy_key": key,
+                        "account_id": None,
+                        "spotify_playlist_id": entry["spotify_id"],
+                        "spotify_name": entry["spotify_name"],
+                        "source_reference": entry["source_path"],
+                        "last_transferred_at": entry["last_synced"],
+                    }
+                    if name == ".djsupport_playlists.json":
+                        relink_candidates.append({
+                            **record, "source_label": "Rekordbox",
+                            "status": "relink_required",
+                        })
+                        relinks += 1
+                    else:
+                        historical_snapshots.append({
+                            **record, "source_label": "Beatport",
+                            "mode": "snapshot", "managed": False,
+                        })
+                        snapshots += 1
+            except (OSError, ValueError, TypeError, json.JSONDecodeError):
+                errors.append(f"{name}: malformed or unsupported")
+
+        current = self._read_current_matching()
+        proposed = 0
+        for key, entry in incoming_cache.items():
+            legacy_entry = {**entry, "approval_status": None, "source_duration": 0}
+            existing = current["entries"].get(key)
+            if existing is None:
+                current["entries"][key] = legacy_entry
+                proposed += 1
+            elif existing != legacy_entry:
+                conflicts += 1
+                skipped += 1
+
+        migration_records = self._read_migration_records()
+        for field, values in (
+            ("relink_candidates", relink_candidates),
+            ("historical_snapshots", historical_snapshots),
+        ):
+            for value in values:
+                identity = self._migration_identity(value)
+                existing = next((
+                    item for item in migration_records[field]
+                    if self._migration_identity(item) == identity
+                ), None)
+                if existing is None:
+                    migration_records[field].append(value)
+                elif existing != value:
+                    conflicts += 1
+                    skipped += 1
+
+        report = MigrationReport(
+            not errors, detected, cache_records, proposed, conflicts, skipped,
+            relinks, snapshots, tuple(errors),
+        )
+        writes = {}
+        if incoming_cache:
+            writes["matching-knowledge.json"] = self._json_bytes(current)
+        if relink_candidates or historical_snapshots:
+            writes["legacy-migration.json"] = self._json_bytes(migration_records)
+        return report, writes
+
+    @staticmethod
+    def _json_bytes(value: dict) -> bytes:
+        return json.dumps(value, indent=2).encode()
+
+    @staticmethod
+    def _migration_identity(value: dict) -> tuple:
+        return (
+            value.get("legacy_key"), value.get("source_label"),
+            value.get("spotify_playlist_id"),
+        )
+
+    @staticmethod
+    def _read_cache(path: Path) -> dict[str, dict]:
+        data = json.loads(path.read_text())
+        if (
+            not isinstance(data, dict) or set(data) != {"version", "entries"}
+            or data.get("version") != 1
+            or not isinstance(data.get("entries"), dict)
+        ):
+            raise ValueError("unsupported cache schema")
+        for key, entry in data["entries"].items():
+            if not isinstance(key, str) or not isinstance(entry, dict):
+                raise ValueError("invalid cache entry")
+            if set(entry) not in (CACHE_FIELDS, CACHE_FIELDS - {"match_type"}):
+                raise ValueError("invalid cache entry shape")
+            if not isinstance(entry["matched"], bool):
+                raise ValueError("invalid cache entry")
+            entry.setdefault("match_type", None)
+        return data["entries"]
+
+    @staticmethod
+    def _read_state(path: Path) -> dict[str, dict]:
+        data = json.loads(path.read_text())
+        if (
+            not isinstance(data, dict) or set(data) != {"version", "entries"}
+            or data.get("version") not in (1, 2)
+            or not isinstance(data.get("entries"), dict)
+        ):
+            raise ValueError("unsupported playlist-state schema")
+        for key, entry in data["entries"].items():
+            if data["version"] == 1 and "rekordbox_path" in entry:
+                entry["source_path"] = entry.pop("rekordbox_path")
+                entry.setdefault("source_type", "rekordbox")
+            if (
+                not isinstance(key, str) or not isinstance(entry, dict)
+                or set(entry) != STATE_FIELDS
+            ):
+                raise ValueError("invalid playlist-state entry shape")
+            if not all(isinstance(entry[field], str) for field in (
+                "spotify_id", "spotify_name", "source_path", "last_synced",
+                "source_type",
+            )):
+                raise ValueError("invalid playlist-state entry")
+        return data["entries"]
+
+    def _read_current_matching(self) -> dict:
+        path = self.app_data / "matching-knowledge.json"
+        if not path.exists():
+            return {
+                "version": 1, "entries": {}, "local_regressions": [],
+                "approval_conflicts": [],
+            }
+        data = json.loads(path.read_text())
+        if data.get("version") != 1 or not isinstance(data.get("entries"), dict):
+            raise ValueError("Current matching knowledge is unsupported or malformed")
+        return data
+
+    def _read_migration_records(self) -> dict:
+        path = self.app_data / "legacy-migration.json"
+        if not path.exists():
+            return {
+                "version": 1, "relink_candidates": [],
+                "historical_snapshots": [],
+            }
+        data = json.loads(path.read_text())
+        if data.get("version") != 1:
+            raise ValueError("Current migration records are unsupported")
+        return data
+
+    def _commit(self, writes: dict[str, bytes]) -> None:
+        self.app_data.mkdir(parents=True, exist_ok=True)
+        with tempfile.TemporaryDirectory(
+            prefix="djsupport-migration-", dir=self.app_data.parent,
+        ) as temporary_name:
+            temporary = Path(temporary_name)
+            staged = temporary / "staged"
+            originals = temporary / "originals"
+            existed = {}
+            for name, content in writes.items():
+                (staged / name).parent.mkdir(parents=True, exist_ok=True)
+                (staged / name).write_bytes(content)
+                target = self.app_data / name
+                existed[name] = target.exists()
+                if target.exists():
+                    originals.mkdir(parents=True, exist_ok=True)
+                    shutil.copy2(target, originals / name)
+            committed = []
+            try:
+                for name in sorted(writes):
+                    self._replace_file(staged / name, self.app_data / name)
+                    committed.append(name)
+            except Exception:
+                for name in reversed(committed):
+                    target = self.app_data / name
+                    if existed[name]:
+                        shutil.copy2(originals / name, target)
+                    else:
+                        target.unlink(missing_ok=True)
+                raise

--- a/docs/backup-and-restore.md
+++ b/docs/backup-and-restore.md
@@ -1,0 +1,22 @@
+# Backup and restore
+
+`djsupport backup` creates a versioned archive in private application storage.
+It includes matching knowledge, Transfer and publication state, migration
+records, and privacy-screened reports. Credentials and unrelated files are not
+included.
+
+Restore is preview-first:
+
+```bash
+djsupport restore /path/to/archive.zip
+djsupport restore /path/to/archive.zip --apply
+```
+
+Archives are checked against their manifest, hashes, known filenames, and
+supported schema versions before use. Restore merges compatible records,
+requires an explicit choice for conflicting truth, stages all writes, and rolls
+back if a commit fails.
+
+The 0.3.0 migration command creates and verifies one of these archives before
+writing. Backups do not replace the unchanged legacy directory; keep or remove
+that directory later according to your own retention policy.

--- a/docs/upgrading.md
+++ b/docs/upgrading.md
@@ -1,0 +1,34 @@
+# Upgrading DJ Support
+
+## From 0.3.0
+
+DJ Support does not migrate working-directory data automatically. Keep the old
+directory intact and explicitly preview its four known 0.3.0 files:
+
+```bash
+djsupport migrate-0-3 /path/to/old-working-directory
+```
+
+The report contains counts only. It does not print track metadata, Spotify
+identifiers, or absolute paths. Unknown files—including credentials and
+reports—are ignored. Malformed or unsupported known files stop migration
+without changing either location.
+
+After reviewing the report, apply it explicitly:
+
+```bash
+djsupport migrate-0-3 /path/to/old-working-directory --apply
+```
+
+Apply creates and verifies a current-format backup before an atomic write.
+Current application-data truth wins every collision. Old cache results remain
+non-authoritative and never become Approved Matches. Old Rekordbox playlist
+state is retained as relink-required because 0.3.0 did not safely retain account
+ownership; no relationship is inferred from a name, path, or playlist content.
+Old Beatport state becomes unmanaged historical Snapshot information. Migration
+makes no Spotify calls and never changes or deletes the old files. Re-running
+apply does not duplicate records.
+
+If apply fails, correct the reported file or storage problem and run preview
+again. A failed validation, backup, conversion, or commit leaves current data
+unchanged.

--- a/tests/test_migration.py
+++ b/tests/test_migration.py
@@ -29,246 +29,382 @@ def _cache_entry(uri_letter="A"):
     }
 
 
-def test_migrate_legacy_directory_previews_without_mutation(tmp_path, monkeypatch):
-    legacy = tmp_path / "legacy"
-    legacy.mkdir()
-    _write_json(legacy / ".djsupport_cache.json", {
-        "version": 1,
-        "entries": {
-            "synthetic artist||synthetic title": _cache_entry(),
-        },
-    })
-    app_data = tmp_path / "app-data"
-    monkeypatch.setattr("djsupport.backup.default_app_data_path", lambda: app_data)
-
-    result = CliRunner().invoke(cli, ["migrate-0-3", str(legacy)])
-
-    assert result.exit_code == 0
-    assert "Preview only" in result.output
-    assert "Detected files: 1" in result.output
-    assert "Cache records: 1" in result.output
-    assert "Proposed cache imports: 1" in result.output
-    assert not app_data.exists()
-    assert (legacy / ".djsupport_cache.json").exists()
-
-
-def test_preview_ignores_unknown_files_and_reports_absent_known_files(tmp_path):
-    legacy = tmp_path / "legacy"
-    legacy.mkdir()
-    (legacy / ".env").write_text("SPOTIPY_CLIENT_SECRET=synthetic-secret")
-    (legacy / "report.md").write_text("/private/synthetic/path")
-
-    report = LegacyMigration(tmp_path / "app-data").preview(legacy)
-
-    assert report.valid
-    assert report.detected_files == 0
-    assert report.skipped == 0
-
-
-@pytest.mark.parametrize("payload", [
-    "not json",
-    json.dumps({"version": 99, "entries": {}}),
-    json.dumps({"version": 1, "entries": []}),
-])
-def test_preview_safely_rejects_malformed_or_unsupported_known_file(
-    tmp_path, payload,
-):
-    legacy = tmp_path / "legacy"
-    legacy.mkdir()
-    (legacy / ".djsupport_cache.json").write_text(payload)
-
-    report = LegacyMigration(tmp_path / "app-data").preview(legacy)
-
-    assert not report.valid
-    assert report.errors == (".djsupport_cache.json: malformed or unsupported",)
-    assert "/" not in report.errors[0]
-
-
-def test_apply_imports_both_caches_as_non_authoritative_and_current_wins(tmp_path):
-    legacy = tmp_path / "legacy"
-    legacy.mkdir()
-    _write_json(legacy / ".djsupport_cache.json", {
-        "version": 1,
-        "entries": {
-            "new||track": _cache_entry("A"),
-            "conflict||track": _cache_entry("B"),
-        },
-    })
-    _write_json(legacy / ".djsupport_beatport_cache.json", {
-        "version": 1, "entries": {"beatport||track": _cache_entry("C")},
-    })
-    app_data = tmp_path / "app-data"
-    _write_json(app_data / "matching-knowledge.json", {
-        "version": 1,
-        "entries": {"conflict||track": {
-            **_cache_entry("D"), "approval_status": "approved",
-            "source_duration": 0,
-        }},
-        "local_regressions": [], "approval_conflicts": [],
-    })
-
-    result = LegacyMigration(app_data).apply(legacy)
-
-    assert result.applied
-    stored = json.loads((app_data / "matching-knowledge.json").read_text())
-    assert stored["entries"]["conflict||track"]["spotify_uri"].endswith("D" * 22)
-    assert stored["entries"]["new||track"]["approval_status"] is None
-    assert stored["entries"]["beatport||track"]["approval_status"] is None
-    assert result.report.proposed_cache_imports == 2
-    assert result.report.conflicts == 1
-    assert any((app_data / "backups").glob("djsupport-backup-*.zip"))
-
-
-def test_state_becomes_unmanaged_history_or_relink_candidate_without_guessing(tmp_path):
-    legacy = tmp_path / "legacy"
-    legacy.mkdir()
-    state = {
-        "version": 2,
-        "entries": {
-            "Synthetic list": {
-                "spotify_id": "playlist-synthetic",
-                "spotify_name": "Synthetic list",
-                "source_path": "Synthetic/Source",
-                "last_synced": "2026-01-01T00:00:00",
-                "prefix_used": "djsupport",
-                "source_type": "rekordbox",
+class TestLegacyMigration:
+    def test_migrate_legacy_directory_previews_without_mutation(
+        self, tmp_path, monkeypatch,
+    ):
+        legacy = tmp_path / "legacy"
+        legacy.mkdir()
+        _write_json(legacy / ".djsupport_cache.json", {
+            "version": 1,
+            "entries": {
+                "synthetic artist||synthetic title": _cache_entry(),
             },
-        },
-    }
-    _write_json(legacy / ".djsupport_playlists.json", state)
-    state["entries"]["Synthetic list"]["source_type"] = "beatport"
-    _write_json(legacy / ".djsupport_beatport_playlists.json", state)
+        })
+        app_data = tmp_path / "app-data"
+        monkeypatch.setattr("djsupport.backup.default_app_data_path", lambda: app_data)
 
-    result = LegacyMigration(tmp_path / "app-data").apply(legacy)
+        result = CliRunner().invoke(cli, ["migrate-0-3", str(legacy)])
 
-    records = json.loads(
-        (tmp_path / "app-data" / "legacy-migration.json").read_text()
-    )
-    assert result.report.relink_required == 1
-    assert result.report.historical_snapshots == 1
-    assert records["relink_candidates"][0]["account_id"] is None
-    assert records["relink_candidates"][0]["status"] == "relink_required"
-    assert records["historical_snapshots"][0]["managed"] is False
-    assert "mirrors" not in records
+        assert result.exit_code == 0
+        assert "Preview only" in result.output
+        assert "Detected files: 1" in result.output
+        assert "Cache records: 1" in result.output
+        assert "Proposed cache imports: 1" in result.output
+        assert not app_data.exists()
+        assert (legacy / ".djsupport_cache.json").exists()
 
 
-def test_apply_is_idempotent_and_leaves_legacy_files_byte_identical(tmp_path):
-    legacy = tmp_path / "legacy"
-    legacy.mkdir()
-    path = legacy / ".djsupport_cache.json"
-    _write_json(path, {"version": 1, "entries": {"new||track": _cache_entry()}})
-    original = path.read_bytes()
-    migration = LegacyMigration(tmp_path / "app-data")
+    def test_preview_ignores_unknown_files_and_reports_absent_known_files(self, tmp_path):
+        legacy = tmp_path / "legacy"
+        legacy.mkdir()
+        (legacy / ".env").write_text("SPOTIPY_CLIENT_SECRET=synthetic-secret")
+        (legacy / "report.md").write_text("/private/synthetic/path")
 
-    first = migration.apply(legacy)
-    first_data = (tmp_path / "app-data" / "matching-knowledge.json").read_bytes()
-    second = migration.apply(legacy)
+        report = LegacyMigration(tmp_path / "app-data").preview(legacy)
 
-    assert first.applied and second.applied
-    assert second.report.proposed_cache_imports == 0
-    assert (tmp_path / "app-data" / "matching-knowledge.json").read_bytes() == first_data
-    assert path.read_bytes() == original
+        assert report.valid
+        assert report.detected_files == 0
+        assert report.skipped == 0
 
+    def test_unavailable_directory_error_does_not_echo_private_path(self, tmp_path):
+        private_path = tmp_path / "private" / "missing"
 
-def test_cli_apply_reports_only_aggregates_and_never_initializes_spotify(
-    tmp_path, monkeypatch,
-):
-    legacy = tmp_path / "private" / "legacy"
-    legacy.mkdir(parents=True)
-    private_metadata = "Never Print This Synthetic Track"
-    _write_json(legacy / ".djsupport_cache.json", {
-        "version": 1,
-        "entries": {private_metadata: _cache_entry()},
-    })
-    app_data = tmp_path / "app-data"
-    monkeypatch.setattr("djsupport.backup.default_app_data_path", lambda: app_data)
-    monkeypatch.setattr(
-        "djsupport.spotify.get_client",
-        lambda: (_ for _ in ()).throw(AssertionError("Spotify must not be called")),
-    )
+        result = CliRunner().invoke(cli, ["migrate-0-3", str(private_path)])
 
-    result = CliRunner().invoke(
-        cli, ["migrate-0-3", str(legacy), "--apply"],
-    )
-
-    assert result.exit_code == 0
-    assert "Migration completed" in result.output
-    assert private_metadata not in result.output
-    assert str(legacy) not in result.output
-    assert "spotify:track:" not in result.output
+        assert result.exit_code != 0
+        assert "Selected legacy directory is unavailable" in result.output
+        assert str(private_path) not in result.output
 
 
-def test_backup_failure_and_commit_failure_leave_current_data_unchanged(
-    tmp_path, monkeypatch,
-):
-    legacy = tmp_path / "legacy"
-    legacy.mkdir()
-    _write_json(legacy / ".djsupport_cache.json", {
-        "version": 1, "entries": {"new||track": _cache_entry()},
-    })
-    _write_json(legacy / ".djsupport_playlists.json", {
-        "version": 2,
-        "entries": {"Synthetic": {
+    @pytest.mark.parametrize("payload", [
+        "not json",
+        json.dumps({"version": 99, "entries": {}}),
+        json.dumps({"version": 1, "entries": []}),
+        json.dumps({
+            "version": 1,
+            "entries": {"synthetic": {
+                **_cache_entry(), "spotify_uri": "not-a-spotify-track-uri",
+            }},
+        }),
+    ])
+    def test_preview_safely_rejects_malformed_or_unsupported_known_file(
+        self,
+        tmp_path, payload,
+    ):
+        legacy = tmp_path / "legacy"
+        legacy.mkdir()
+        (legacy / ".djsupport_cache.json").write_text(payload)
+
+        report = LegacyMigration(tmp_path / "app-data").preview(legacy)
+
+        assert not report.valid
+        assert report.errors == (".djsupport_cache.json: malformed or unsupported",)
+        assert "/" not in report.errors[0]
+
+
+    def test_apply_imports_both_caches_as_non_authoritative_and_current_wins(self, tmp_path):
+        legacy = tmp_path / "legacy"
+        legacy.mkdir()
+        _write_json(legacy / ".djsupport_cache.json", {
+            "version": 1,
+            "entries": {
+                "new||track": _cache_entry("A"),
+                "conflict||track": _cache_entry("B"),
+            },
+        })
+        _write_json(legacy / ".djsupport_beatport_cache.json", {
+            "version": 1, "entries": {"beatport||track": _cache_entry("C")},
+        })
+        app_data = tmp_path / "app-data"
+        _write_json(app_data / "matching-knowledge.json", {
+            "version": 1,
+            "entries": {"conflict||track": {
+                **_cache_entry("D"), "approval_status": "approved",
+                "source_duration": 0,
+            }},
+            "local_regressions": [], "approval_conflicts": [],
+        })
+
+        result = LegacyMigration(app_data).apply(legacy)
+
+        assert result.applied
+        stored = json.loads((app_data / "matching-knowledge.json").read_text())
+        assert stored["entries"]["conflict||track"]["spotify_uri"].endswith("D" * 22)
+        assert stored["entries"]["new||track"]["approval_status"] is None
+        assert stored["entries"]["beatport||track"]["approval_status"] is None
+        assert result.report.proposed_cache_imports == 2
+        assert result.report.conflicts == 1
+        assert any((app_data / "backups").glob("djsupport-backup-*.zip"))
+
+
+    def test_ambiguous_cross_cache_entry_is_reported_and_not_imported(self, tmp_path):
+        legacy = tmp_path / "legacy"
+        legacy.mkdir()
+        _write_json(legacy / ".djsupport_cache.json", {
+            "version": 1, "entries": {"ambiguous||track": _cache_entry("A")},
+        })
+        _write_json(legacy / ".djsupport_beatport_cache.json", {
+            "version": 1, "entries": {"ambiguous||track": _cache_entry("B")},
+        })
+
+        result = LegacyMigration(tmp_path / "app-data").apply(legacy)
+
+        stored = json.loads(
+            (tmp_path / "app-data" / "matching-knowledge.json").read_text()
+        )
+        assert result.report.conflicts == 1
+        assert result.report.skipped == 1
+        assert "ambiguous||track" not in stored["entries"]
+
+
+    def test_state_becomes_unmanaged_history_or_relink_candidate_without_guessing(self, tmp_path):
+        legacy = tmp_path / "legacy"
+        legacy.mkdir()
+        state = {
+            "version": 2,
+            "entries": {
+                "Synthetic list": {
+                    "spotify_id": "playlist-synthetic",
+                    "spotify_name": "Synthetic list",
+                    "source_path": "Synthetic/Source",
+                    "last_synced": "2026-01-01T00:00:00",
+                    "prefix_used": "djsupport",
+                    "source_type": "rekordbox",
+                },
+            },
+        }
+        _write_json(legacy / ".djsupport_playlists.json", state)
+        state["entries"]["Synthetic list"]["source_type"] = "beatport"
+        _write_json(legacy / ".djsupport_beatport_playlists.json", state)
+
+        result = LegacyMigration(tmp_path / "app-data").apply(legacy)
+
+        records = json.loads(
+            (tmp_path / "app-data" / "legacy-migration.json").read_text()
+        )
+        assert result.report.relink_required == 1
+        assert result.report.historical_snapshots == 1
+        assert records["relink_candidates"][0]["account_id"] is None
+        assert records["relink_candidates"][0]["status"] == "relink_required"
+        assert records["historical_snapshots"][0]["managed"] is False
+        assert "mirrors" not in records
+
+
+    def test_relink_candidate_uses_only_one_exact_current_account_match(self, tmp_path):
+        legacy = tmp_path / "legacy"
+        legacy.mkdir()
+        _write_json(legacy / ".djsupport_playlists.json", {
+            "version": 2,
+            "entries": {"Synthetic": {
+                "spotify_id": "playlist-synthetic",
+                "spotify_name": "A renamed destination",
+                "source_path": "Synthetic/Exact Reference",
+                "last_synced": "2026-01-01T00:00:00",
+                "prefix_used": None,
+                "source_type": "rekordbox",
+            }},
+        })
+        app_data = tmp_path / "app-data"
+        _write_json(app_data / "publication-manifests.json", {
+            "version": 4,
+            "manifests": [{
+                "account_id": "account-synthetic",
+                "spotify_playlist_id": "playlist-synthetic",
+                "source_reference": "Synthetic/Exact Reference",
+            }],
+            "approvals": [], "mirrors": [],
+        })
+
+        result = LegacyMigration(app_data).apply(legacy)
+
+        records = json.loads((app_data / "legacy-migration.json").read_text())
+        assert result.applied
+        assert records["relink_candidates"][0]["account_id"] == "account-synthetic"
+
+    def test_ambiguous_exact_accounts_remain_unresolved(self, tmp_path):
+        legacy = tmp_path / "legacy"
+        legacy.mkdir()
+        state = {
             "spotify_id": "playlist-synthetic",
             "spotify_name": "Synthetic",
-            "source_path": "Synthetic/Source",
+            "source_path": "Synthetic/Exact Reference",
             "last_synced": "2026-01-01T00:00:00",
             "prefix_used": None,
             "source_type": "rekordbox",
-        }},
-    })
-    app_data = tmp_path / "app-data"
-    current = {
-        "version": 1, "entries": {}, "local_regressions": [],
-        "approval_conflicts": [],
-    }
-    _write_json(app_data / "matching-knowledge.json", current)
-    before = (app_data / "matching-knowledge.json").read_bytes()
-    def fail_backup(*args, **kwargs):
-        raise OSError("synthetic backup failure")
+        }
+        _write_json(legacy / ".djsupport_playlists.json", {
+            "version": 2, "entries": {"Synthetic": state},
+        })
+        app_data = tmp_path / "app-data"
+        _write_json(app_data / "publication-manifests.json", {
+            "version": 4,
+            "manifests": [
+                {
+                    "account_id": account,
+                    "spotify_playlist_id": state["spotify_id"],
+                    "source_reference": state["source_path"],
+                }
+                for account in ("account-one", "account-two")
+            ],
+            "approvals": [], "mirrors": [],
+        })
 
-    monkeypatch.setattr(LocalDataBackup, "create", fail_backup)
+        result = LegacyMigration(app_data).apply(legacy)
 
-    failed_backup = LegacyMigration(app_data).apply(legacy)
-
-    assert not failed_backup.applied
-    assert (app_data / "matching-knowledge.json").read_bytes() == before
-
-    monkeypatch.undo()
-    calls = 0
-
-    def fail_second_replace(source: Path, target: Path):
-        nonlocal calls
-        calls += 1
-        if calls == 2:
-            raise OSError("synthetic commit failure")
-        source.replace(target)
-
-    failed_commit = LegacyMigration(
-        app_data, replace_file=fail_second_replace,
-    ).apply(legacy)
-
-    assert not failed_commit.applied
-    assert (app_data / "matching-knowledge.json").read_bytes() == before
-    assert list((app_data / "backups").glob("*.zip")) == []
-
-    retry = LegacyMigration(app_data).apply(legacy)
-    assert retry.applied
+        records = json.loads((app_data / "legacy-migration.json").read_text())
+        assert result.report.conflicts == 1
+        assert records["relink_candidates"][0]["account_id"] is None
 
 
-def test_apply_verifies_backup_containing_current_publication_schema_v4(tmp_path):
-    legacy = tmp_path / "legacy"
-    legacy.mkdir()
-    _write_json(legacy / ".djsupport_cache.json", {
-        "version": 1, "entries": {"new||track": _cache_entry()},
-    })
-    app_data = tmp_path / "app-data"
-    _write_json(app_data / "publication-manifests.json", {
-        "version": 4, "manifests": [], "approvals": [], "mirrors": [],
-    })
+    @pytest.mark.parametrize("filename,source_type", [
+        (".djsupport_playlists.json", "beatport"),
+        (".djsupport_beatport_playlists.json", "rekordbox"),
+    ])
+    def test_mismatched_state_ownership_is_reported_without_guessing(
+        self,
+        tmp_path, filename, source_type,
+    ):
+        legacy = tmp_path / "legacy"
+        legacy.mkdir()
+        _write_json(legacy / filename, {
+            "version": 2,
+            "entries": {"Synthetic": {
+                "spotify_id": "playlist-synthetic",
+                "spotify_name": "Synthetic",
+                "source_path": "Synthetic/Source",
+                "last_synced": "2026-01-01T00:00:00",
+                "prefix_used": None,
+                "source_type": source_type,
+            }},
+        })
 
-    result = LegacyMigration(app_data).apply(legacy)
+        report = LegacyMigration(tmp_path / "app-data").preview(legacy)
 
-    assert result.applied
-    archive = next((app_data / "backups").glob("*.zip"))
-    assert LocalDataBackup(app_data).preview(archive).valid
+        assert not report.valid
+        assert report.relink_required == 0
+        assert report.historical_snapshots == 0
+
+
+    def test_apply_is_idempotent_and_leaves_legacy_files_byte_identical(self, tmp_path):
+        legacy = tmp_path / "legacy"
+        legacy.mkdir()
+        path = legacy / ".djsupport_cache.json"
+        _write_json(path, {"version": 1, "entries": {"new||track": _cache_entry()}})
+        original = path.read_bytes()
+        migration = LegacyMigration(tmp_path / "app-data")
+
+        first = migration.apply(legacy)
+        first_data = (tmp_path / "app-data" / "matching-knowledge.json").read_bytes()
+        second = migration.apply(legacy)
+
+        assert first.applied and second.applied
+        assert second.report.proposed_cache_imports == 0
+        assert (tmp_path / "app-data" / "matching-knowledge.json").read_bytes() == first_data
+        assert path.read_bytes() == original
+
+
+    def test_cli_apply_reports_only_aggregates_and_never_initializes_spotify(
+        self,
+        tmp_path, monkeypatch,
+    ):
+        legacy = tmp_path / "private" / "legacy"
+        legacy.mkdir(parents=True)
+        private_metadata = "Never Print This Synthetic Track"
+        _write_json(legacy / ".djsupport_cache.json", {
+            "version": 1,
+            "entries": {private_metadata: _cache_entry()},
+        })
+        app_data = tmp_path / "app-data"
+        monkeypatch.setattr("djsupport.backup.default_app_data_path", lambda: app_data)
+        monkeypatch.setattr(
+            "djsupport.spotify.get_client",
+            lambda: (_ for _ in ()).throw(AssertionError("Spotify must not be called")),
+        )
+
+        result = CliRunner().invoke(
+            cli, ["migrate-0-3", str(legacy), "--apply"],
+        )
+
+        assert result.exit_code == 0
+        assert "Migration completed" in result.output
+        assert private_metadata not in result.output
+        assert str(legacy) not in result.output
+        assert "spotify:track:" not in result.output
+
+
+    def test_backup_failure_and_commit_failure_leave_current_data_unchanged(
+        self,
+        tmp_path, monkeypatch,
+    ):
+        legacy = tmp_path / "legacy"
+        legacy.mkdir()
+        _write_json(legacy / ".djsupport_cache.json", {
+            "version": 1, "entries": {"new||track": _cache_entry()},
+        })
+        _write_json(legacy / ".djsupport_playlists.json", {
+            "version": 2,
+            "entries": {"Synthetic": {
+                "spotify_id": "playlist-synthetic",
+                "spotify_name": "Synthetic",
+                "source_path": "Synthetic/Source",
+                "last_synced": "2026-01-01T00:00:00",
+                "prefix_used": None,
+                "source_type": "rekordbox",
+            }},
+        })
+        app_data = tmp_path / "app-data"
+        current = {
+            "version": 1, "entries": {}, "local_regressions": [],
+            "approval_conflicts": [],
+        }
+        _write_json(app_data / "matching-knowledge.json", current)
+        before = (app_data / "matching-knowledge.json").read_bytes()
+        def fail_backup(*args, **kwargs):
+            raise OSError("synthetic backup failure")
+
+        monkeypatch.setattr(LocalDataBackup, "create", fail_backup)
+
+        failed_backup = LegacyMigration(app_data).apply(legacy)
+
+        assert not failed_backup.applied
+        assert (app_data / "matching-knowledge.json").read_bytes() == before
+
+        monkeypatch.undo()
+        calls = 0
+
+        def fail_second_replace(source: Path, target: Path):
+            nonlocal calls
+            calls += 1
+            if calls == 2:
+                raise OSError("synthetic commit failure")
+            source.replace(target)
+
+        failed_commit = LegacyMigration(
+            app_data, replace_file=fail_second_replace,
+        ).apply(legacy)
+
+        assert not failed_commit.applied
+        assert (app_data / "matching-knowledge.json").read_bytes() == before
+        assert list((app_data / "backups").glob("*.zip")) == []
+
+        retry = LegacyMigration(app_data).apply(legacy)
+        assert retry.applied
+
+
+    def test_apply_verifies_backup_containing_current_publication_schema_v4(self, tmp_path):
+        legacy = tmp_path / "legacy"
+        legacy.mkdir()
+        _write_json(legacy / ".djsupport_cache.json", {
+            "version": 1, "entries": {"new||track": _cache_entry()},
+        })
+        app_data = tmp_path / "app-data"
+        _write_json(app_data / "publication-manifests.json", {
+            "version": 4, "manifests": [], "approvals": [], "mirrors": [],
+        })
+
+        result = LegacyMigration(app_data).apply(legacy)
+
+        assert result.applied
+        archive = next((app_data / "backups").glob("*.zip"))
+        assert LocalDataBackup(app_data).preview(archive).valid

--- a/tests/test_migration.py
+++ b/tests/test_migration.py
@@ -87,6 +87,13 @@ class TestLegacyMigration:
                 **_cache_entry(), "spotify_uri": "not-a-spotify-track-uri",
             }},
         }),
+        json.dumps({
+            "version": 1,
+            "entries": {"synthetic": {
+                **_cache_entry(), "threshold": True,
+                "match_type": "unknown",
+            }},
+        }),
     ])
     def test_preview_safely_rejects_malformed_or_unsupported_known_file(
         self,
@@ -284,6 +291,26 @@ class TestLegacyMigration:
         assert not report.valid
         assert report.relink_required == 0
         assert report.historical_snapshots == 0
+
+    def test_malformed_state_prefix_is_not_converted(self, tmp_path):
+        legacy = tmp_path / "legacy"
+        legacy.mkdir()
+        _write_json(legacy / ".djsupport_playlists.json", {
+            "version": 2,
+            "entries": {"Synthetic": {
+                "spotify_id": "playlist-synthetic",
+                "spotify_name": "Synthetic",
+                "source_path": "Synthetic/Source",
+                "last_synced": "2026-01-01T00:00:00",
+                "prefix_used": ["not", "a", "string"],
+                "source_type": "rekordbox",
+            }},
+        })
+
+        report = LegacyMigration(tmp_path / "app-data").preview(legacy)
+
+        assert not report.valid
+        assert report.relink_required == 0
 
 
     def test_apply_is_idempotent_and_leaves_legacy_files_byte_identical(self, tmp_path):

--- a/tests/test_migration.py
+++ b/tests/test_migration.py
@@ -1,0 +1,274 @@
+"""Public-seam tests for explicit 0.3.0 local-data migration."""
+
+import json
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+from djsupport.backup import LocalDataBackup
+from djsupport.cli import cli
+from djsupport.migration import LegacyMigration
+
+
+def _write_json(path, value):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(value))
+
+
+def _cache_entry(uri_letter="A"):
+    return {
+        "spotify_uri": "spotify:track:" + uri_letter * 22,
+        "spotify_name": "Synthetic result",
+        "spotify_artist": "Synthetic artist",
+        "score": 91.0,
+        "matched": True,
+        "timestamp": "2026-01-01T00:00:00",
+        "threshold": 80,
+        "match_type": "exact",
+    }
+
+
+def test_migrate_legacy_directory_previews_without_mutation(tmp_path, monkeypatch):
+    legacy = tmp_path / "legacy"
+    legacy.mkdir()
+    _write_json(legacy / ".djsupport_cache.json", {
+        "version": 1,
+        "entries": {
+            "synthetic artist||synthetic title": _cache_entry(),
+        },
+    })
+    app_data = tmp_path / "app-data"
+    monkeypatch.setattr("djsupport.backup.default_app_data_path", lambda: app_data)
+
+    result = CliRunner().invoke(cli, ["migrate-0-3", str(legacy)])
+
+    assert result.exit_code == 0
+    assert "Preview only" in result.output
+    assert "Detected files: 1" in result.output
+    assert "Cache records: 1" in result.output
+    assert "Proposed cache imports: 1" in result.output
+    assert not app_data.exists()
+    assert (legacy / ".djsupport_cache.json").exists()
+
+
+def test_preview_ignores_unknown_files_and_reports_absent_known_files(tmp_path):
+    legacy = tmp_path / "legacy"
+    legacy.mkdir()
+    (legacy / ".env").write_text("SPOTIPY_CLIENT_SECRET=synthetic-secret")
+    (legacy / "report.md").write_text("/private/synthetic/path")
+
+    report = LegacyMigration(tmp_path / "app-data").preview(legacy)
+
+    assert report.valid
+    assert report.detected_files == 0
+    assert report.skipped == 0
+
+
+@pytest.mark.parametrize("payload", [
+    "not json",
+    json.dumps({"version": 99, "entries": {}}),
+    json.dumps({"version": 1, "entries": []}),
+])
+def test_preview_safely_rejects_malformed_or_unsupported_known_file(
+    tmp_path, payload,
+):
+    legacy = tmp_path / "legacy"
+    legacy.mkdir()
+    (legacy / ".djsupport_cache.json").write_text(payload)
+
+    report = LegacyMigration(tmp_path / "app-data").preview(legacy)
+
+    assert not report.valid
+    assert report.errors == (".djsupport_cache.json: malformed or unsupported",)
+    assert "/" not in report.errors[0]
+
+
+def test_apply_imports_both_caches_as_non_authoritative_and_current_wins(tmp_path):
+    legacy = tmp_path / "legacy"
+    legacy.mkdir()
+    _write_json(legacy / ".djsupport_cache.json", {
+        "version": 1,
+        "entries": {
+            "new||track": _cache_entry("A"),
+            "conflict||track": _cache_entry("B"),
+        },
+    })
+    _write_json(legacy / ".djsupport_beatport_cache.json", {
+        "version": 1, "entries": {"beatport||track": _cache_entry("C")},
+    })
+    app_data = tmp_path / "app-data"
+    _write_json(app_data / "matching-knowledge.json", {
+        "version": 1,
+        "entries": {"conflict||track": {
+            **_cache_entry("D"), "approval_status": "approved",
+            "source_duration": 0,
+        }},
+        "local_regressions": [], "approval_conflicts": [],
+    })
+
+    result = LegacyMigration(app_data).apply(legacy)
+
+    assert result.applied
+    stored = json.loads((app_data / "matching-knowledge.json").read_text())
+    assert stored["entries"]["conflict||track"]["spotify_uri"].endswith("D" * 22)
+    assert stored["entries"]["new||track"]["approval_status"] is None
+    assert stored["entries"]["beatport||track"]["approval_status"] is None
+    assert result.report.proposed_cache_imports == 2
+    assert result.report.conflicts == 1
+    assert any((app_data / "backups").glob("djsupport-backup-*.zip"))
+
+
+def test_state_becomes_unmanaged_history_or_relink_candidate_without_guessing(tmp_path):
+    legacy = tmp_path / "legacy"
+    legacy.mkdir()
+    state = {
+        "version": 2,
+        "entries": {
+            "Synthetic list": {
+                "spotify_id": "playlist-synthetic",
+                "spotify_name": "Synthetic list",
+                "source_path": "Synthetic/Source",
+                "last_synced": "2026-01-01T00:00:00",
+                "prefix_used": "djsupport",
+                "source_type": "rekordbox",
+            },
+        },
+    }
+    _write_json(legacy / ".djsupport_playlists.json", state)
+    state["entries"]["Synthetic list"]["source_type"] = "beatport"
+    _write_json(legacy / ".djsupport_beatport_playlists.json", state)
+
+    result = LegacyMigration(tmp_path / "app-data").apply(legacy)
+
+    records = json.loads(
+        (tmp_path / "app-data" / "legacy-migration.json").read_text()
+    )
+    assert result.report.relink_required == 1
+    assert result.report.historical_snapshots == 1
+    assert records["relink_candidates"][0]["account_id"] is None
+    assert records["relink_candidates"][0]["status"] == "relink_required"
+    assert records["historical_snapshots"][0]["managed"] is False
+    assert "mirrors" not in records
+
+
+def test_apply_is_idempotent_and_leaves_legacy_files_byte_identical(tmp_path):
+    legacy = tmp_path / "legacy"
+    legacy.mkdir()
+    path = legacy / ".djsupport_cache.json"
+    _write_json(path, {"version": 1, "entries": {"new||track": _cache_entry()}})
+    original = path.read_bytes()
+    migration = LegacyMigration(tmp_path / "app-data")
+
+    first = migration.apply(legacy)
+    first_data = (tmp_path / "app-data" / "matching-knowledge.json").read_bytes()
+    second = migration.apply(legacy)
+
+    assert first.applied and second.applied
+    assert second.report.proposed_cache_imports == 0
+    assert (tmp_path / "app-data" / "matching-knowledge.json").read_bytes() == first_data
+    assert path.read_bytes() == original
+
+
+def test_cli_apply_reports_only_aggregates_and_never_initializes_spotify(
+    tmp_path, monkeypatch,
+):
+    legacy = tmp_path / "private" / "legacy"
+    legacy.mkdir(parents=True)
+    private_metadata = "Never Print This Synthetic Track"
+    _write_json(legacy / ".djsupport_cache.json", {
+        "version": 1,
+        "entries": {private_metadata: _cache_entry()},
+    })
+    app_data = tmp_path / "app-data"
+    monkeypatch.setattr("djsupport.backup.default_app_data_path", lambda: app_data)
+    monkeypatch.setattr(
+        "djsupport.spotify.get_client",
+        lambda: (_ for _ in ()).throw(AssertionError("Spotify must not be called")),
+    )
+
+    result = CliRunner().invoke(
+        cli, ["migrate-0-3", str(legacy), "--apply"],
+    )
+
+    assert result.exit_code == 0
+    assert "Migration completed" in result.output
+    assert private_metadata not in result.output
+    assert str(legacy) not in result.output
+    assert "spotify:track:" not in result.output
+
+
+def test_backup_failure_and_commit_failure_leave_current_data_unchanged(
+    tmp_path, monkeypatch,
+):
+    legacy = tmp_path / "legacy"
+    legacy.mkdir()
+    _write_json(legacy / ".djsupport_cache.json", {
+        "version": 1, "entries": {"new||track": _cache_entry()},
+    })
+    _write_json(legacy / ".djsupport_playlists.json", {
+        "version": 2,
+        "entries": {"Synthetic": {
+            "spotify_id": "playlist-synthetic",
+            "spotify_name": "Synthetic",
+            "source_path": "Synthetic/Source",
+            "last_synced": "2026-01-01T00:00:00",
+            "prefix_used": None,
+            "source_type": "rekordbox",
+        }},
+    })
+    app_data = tmp_path / "app-data"
+    current = {
+        "version": 1, "entries": {}, "local_regressions": [],
+        "approval_conflicts": [],
+    }
+    _write_json(app_data / "matching-knowledge.json", current)
+    before = (app_data / "matching-knowledge.json").read_bytes()
+    def fail_backup(*args, **kwargs):
+        raise OSError("synthetic backup failure")
+
+    monkeypatch.setattr(LocalDataBackup, "create", fail_backup)
+
+    failed_backup = LegacyMigration(app_data).apply(legacy)
+
+    assert not failed_backup.applied
+    assert (app_data / "matching-knowledge.json").read_bytes() == before
+
+    monkeypatch.undo()
+    calls = 0
+
+    def fail_second_replace(source: Path, target: Path):
+        nonlocal calls
+        calls += 1
+        if calls == 2:
+            raise OSError("synthetic commit failure")
+        source.replace(target)
+
+    failed_commit = LegacyMigration(
+        app_data, replace_file=fail_second_replace,
+    ).apply(legacy)
+
+    assert not failed_commit.applied
+    assert (app_data / "matching-knowledge.json").read_bytes() == before
+    assert list((app_data / "backups").glob("*.zip")) == []
+
+    retry = LegacyMigration(app_data).apply(legacy)
+    assert retry.applied
+
+
+def test_apply_verifies_backup_containing_current_publication_schema_v4(tmp_path):
+    legacy = tmp_path / "legacy"
+    legacy.mkdir()
+    _write_json(legacy / ".djsupport_cache.json", {
+        "version": 1, "entries": {"new||track": _cache_entry()},
+    })
+    app_data = tmp_path / "app-data"
+    _write_json(app_data / "publication-manifests.json", {
+        "version": 4, "manifests": [], "approvals": [], "mirrors": [],
+    })
+
+    result = LegacyMigration(app_data).apply(legacy)
+
+    assert result.applied
+    archive = next((app_data / "backups").glob("*.zip"))
+    assert LocalDataBackup(app_data).preview(archive).valid


### PR DESCRIPTION
Closes #64

## Summary
- add an explicit preview-first `migrate-0-3` command for one selected legacy directory
- retain legacy cache entries as non-authoritative knowledge while current truth wins conflicts
- retain Rekordbox relationships as explicit relink candidates and Beatport relationships as unmanaged Snapshot history
- create and verify a current-format backup before atomic, rollback-safe apply
- document upgrade, backup/restore, and release behavior

## Validation
- 476 offline tests pass (20 migration tests)
- Python compilation passes
- repository privacy tests pass
- diff/whitespace and credential/personal-data scans pass
- parallel Standards and Spec reviews report no remaining blockers