### PR TITLE
DJ Support 0.4.0 release readiness

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,78 +5,71 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
-## [Unreleased]
+## [0.4.0] - 2026-08-01
 
 ### Added
 
 - Explicit, preview-first migration of known 0.3.0 working-directory cache and
   playlist-state files into versioned application data, with verified backup,
-  atomic rollback, privacy-safe aggregate reporting, and idempotent apply
-- Versioned, timestamped local-data backup archives and integrity-checked,
-  preview-first, conflict-aware atomic restore; OAuth credentials and unrelated
-  files are excluded
-- Durable Rekordbox Batch execution with independent playlist outcomes,
-  partial-success reporting, safe shared-failure stops, and resumable checkpoints
-- Explicit Corrections from edited review CSV files, with validated stable source
-  references and Spotify track URLs/URIs, idempotent playlist repair, Approved
-  Match promotion, and local-only matcher regression knowledge
-- Playlist-scoped Provisional Playlist approval with durable approved, rejected,
-  and abandoned review outcomes
-- Clickable Spotify proposals and stable source references in Markdown reports,
-  plus editable CSV review files for Beatport Transfers
-- Account-scoped Provisional Playlist state, per-account publishing serialization,
-  and bounded Spotify retries with safe Transfer checkpointing
-- Beatport chart playlists now include the curator/DJ name — e.g. `"Adam Beyer - Tech House Vibes"` instead of just `"Tech House Vibes"`
-- `compose_chart_playlist_name()` helper in `beatport.py` for chart name composition (curator omitted when `"Unknown"`, empty, or `None`)
+  atomic rollback, privacy-safe aggregate reporting, and idempotent apply.
+- Durable Transfer orchestration for Rekordbox Batches and Beatport chart or
+  label Snapshots, with resumable checkpoints, partial outcomes, safe failure
+  handling, and optional recurring Beatport Mirrors.
+- Provisional Playlist review, Approval, Rejection, Abandonment, and explicit
+  Corrections supplied through editable review CSV files.
+- Versioned, timestamped local-data backups with integrity validation,
+  preview-first conflict handling, and atomic restore.
+- Beatport label discovery and paginated ingestion, including interactive name
+  search, URL validation, deduplication, and bounded pagination.
+- Optional FastAPI web UI (`pip install djsupport[web]`) with Spotify OAuth,
+  background Transfers, and progress events.
+- Account-scoped publication state, reusable Approved Matches, and private
+  Correction-derived matcher regression knowledge.
+- Clickable Spotify proposals, stable source references, and editable review
+  CSV files in Transfer reports.
 
 ### Changed
 
-- Live matcher accuracy checks now read Correction-derived regression knowledge
-  from private, versioned application storage. The tracked personal report and
-  curated mapping fixture were removed, with stronger ignore and contribution
-  guardrails for user-derived artifacts.
-- All production flows now enter the public Transfer interface; the replaced
-  shallow `service.py` orchestration and its implementation-coupled tests were
-  removed. Rekordbox work now requires explicit playlist selection or an
-  opt-in whole-library Batch, with Preview and lookup preflight owned by Transfer.
-- User and contributor documentation now uses the canonical Transfer, Preview,
-  Mirror, Snapshot, Approval, and Correction vocabulary. Compatible command
-  names such as `sync` and flags such as `--dry-run` remain available.
-- FastAPI and uvicorn are now optional dependencies — install with `pip install djsupport[web]`
-- `djsupport web` shows a friendly install hint when web dependencies are missing
-
-### Added
-
-- Logo and favicon images for web UI — neon green vinyl/sync icon and headphones icon
-- `djsupport web` command — starts a web UI at localhost:8000 for syncing Beatport playlists to Spotify
-- Web frontend with responsive single-page UI (Tailwind CSS) — paste URL, see real-time progress via SSE, view results with Spotify link
-- FastAPI backend with Spotify OAuth browser flow, background sync, and single-job enforcement
-- `djsupport/service.py` module — framework-agnostic sync orchestration shared by CLI and web
-- `spotify_playlist_id` field on `PlaylistReport` for constructing Spotify URLs
-- 28 new tests (10 service layer + 18 web endpoints)
-- `djsupport label <url-or-name>` command — import tracks from a Beatport record label into a Spotify playlist
-- Label name search with interactive selection — `djsupport label "Drumcode"` searches Beatport and presents matching labels with latest release info
-- Paginated label fetching with `per_page=150` for efficient large label imports
-- Track deduplication across compilations — same track on multiple releases is imported only once (newest first)
-- Warning prompt when a label has >1000 tracks before proceeding
-- `djsupport/label.py` module — Beatport label page scraper with URL validation, pagination, deduplication, and search
-- Label-specific cache (`.djsupport_label_cache.json`) and state (`.djsupport_label_playlists.json`), isolated from chart and Rekordbox data
-- 53 new tests for label module (URL validation, track parsing, pagination, deduplication, search, error handling)
-- Playlist descriptions on sync — Rekordbox playlists show "Synced from Rekordbox by djsupport", Beatport playlists show "Imported from Beatport by djsupport"
+- Rekordbox Transfers require explicit playlist selection or an opt-in
+  whole-library Batch and now provide lookup-cost preflight.
+- Beatport charts and labels publish one-time Snapshots by default; `--mirror`
+  opts into a recurring Mirror.
+- Compatible CLI names and flags such as `sync`, `--dry-run`, `--no-cache`, and
+  `--retry-days` remain available while documentation uses Transfer, Preview,
+  Mirror, Snapshot, Approval, Correction, and Batch terminology.
+- FastAPI and uvicorn moved to the optional `web` dependency group.
+- Local user-derived reports and matcher evidence were removed from Git and are
+  read from versioned private application storage instead.
+- The obsolete `djsupport.service` orchestration layer was removed; CLI and web
+  flows use the public Transfer interface.
 
 ### Fixed
 
-- Provisional publication manifests and review CSVs now retain unmatched source
-  tracks with blank Spotify targets, allowing playlist-scoped Approval to apply
-  Corrections without losing source order or rejecting rows left unresolved
-- Label search now handles new Beatport search API response format (`label_id`/`label_name` under `data` key) alongside old format
-- Label scraper no longer imports `click` — pagination errors communicated via `on_page_error` callback, keeping library decoupled from CLI
-- Search result URLs are re-validated before fetching, closing a trust boundary gap
-- Pagination capped at 100 pages (15,000 tracks) to prevent runaway requests from corrupted server responses
-- URL validation now strips `#` fragments (browser-pasted URLs with anchors no longer rejected)
-- Invalid JSON in `__NEXT_DATA__` now raises `LabelParseError` instead of raw `JSONDecodeError`
-- Matcher now recognizes "Original" as a standalone version descriptor — Spotify uses " - Original" suffix on many tracks, previously causing match failures
-- Matcher now recognizes "Interpretation" as a version descriptor — handles tracks like "Selderv Interpretation" common in electronic music
+- Current schema-v4 publication manifests can be validated and restored from a
+  local-data backup, alongside supported 0.3.0-era schemas.
+- Approval preserves unmatched source tracks so explicit Corrections can add
+  missing Spotify targets without losing source order.
+- Partial Match Collisions remain unresolved until every source mapping is
+  explicitly corrected or rejected.
+- Beatport chart curator metadata is retained for supported page-data shapes and
+  used in playlist names when available.
+- Label parsing handles the current and legacy search response shapes, validates
+  returned URLs, caps pagination, and reports malformed page data safely.
+- Matcher version recognition includes standalone Original and Interpretation
+  descriptors.
+
+### Known limitations
+
+- Some Beatport chart payload shapes do not expose curator metadata through the
+  supported parser, so the playlist can fall back to the chart name alone (#60).
+- Provisional Playlist descriptions retain an opaque Transfer marker and
+  machine timestamp because crash recovery and duplicate-publication prevention
+  currently depend on that marker (#61).
+- Material duration differences can still be classified as exact, and repeated
+  parenthetical subtitles can reduce a valid candidate below threshold (#56,
+  #57). Review proposals before Approval and use a Correction when needed.
+- Broader Spotify candidate recall, noisy-source cleanup, and ISRC-first lookup
+  remain research work rather than release behavior (#31, #32, #39, #42).
 
 ## [0.3.0] - 2026-02-26
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,3 +34,23 @@ Use `--knowledge-path PATH` to select another local matching-knowledge file.
 This workflow calls Spotify and is not part of the offline test suite. Do not
 attach its output to an issue or pull request unless it has been generalized
 and privacy-reviewed.
+
+## Development and release checks
+
+Install development and optional web dependencies with:
+
+```bash
+python -m pip install -e ".[dev,web]"
+```
+
+Run the offline suite with `pytest`. Release preparation also compiles the
+Python package, runs the repository privacy tests, builds both source and wheel
+artifacts, inspects every archive member, and installs the wheel in a clean
+temporary environment for CLI/import smoke tests. Live Spotify and Beatport
+checks are separate, explicitly authorized workflows and are never part of the
+offline release gate.
+
+When a persistent schema changes, keep its reader compatible with documented
+older versions or provide an explicit migration. Add a synthetic backup/restore
+test that covers the current schema and the supported upgrade boundary. Never
+use an actual application-data directory for release validation.

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,6 @@
+include CHANGELOG.md
+include CONTRIBUTING.md
+include docs/backup-and-restore.md
+include docs/release-notes-0.4.0.md
+include docs/upgrading.md
+recursive-include djsupport/static *.html *.png

--- a/README.md
+++ b/README.md
@@ -9,7 +9,9 @@ Transfer curated Rekordbox and Beatport selections to Spotify through reviewable
 - **Duration-based matching** — disambiguates original, radio, and extended versions using track duration
 - **Matching knowledge** — reuses Approved Matches and retained proposals across Transfers
 - **Incremental updates** — only adds/removes changed tracks instead of replacing entire playlists
-- **Preview** — complete matching and reporting without playlist or playlist-state mutation (`--dry-run` remains the compatible flag)
+- **Preview** — complete matching and reporting without Spotify playlist or
+  publication-manifest mutation; local matching knowledge and durable Transfer
+  checkpoints may be retained (`--dry-run` remains the compatible flag)
 - **Markdown reports** — save detailed match reports with per-playlist breakdowns
 - **Playlist prefix** — prefix Spotify playlist names (e.g. `djsupport / Deep House`) to keep them organized
 - **Explicit Batches** — select one or more Rekordbox playlists, or opt into the whole library with cost preflight
@@ -24,10 +26,24 @@ Transfer curated Rekordbox and Beatport selections to Spotify through reviewable
 
 ## Installation
 
+Install the command-line application from a release artifact:
+
+```bash
+python -m pip install djsupport
+```
+
+Install the optional local web UI as well:
+
+```bash
+python -m pip install "djsupport[web]"
+```
+
+For a source checkout used for development:
+
 ```bash
 git clone <repo-url>
 cd djsupport          # project root (contains pyproject.toml)
-pip install -e .
+python -m pip install -e ".[dev,web]"
 ```
 
 > **Troubleshooting:** Make sure you run `pip install` from the project root
@@ -35,6 +51,12 @@ pip install -e .
 > inside it. If you downloaded a zip from GitHub, the root folder is typically
 > named `djsupport-main`. Also note that `pipx` does not support editable
 > installs (`-e`); use `pip` instead.
+
+### Upgrading from 0.3.0
+
+Install 0.4.0, keep the old working directory intact, and use the explicit
+preview-first migration described under [Upgrade from 0.3.0](#upgrade-from-030).
+Version 0.4.0 does not discover or rewrite legacy files automatically.
 
 ## Setup
 
@@ -108,6 +130,12 @@ the legacy directory is never changed or deleted. Repeating apply is safe.
 See [upgrade guidance](docs/upgrading.md) and
 [backup and restore details](docs/backup-and-restore.md).
 
+Backups include only recognized versioned djsupport data and local Markdown/CSV
+reports that do not contain common credential fields. OAuth tokens, `.env`
+files, unrelated files, and report symlinks are excluded. Restore rejects
+unexpected paths, unsupported schemas, integrity failures, and unresolved
+Approval or playlist-state conflicts before replacing current data.
+
 ### List playlists
 
 Preview what playlists are available in your Rekordbox export:
@@ -144,7 +172,8 @@ Opt into a whole-library Batch:
 djsupport sync --whole-library
 ```
 
-Preview a selection without modifying Spotify playlists or playlist state:
+Preview a selection without modifying Spotify playlists or publication
+manifests:
 
 ```bash
 djsupport sync -p "Deep House" --dry-run
@@ -208,6 +237,58 @@ local Corrections directly; no personal mapping fixture is kept in Git. See
 [CONTRIBUTING.md](CONTRIBUTING.md) for the privacy-safe workflow and synthetic
 fixture requirements.
 
+### Beatport Snapshots and Mirrors
+
+Create a one-time chart or label Snapshot (the default):
+
+```bash
+djsupport beatport <chart-url> --dry-run
+djsupport beatport <chart-url>
+djsupport label <label-url-or-name> --dry-run
+djsupport label <label-url-or-name>
+```
+
+Use `--mirror` only when you want later Transfers to maintain one recurring
+playlist. Interrupted Beatport Transfers print an ID that can be supplied to
+`--resume`; use `--abandon` to end a retained Transfer explicitly.
+
+```bash
+djsupport beatport <chart-url> --mirror
+djsupport beatport <chart-url> --resume <transfer-id>
+djsupport beatport <chart-url> --abandon <transfer-id>
+```
+
+Chart playlist names include `Curator - Chart Name` when the supported Beatport
+payload provides a curator; otherwise they use the chart name. Label Snapshots
+use the label name.
+
+### Review lifecycle
+
+Preview performs source intake, matching, and reporting without modifying
+Spotify playlists or publication manifests. It may retain local matching
+knowledge and durable Transfer checkpoints so work can be inspected or resumed.
+A non-Preview Beatport Transfer publishes a Provisional Playlist. Review it in
+Spotify, remove wrong proposals, optionally edit the generated CSV with
+Corrections, and then run `approve`. Approved Matches become reusable local
+matching knowledge. A deleted Provisional Playlist is recorded as Abandoned,
+and Match Collisions remain review-required until each mapping is corrected or
+rejected.
+
+### Privacy and local state
+
+Credentials, source-library paths, matching knowledge, Corrections, Transfer
+checkpoints, publication manifests, playlist identifiers, and reports are local
+user data. They are not package assets and must not be committed or attached to
+issues without explicit export, consent, and privacy review. On macOS and Linux,
+default durable Transfer data is stored under the platform data directory
+(`~/Library/Application Support/djsupport` on macOS and
+`$XDG_DATA_HOME/djsupport` or `~/.local/share/djsupport` on Linux). The saved
+Rekordbox XML path remains in the local configuration file created by
+`djsupport library set`.
+
+See [the 0.4.0 release notes](docs/release-notes-0.4.0.md) for the complete
+upgrade summary and known limitations.
+
 ### Playlist naming
 
 Spotify playlists are prefixed with `djsupport /` by default. Change or disable the prefix:
@@ -231,7 +312,7 @@ Rekordbox Transfer options (the `sync` command name and `--dry-run` flag remain 
 |------|---------|-------------|
 | `-p, --playlist` | | Select by exact name/path; repeat for a Batch |
 | `--whole-library` | | Explicitly select every playlist |
-| `--dry-run` | | Preview without modifying Spotify or playlist state |
+| `--dry-run` | | Preview without modifying Spotify or publication manifests; local knowledge/checkpoints may be retained |
 | `-t, --threshold` | 80 | Minimum match confidence (0–100) |
 | `--report` | | Save Markdown report to this path |
 | `--no-cache` | | Bypass retained matching knowledge (compatible flag) |

--- a/agent.md
+++ b/agent.md
@@ -128,7 +128,7 @@ pytest --cov=djsupport     # Run with coverage
   credentials, local paths, and playlist state stay in private application
   storage. Repository matcher tests are synthetic unless a user explicitly
   exports and consents to a privacy-reviewed contribution.
-- Version tracked in `pyproject.toml` (`version = "0.3.0"`)
+- Version tracked in `pyproject.toml` (`version = "0.4.0"`)
 - Changelog follows Keep a Changelog format in `CHANGELOG.md`
 - `docs/` contains plans, test plans, and reports
 - `docs/solutions/` holds documented problem solutions with YAML frontmatter (created via `/compound` workflow)

--- a/djsupport/beatport.py
+++ b/djsupport/beatport.py
@@ -11,7 +11,7 @@ BEATPORT_CHART_URL_PREFIX = "beatport.com/chart/"
 BEATPORT_CHART_PATTERN = re.compile(
     r"^https://(www\.)?beatport\.com/chart/[\w-]+/\d+/?$"
 )
-USER_AGENT = "Mozilla/5.0 (compatible; djsupport/0.3.0)"
+USER_AGENT = "Mozilla/5.0 (compatible; djsupport/0.4.0)"
 REQUEST_TIMEOUT = (5, 30)  # (connect, read) seconds
 MAX_RESPONSE_SIZE = 5 * 1024 * 1024  # 5 MB
 

--- a/docs/release-notes-0.4.0.md
+++ b/docs/release-notes-0.4.0.md
@@ -1,0 +1,81 @@
+# DJ Support 0.4.0 release notes
+
+DJ Support 0.4.0 makes Transfers durable and reviewable. Rekordbox selections
+publish as Mirrors, Beatport charts and labels publish as Snapshots by default,
+and retained proposals become authoritative matching knowledge only after
+playlist-scoped Approval.
+
+## Highlights
+
+- Explicit Rekordbox Batches with lookup-cost preflight and independent playlist
+  outcomes.
+- Resumable Beatport Transfers, optional recurring Mirrors, and retained
+  Abandonment history.
+- Provisional Playlist review with editable Correction CSVs, Approved and
+  Rejected Matches, and collision-safe Approval.
+- Versioned local-data backup, validation, conflict preview, and atomic restore.
+- Beatport label discovery plus an optional local web UI installed with
+  `djsupport[web]`.
+- Private, shared matching knowledge across source types; repository tests and
+  fixtures remain synthetic.
+
+## Upgrade from 0.3.0
+
+Install 0.4.0, keep the old 0.3.0 working directory intact, and preview its four
+known local-data files explicitly:
+
+```bash
+djsupport migrate-0-3 /path/to/old-working-directory
+djsupport migrate-0-3 /path/to/old-working-directory --apply
+```
+
+Apply creates and verifies a current-format backup before writing atomically.
+Current application-data truth wins collisions. Legacy cache entries remain
+non-authoritative proposals; Rekordbox relationships require a future explicit
+relink, while Beatport relationships are retained only as unmanaged historical
+Snapshots. Migration is idempotent, makes no Spotify calls, and never changes
+or deletes the legacy directory.
+
+Publication manifests from schema versions 1–3 are accepted by the current
+reader; schema v4 is the current format. Backup/restore accepts every supported
+version and refuses unknown schemas, damaged archives, unexpected files, and
+unresolved conflicts.
+
+No migration reads a Rekordbox library, contacts Spotify or Beatport, or moves
+data into the repository. Validation for this release used synthetic temporary
+application data only.
+
+## Privacy and recovery
+
+OAuth credentials and tokens are not part of local-data backups. Recognized
+versioned state and local Markdown/CSV reports are included only when they pass
+the backup filters; unrelated files and report symlinks are excluded.
+
+Provisional Playlist descriptions currently contain an opaque Transfer marker
+and machine timestamp. They contain no OAuth credential or source-library path,
+but they are internal recovery metadata shown in Spotify. Removing them safely
+requires a replacement for crash recovery and duplicate-publication prevention,
+so issue #61 remains a documented, non-blocking recovery/UX limitation.
+
+## Known limitations
+
+- Beatport may change its undocumented page-data shapes. Supported shapes retain
+  the curator and use `Curator - Chart Name`; an unhandled shape can fall back
+  to the chart name (#60).
+- A materially shorter Spotify substitute may still be labelled exact even
+  though its confidence receives a duration penalty (#56).
+- A duplicated parenthetical subtitle can depress the correct candidate below
+  the default threshold (#57).
+- Spotify candidate breadth/fallback behavior, noisy source cleanup, and
+  ISRC-first matching remain research items (#31, #32, #39, #42).
+
+These matcher limitations do not bypass the threshold or Approval workflow.
+Preview the Transfer, review Provisional Playlists, and use an explicit
+Correction for a missing or wrong proposal.
+
+## Compatibility note
+
+The command names `sync` and flag `--dry-run` remain supported. Likewise,
+`--no-cache` and `--retry-days` remain accepted for compatibility even though
+the product language is matching knowledge and failed matches are retried only
+when `--retry` is explicit.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,10 +5,15 @@ build-backend = "setuptools.build_meta"
 [tool.setuptools.packages.find]
 include = ["djsupport*"]
 
+[tool.setuptools.package-data]
+djsupport = ["static/*.html", "static/*.png"]
+
 [project]
 name = "djsupport"
-version = "0.3.0"
+version = "0.4.0"
 description = "Transfer Rekordbox and Beatport selections to Spotify"
+readme = "README.md"
+license = "MIT"
 requires-python = ">=3.10"
 dependencies = [
     "spotipy>=2.23",
@@ -31,6 +36,10 @@ dev = [
 
 [project.scripts]
 djsupport = "djsupport.cli:cli"
+
+[project.urls]
+Repository = "https://github.com/spontain112/djsupport"
+Issues = "https://github.com/spontain112/djsupport/issues"
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]

--- a/tests/test_backup.py
+++ b/tests/test_backup.py
@@ -133,6 +133,21 @@ class TestRestorePreview:
         assert preview.conflicts == ()
         assert (target / "matching-knowledge.json").read_bytes() == before
 
+    def test_accepts_current_publication_manifest_schema(self, tmp_path):
+        source = tmp_path / "source"
+        _write_json(source / "publication-manifests.json", {
+            "version": 4,
+            "manifests": [],
+            "approvals": [],
+            "mirrors": [],
+        })
+        archive = LocalDataBackup(source).create(tmp_path / "backups")
+
+        preview = LocalDataBackup(tmp_path / "target").preview(archive)
+
+        assert preview.valid is True
+        assert preview.contents == ("publication-manifests.json",)
+
     @pytest.mark.parametrize("damage", ["corrupt", "unsupported-backup", "unsupported-data"])
     def test_rejects_corrupt_or_unsupported_archive(self, tmp_path, damage):
         source = tmp_path / "source"


### PR DESCRIPTION
## Summary
- bump authoritative release metadata and runtime identification to 0.4.0
- consolidate the changelog and add release notes with explicit known limitations
- document installation, web extras, Preview semantics, review workflows, privacy, backup/restore, and the explicit 0.3.0 migration
- include required web assets and release documentation in wheel/source artifacts
- accept current publication-manifest schema v4 in backup/restore validation

## Release audit
- #60/#61 documented as non-blocking naming/recovery UX limitations
- #56/#57 documented as non-blocking matcher limitations requiring review/Correction
- #31/#32/#39/#42 remain post-release research
- explicit #64 migration verified with synthetic 0.3.0 data only
- no live Spotify or Beatport calls and no playlist mutation

## Validation
- 477 offline tests passed
- 15 repository privacy tests passed
- Python compilation and diff checks passed
- sdist and wheel built and inspected
- runtime assets, upgrade docs, README metadata, and license metadata verified
- artifact privacy scan clean
- wheel installed with dependencies in a clean temporary virtual environment
- CLI help/list, imports, version, user-agent, and static assets smoke-tested
- synthetic migration idempotence and schema-v4 backup/restore passed
- Standards review: no hard violations; one non-blocking duplicated-version maintainability observation
- Spec review: pass, zero findings

This PR does not merge, tag, publish packages, or create a GitHub Release.