### PR TITLE
Preserve repeated subtitle matches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   returned URLs, caps pagination, and reports malformed page data safely.
 - Matcher version recognition includes standalone Original and Interpretation
   descriptors.
+- Matcher title comparison preserves one copy of immediately adjacent repeated
+  parenthetical subtitles, without changing source or matching identities.
 
 ### Known limitations
 
@@ -65,9 +67,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - Provisional Playlist descriptions retain an opaque Transfer marker and
   machine timestamp because crash recovery and duplicate-publication prevention
   currently depend on that marker (#61).
-- Material duration differences can still be classified as exact, and repeated
-  parenthetical subtitles can reduce a valid candidate below threshold (#56,
-  #57). Review proposals before Approval and use a Correction when needed.
+- Material duration differences can still be classified as exact (#56). Review
+  proposals before Approval and use a Correction when needed.
 - Broader Spotify candidate recall, noisy-source cleanup, and ISRC-first lookup
   remain research work rather than release behavior (#31, #32, #39, #42).
 

--- a/djsupport/matcher.py
+++ b/djsupport/matcher.py
@@ -28,6 +28,30 @@ def _normalize(text: str) -> str:
     return re.sub(r"\s+", " ", text).strip()
 
 
+def _collapse_repeated_parenthetical_groups(title: str) -> str:
+    """Collapse adjacent equivalent parenthetical groups for comparison only."""
+    adjacent_groups = re.compile(
+        r"(?P<first_group>\((?P<first_content>[^()]*)\))"
+        r"\s*\((?P<second_content>[^()]*)\)",
+    )
+
+    def collapse(match: re.Match[str]) -> str:
+        def normalized_content(value: str) -> str:
+            return re.sub(r"\s+", " ", value.strip()).casefold()
+
+        if normalized_content(match.group("first_content")) == normalized_content(
+            match.group("second_content"),
+        ):
+            return match.group("first_group")
+        return match.group(0)
+
+    previous = None
+    while title != previous:
+        previous = title
+        title = adjacent_groups.sub(collapse, title)
+    return title
+
+
 def _strip_mix_info(title: str) -> str:
     """Remove parenthetical remix/mix info and bracket tags from a title.
 
@@ -130,8 +154,10 @@ def _artist_score(track: Track, result: dict) -> tuple[float, str]:
 def _score_components(track: Track, result: dict) -> dict[str, float]:
     """Return matching score components for a Rekordbox/Spotify pair."""
     artist_score, _artist_score_reason = _artist_score(track, result)
-    norm_title = _normalize(track.name)
-    norm_result = _normalize(result["name"])
+    norm_title = _normalize(_collapse_repeated_parenthetical_groups(track.name))
+    norm_result = _normalize(
+        _collapse_repeated_parenthetical_groups(result["name"]),
+    )
     raw_title_score = fuzz.token_sort_ratio(norm_title, norm_result)
     stripped_title_score = fuzz.token_sort_ratio(
         _normalize(_strip_mix_info(track.name)),

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -193,6 +193,42 @@ class TestMatchCacheLookup:
         assert entry.spotify_uri == "spotify:track:approved"
         assert entry.score == 88.0
 
+    def test_repeated_subtitle_keeps_distinct_approved_match_identity(self, cache):
+        repeated = "Signal (Sunrise Mix) (Sunrise Mix)"
+        single = "Signal (Sunrise Mix)"
+        cache.record_approval(
+            "Synthetic Artist", repeated, "approved",
+            _matched_result(uri="spotify:track:signal", name=single),
+        )
+
+        assert cache.cache_key("Synthetic Artist", repeated) != cache.cache_key(
+            "Synthetic Artist", single,
+        )
+        assert cache.lookup("Synthetic Artist", repeated, 100) is not None
+        assert cache.lookup("Synthetic Artist", single, 100) is None
+
+    def test_repeated_subtitle_correction_persists_original_identity(self, tmp_path):
+        path = tmp_path / "matching-knowledge.json"
+        repeated = "Signal (Sunrise Mix) (Sunrise Mix)"
+        correction = {
+            "source_track_id": "synthetic-1",
+            "source_artist": "Synthetic Artist",
+            "source_title": repeated,
+            "source_duration": 360,
+            "spotify_uri": "spotify:track:signal",
+            "spotify_name": "Signal (Sunrise Mix)",
+            "spotify_artist": "Synthetic Artist",
+        }
+        knowledge = MatchCache(path=str(path))
+
+        knowledge.record_correction(correction)
+        knowledge.save()
+        reloaded = MatchCache(path=str(path))
+        reloaded.load()
+
+        assert reloaded.local_regressions == [correction]
+        assert reloaded.local_regressions[0]["source_title"] == repeated
+
 
 class TestMatchCacheRetryEligibility:
     def test_not_eligible_for_recent_failed_entry(self, cache):

--- a/tests/test_matcher.py
+++ b/tests/test_matcher.py
@@ -6,6 +6,7 @@ import pytest
 
 from djsupport.matcher import (
     EARLY_EXIT_THRESHOLD,
+    _collapse_repeated_parenthetical_groups,
     _normalize,
     _strip_mix_info,
     _extract_mix_descriptor,
@@ -13,6 +14,7 @@ from djsupport.matcher import (
     _is_named_variant,
     _classify_version_match,
     _duration_penalty,
+    _score_components,
     _score_result,
     match_track,
     match_track_cached,
@@ -84,6 +86,47 @@ class TestNormalize:
 
     def test_empty_string(self):
         assert _normalize("") == ""
+
+
+class TestRepeatedParentheticalComparison:
+    def test_collapses_immediately_adjacent_equivalent_groups_to_one_copy(self):
+        assert _collapse_repeated_parenthetical_groups(
+            "Signal (Sunrise Mix) (Sunrise Mix)",
+        ) == "Signal (Sunrise Mix)"
+
+    def test_equivalence_ignores_case_and_normalizes_content_whitespace(self):
+        assert _collapse_repeated_parenthetical_groups(
+            "Signal (  Sunrise   Mix ) (sunrise mix)",
+        ) == "Signal (  Sunrise   Mix )"
+
+    @pytest.mark.parametrize(
+        "title",
+        [
+            "Signal (Sunrise Mix) (Sunset Mix)",
+            "Signal (Sunrise Mix) Interlude (Sunrise Mix)",
+            "Signal (Sunrise Mix!) (Sunrise Mix)",
+            "Signal (Sunrise Mix) (Sunrise)",
+            "Signal Signal",
+        ],
+    )
+    def test_leaves_non_duplicate_forms_unchanged(self, title):
+        assert _collapse_repeated_parenthetical_groups(title) == title
+
+    def test_title_scoring_compares_one_preserved_copy(self):
+        components = _score_components(
+            make_track("Signal (Sunrise Mix) (Sunrise Mix)", "Synthetic Artist"),
+            make_result("Signal (Sunrise Mix)", "Synthetic Artist"),
+        )
+
+        assert components["raw_title_score"] == 100
+
+    def test_candidate_without_subtitle_is_not_comparison_equivalent(self):
+        components = _score_components(
+            make_track("Signal (Sunrise Mix) (Sunrise Mix)", "Synthetic Artist"),
+            make_result("Signal", "Synthetic Artist"),
+        )
+
+        assert components["raw_title_score"] < 100
 
 
 class TestStripMixInfo:
@@ -241,6 +284,31 @@ class TestMatchTrack:
         assert result["uri"] == "spotify:track:abc"
         assert result["score"] >= 80
         assert result["match_type"] == "exact"
+
+    def test_recovers_existing_repeated_subtitle_candidate_without_new_search(self):
+        source_title = "Signal (Sunrise Mix) (  sunrise   mix )"
+        track = make_track(source_title, "Synthetic Artist")
+        original_track = Track(**vars(track))
+        sp = self._mock_sp([
+            make_spotify_item("Unrelated", "Other Artist", "spotify:track:other"),
+            make_spotify_item(
+                "Signal (Sunrise Mix)",
+                "Synthetic Artist",
+                "spotify:track:signal",
+            ),
+        ])
+
+        result = match_track(sp, track, threshold=80)
+
+        assert result is not None
+        assert result["uri"] == "spotify:track:signal"
+        assert result["match_type"] == "exact"
+        assert result["score"] == 100
+        assert track == original_track
+        assert sp.search.call_count == 1
+        assert sp.search.call_args.kwargs["q"] == (
+            f"artist:Synthetic Artist track:{source_title}"
+        )
 
     def test_matches_remix_when_spotify_co_credits_named_remixer(self):
         sp = self._mock_sp([

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -175,6 +175,19 @@ class TestSaveReport:
         assert "Known Artist - Signal (Original Mix).aiff" in content
         assert "Known Artist - Signal" in content
 
+    def test_repeated_subtitle_recovery_keeps_original_report_title(self, tmp_path):
+        path = str(tmp_path / "report.md")
+        source_title = "Signal (Sunrise Mix) (Sunrise Mix)"
+        match = _matched(
+            name=source_title,
+            spotify_name="Signal (Sunrise Mix)",
+            artist="Synthetic Artist",
+        )
+
+        save_report(_report(playlists=[_playlist(matched=[match])]), path)
+
+        assert source_title in (tmp_path / "report.md").read_text()
+
     def test_file_contains_unmatched_tracks(self, tmp_path):
         path = str(tmp_path / "report.md")
         pl = _playlist(unmatched=["Obscure Track"])


### PR DESCRIPTION
## Summary
- collapse only immediately adjacent equivalent parenthetical groups during transient title scoring
- preserve original Track, query, report, cache, Approved Match, Correction, and persisted-knowledge identities
- add synthetic regression coverage for positive, negative, call-count, display, and identity invariants

## Validation
- 490 offline tests passed
- 15 repository privacy tests passed
- Python compilation passed
- git diff --check passed
- Standards review: pass, no findings
- Spec review: pass, no findings

Closes #57