### PR TITLE
docs: retain Wayfinder research evidence

### DIFF
--- a/docs/research/2026-08-01-chrome-discovery-workflow.md
+++ b/docs/research/2026-08-01-chrome-discovery-workflow.md
@@ -1,0 +1,92 @@
+# Chrome discovery-to-Spotify workflow
+
+**Date:** 2026-08-01
+
+**Chrome baseline:** `e26bdcacdbe6d66725fad489ff29690e42dea808`. The Chrome working tree was read only; only committed source is treated as durable evidence here.
+
+**Status:** Primary-source code research only. No extension build, live Beatport/Spotify call, user-derived data inspection, or production change was made.
+
+## Executive summary
+
+The Chrome project embodies a compelling personal workflow: encounter a useful Beatport page while browsing, click the extension in place, see that it understands the page, run matching with visible progress, review exceptions, create a private Spotify playlist, and open the result. Its strength is contextual immediacy rather than breadth. The active tab supplies both source and intent, the page title supplies a usable playlist name, and the user remains in one persistent side panel through discovery, review, and handoff.
+
+The extension is currently a separate client-side implementation, not an adapter to DJ Support's durable `Transfer`. It directly parses Beatport, owns a second matching/cache implementation, authenticates to Spotify, and creates playlists itself. That makes it an excellent interaction reference but a poor second policy authority. The roadmap opportunity is to preserve its low-friction capture and feedback while moving durable execution, matching knowledge, Approval, Mirror/Snapshot choice, recovery, and playlist mutation behind the core Transfer seam.
+
+This evidence does **not** justify reviving the dropped standalone Mirror/Drift UX study or PR #76. The useful question is broader and plainer: how can a discovery made in the browser become a trustworthy Transfer without losing the extension's momentum?
+
+## The workflow it currently embodies
+
+1. **Recognition before action.** On completed Beatport navigation, the extension extracts tracks and puts the count on its badge, giving a small signal that the current page is actionable before the user opens anything (`djsupport-chrome/src/entrypoints/background.ts`, lines 28–41). It also watches Beatport's single-page navigation, invalidates stale extraction, and refreshes the result (`src/entrypoints/content.ts`, lines 25–38, 42–95).
+2. **Context is the input.** Clicking the extension opens a side panel; the active tab is queried and its Beatport data becomes the job. There is no URL form, import wizard, or separate source-selection step (`src/entrypoints/background.ts`, lines 13–15, 47–60; `src/entrypoints/sidepanel/App.tsx`, lines 26–49).
+3. **A short readiness check.** The panel asks for Spotify connection when needed, otherwise shows the detected page title, track count, a prefilled editable playlist name, and one primary “Match Tracks” action (`src/entrypoints/sidepanel/App.tsx`, lines 146–215). If the context is unsupported, it simply asks the user to navigate to a Beatport page with tracks (lines 161–169).
+4. **Visible work, not a frozen button.** Matching changes into a dedicated progress phase with count, progress bar, and current artist/track (`src/entrypoints/sidepanel/App.tsx`, lines 66–108, 217–289). Per-track progress comes from the background worker for both cached and API results (`src/entrypoints/background.ts`, lines 100–170).
+5. **Review defaults toward completion.** Every successful match begins selected. The results screen shows source and Spotify identities, score, fallback marker, unmatched items, totals, select-all/none, and per-track checkboxes before mutation (`src/entrypoints/sidepanel/App.tsx`, lines 89–102, 292–355, 432–489).
+6. **Immediate publication and handoff.** Confirmation creates a new private playlist, adds selected tracks in order-preserving deduplicated batches, reports success, and offers “Open in Spotify” or “Start over” (`src/entrypoints/background.ts`, lines 173–181; `src/lib/spotify-api.ts`, lines 128–181; `src/entrypoints/sidepanel/App.tsx`, lines 359–390).
+
+The observable state path is:
+
+`loading -> connect or ready -> matching -> review results -> creating -> done`
+
+with explicit unsupported-context and error states (`src/entrypoints/sidepanel/App.tsx`, lines 5–14, 395–409). This is a useful behavioral spine for Wayfinder: recognition, one purposeful action, continuous feedback, review, publication, handoff.
+
+## Sources and actions actually supported
+
+- The content script runs only on `beatport.com` (`src/entrypoints/content.ts`, lines 8–10). The parser classifies chart, label, release, search, and top pages, with `unknown` as a fallback (`src/lib/beatport-parser.ts`, lines 16–28; `src/lib/types.ts`, lines 14–19).
+- Track extraction is heuristic over Beatport's undocumented `__NEXT_DATA__`, supporting both `results` and `data` shapes and tolerating parse failure (`src/lib/beatport-parser.ts`, lines 30–63, 171–196). The repository guide explicitly warns that Beatport changes fields without notice (`CLAUDE.md`, lines 74–85).
+- The only source action is extract the tracks represented by the current page. Artist pages, arbitrary URLs, following artists/labels, saved discoveries, scheduled refreshes, and non-Beatport sites are not modeled.
+- The Spotify actions are search, current-user lookup, create a private playlist, and add/replace its items (`src/lib/spotify-api.ts`, lines 81–181). There is no update of an existing managed playlist, durable source relationship, Approval lifecycle, Correction, resume UI, or scheduled follow-up.
+
+## Relationship to core DJ Support
+
+The Chrome code says it ports Python DJ Support's parsing and matching into a fully client-side TypeScript extension (`djsupport-chrome/CLAUDE.md`, lines 3–15). Matching is required by convention to produce the same results, and several operational lessons are copied across, including version handling, duration penalties, deduplication, rate-limit bounds, and versioned storage (`CLAUDE.md`, lines 69–85). Its local match cache is threshold-aware and versioned (`src/lib/cache.ts`, lines 4–22, 28–89).
+
+There is nevertheless **no runtime integration with core DJ Support**. The service worker owns extraction, matching, cache writes, Spotify OAuth, and playlist publication (`src/entrypoints/background.ts`, lines 45–181). Core DJ Support defines a Transfer as the complete attempt, with Transfer owning policy and publishing either a Mirror or Snapshot (`CONTEXT.md`, lines 7–16; `djsupport/transfer.py`, lines 1–5 and 1119–1147). Today, a playlist created by Chrome therefore bypasses durable Transfer identity, retained cross-source matching knowledge, Provisional Playlist/Approval behavior, publication checkpoints, account-level publishing serialization, and Mirror/Snapshot semantics.
+
+That boundary should inform—not dictate—the eventual architecture:
+
+- **Keep in Chrome:** recognize the current browser context; capture explicit user intent; show lightweight source facts and Transfer status; deep-link to review or Spotify.
+- **Keep in Transfer:** source identity; mode and publication policy; matching/Corrections/Approved Matches; Preview and Approval; Spotify mutation; checkpoints, resume, concurrency, and outcome reporting.
+- **Do not silently infer:** following, recurrence, Mirror status, Approval, source relinking, or destructive playlist intent from one extension click.
+
+## Why it feels close to the desired personal workflow
+
+- **It begins where discovery happens.** The user does not have to remember a URL or switch to a command-line workflow.
+- **It answers “will this work?” early.** Badge count, detected title, and track count turn a vague page into a concrete possible playlist before costly matching.
+- **It compresses setup.** Page context proposes the source and playlist name; cached results reduce repeated work.
+- **It maintains momentum without hiding uncertainty.** Progress is visible; questionable or absent matches remain reviewable; publication is a separate explicit action.
+- **It ends at the natural next place.** “Open in Spotify” closes the loop instead of asking the user to locate the output.
+
+These are interaction principles, not a mandate to preserve the current screens or expose technical controls. In particular, the raw numeric match-threshold slider (`src/entrypoints/sidepanel/App.tsx`, lines 180–193) is implementation language and may be less useful than a stable product policy plus exception review.
+
+## Constraints exposed by the code
+
+1. **Beatport-only and structurally fragile.** Supported page categories are broader than chart/label, but all depend on undocumented page internals. Anti-bot and stale SPA states are expected and explicitly handled (`src/entrypoints/content.ts`, lines 42–95).
+2. **Two authorities will drift.** Parsing, matching, cache schema, rate-limit behavior, and Spotify contracts are duplicated in TypeScript and Python. “Same result” is a convention, not a shared durable implementation.
+3. **Current Spotify creation is legacy-shaped.** Chrome calls `/users/{userId}/playlists` and playlist `/tracks` routes (`src/lib/spotify-api.ts`, lines 128–181); the playlist API review identifies `/me/playlists`, `/items`, scopes, stable `account_id`, and snapshot/concurrency work as required foundations (`docs/research/2026-08-01-playlist-management-api-review.md`, sections 1 and 6).
+4. **The happy path is synchronous and panel-bound.** Progress messages are live, but the UI does not reattach to a durable job after the panel/browser lifecycle. Rate limiting saves the cache and returns an error with progress, not a resumable Transfer (`src/entrypoints/background.ts`, lines 147–170).
+5. **Local state includes sensitive credentials and derived music data.** Refresh tokens and match cache live in extension-local storage (`src/lib/spotify-auth.ts`, lines 174–214; `src/lib/cache.ts`, lines 28–52). Any core handoff must define minimal payloads, ownership, retention, and migration; none should enter Git or telemetry by accident.
+6. **Publication means “new private Snapshot-like playlist,” but is unnamed as such.** It never updates an existing playlist or retains a relationship. The product must not reinterpret that click as a recurring Mirror without asking.
+7. **Selection is URI-set based.** The UI's `Set` and publication deduplication intentionally collapse many-to-one matches (`src/entrypoints/sidepanel/App.tsx`, lines 18–20, 89–92; `src/lib/spotify-api.ts`, lines 149–165). This fits current matching publication but must not leak into future exact backup/restore, where duplicate occurrences and order are facts.
+
+## Wayfinder opportunity frontier
+
+These are decision areas, not feature commitments:
+
+1. **Capture contract:** What is the smallest browser-to-Transfer request that preserves explicit intent—current URL, detected source kind and title, or a normalized immutable source reference? What can be recomputed safely server/core-side?
+2. **Immediate versus saved intent:** Does clicking normally start a Preview/Transfer now, save a discovery for later, or make that choice explicit? The current workflow strongly supports immediate action; following artists/labels introduces durable subscriptions and therefore needs a separate explicit act.
+3. **Supported discovery objects:** Which encountered things deserve first-class intake: Beatport chart, label, release, search result, artist, or a playlist on another site? Each needs a truthful source identity and refresh contract before UI expansion.
+4. **Mode at capture:** Is an encountered page a one-time Snapshot by default, with Mirror/following offered only when the source is durably re-readable? Do not infer recurrence from “label” or “artist.”
+5. **Review placement:** Which facts must remain in the side panel, and when should Chrome hand off to DJ Support's fuller review? Preserve selected/unmatched visibility and avoid exposing domain terms before they help a decision.
+6. **Durable progress:** How should the side panel reconnect to a prepared Transfer after closure, auth, rate limit, or browser restart? The current progress experience is valuable but not durable.
+7. **Matching authority migration:** Can Chrome stop owning a second matcher/cache while retaining its responsive progress? If an offline/browser-only mode remains, how are result parity, Corrections, and Approved Matches reconciled without silent divergence?
+8. **Feedback and completion:** Should success open Spotify, DJ Support's report/review, or offer both based on state? “Open in Spotify” is a proven finish for completed publication; paused or approval-needed work needs a different truthful destination.
+9. **Follow discovery:** For artists and labels, what constitutes “new and relevant,” how often is checked, which sources are legally/reliably queryable, and is the output an inbox, a proposed Transfer, or a managed Mirror? This is a new domain capability, not merely another page parser.
+10. **Metadata enrichment:** When discovery reveals missing label, release, date, mix, or identifier data, where may suggestions be retained and reviewed? Never silently rewrite Rekordbox, audio tags, Spotify metadata, or Approved Matches.
+
+## Recommended next map question
+
+Before choosing screens or a release number, decide the default meaning of the extension click in plain personal terms:
+
+> When I find something worth keeping while browsing, do I want DJ Support to make a playlist now, remember it for later, or let me choose each time?
+
+That decision separates the proven immediate-conversion journey from the new capture/following opportunity, while leaving Mirror, Snapshot, Approval, and recovery policy with Transfer.

--- a/docs/research/2026-08-01-mobile-discovery-and-capture.md
+++ b/docs/research/2026-08-01-mobile-discovery-and-capture.md
@@ -1,0 +1,134 @@
+# Mobile discovery and capture: evidence for the DJ Support roadmap
+
+**Date:** 2026-08-01
+
+**Status:** Planning research only. No production code, live account access, private
+music data, or playlist mutation was involved.
+
+## Answer in brief
+
+The available first-party evidence does **not** support the claim that DJs seldom
+search Beatport on phones. Beatport deliberately offers mobile search, discovery,
+artist/label following, Track ID, and playlist management. What the evidence does
+support is a mobile-to-later pattern: capture tracks into a playlist while away
+from the desk, then continue in Beatport, DJ software, or hardware later.
+
+For DJ Support, the defensible roadmap choice is therefore personal and
+evidence-gated rather than a market generalization:
+
+- lead with laptop browsing and immediate conversion because that is the owner's
+  stated behavior and already has a working Chrome prototype;
+- preserve a separate future mobile intent—**remember this for later**—behind the
+  same narrow intake contract;
+- do not build a mobile product until a small diary or usage sample shows where
+  Beatport's own playlist handoff fails the owner's Spotify workflow.
+
+## What first-party sources establish
+
+1. **Beatport intends mobile to support discovery, not merely passive playback.**
+   Beatport describes its app as optimized for mobile music search and says it
+   supports discovering music, creating playlists, and following genres, artists,
+   and labels through My Beatport
+   ([Beatport Mobile v1.2](https://www.beatportal.com/articles/201000-introducing-beatport-mobile-v1-2-now-free-for-all-users)).
+
+2. **The official cross-device journey explicitly includes “collect now, continue
+   later.”** The current App Store listing says users can discover music and add
+   tracks to playlists on the go, then access those finds on Beatport.com to check
+   out and download them
+   ([Beatport on the App Store](https://apps.apple.com/us/app/beatport-music-for-djs-app/id1543739988)).
+   Beatport's streaming page likewise presents mobile as a place to build
+   playlists, discover music, add tracks, and identify heard tracks with Track ID
+   ([Beatport Streaming](https://stream.beatport.com/)).
+
+3. **Beatport presents mobile playlists as portable preparation artifacts.** Its
+   official getting-started guidance says playlists created on mobile are
+   immediately available in Beatport DJ, the store, and integrated DJ software
+   and hardware
+   ([Getting Started with Beatport Mobile](https://www.beatportal.com/videos/92586-getting-started-with-beatport-mobile)).
+   A first-party artist demonstration describes listening on a phone while on the
+   road, putting a track in a playlist, and later arriving and playing it
+   ([Eats Everything explores Beatport Streaming](https://www.beatportal.com/videos/831864-eats-everything-explores-beatport-streaming-cdj-3000s)).
+
+4. **There is meaningful distribution, but no public behavioral split.** The
+   official Google Play listing reports 500K+ installs and advertises on-the-go
+   discovery and playlist building. Install count does not tell us how often DJs
+   search, merely capture, or complete downstream playlist work on mobile
+   ([Beatport on Google Play](https://play.google.com/store/apps/details?id=com.beatport.mobile)).
+
+5. **The existing Chrome extension is inherently laptop-first.** Google states
+   that Chrome extensions can only be used on computers and cannot be installed
+   on mobile devices
+   ([Chrome Web Store Help](https://support.google.com/chrome_webstore/answer/1698338)).
+   A future iPhone doorway is technically possible as a Safari Web Extension, but
+   it would require an iOS containing app, signing, and App Store distribution; it
+   is not a free deployment of the current Chrome artifact
+   ([Apple Safari Web Extensions](https://developer.apple.com/documentation/safariservices/distributing-your-safari-web-extension)).
+
+## Evidence, inference, and unknowns
+
+### Evidence
+
+- Beatport provides and promotes mobile search, discovery, following, Track ID,
+  and playlist management.
+- Beatport supports handing a mobile-created playlist into later desktop, store,
+  software, and hardware contexts.
+- The existing DJ Support Chrome doorway is a computer surface, not a mobile one.
+
+### Reasonable inference
+
+- “Remember this for later” is a credible mobile intent because Beatport itself
+  has designed around it and published a concrete artist workflow exhibiting it.
+- A DJ Support mobile inbox could be useful specifically when the desired final
+  destination is Spotify or when the source is outside Beatport—not because
+  mobile discovery is rare.
+- Laptop-first is the lowest-risk next slice for this single-user product because
+  the owner confirmed immediate conversion as the browser default and a working
+  prototype already exists.
+
+### Unknown
+
+- No reviewed first-party source provides the proportion of Beatport discovery,
+  search, or playlist activity performed on mobile versus desktop.
+- There is no evidence here about how often mobile users want Spotify conversion
+  immediately rather than later.
+- We do not yet know whether the owner's easiest mobile capture is a shared URL,
+  a Beatport playlist, a system share-sheet action, or no DJ Support action at all.
+- We do not know whether mobile capture happens often enough to justify a new
+  client and its authentication, synchronization, privacy, and packaging costs.
+
+## Roadmap implications
+
+### Leading path: laptop immediate conversion
+
+Use the current Chrome interaction as the first doorway: on a supported desktop
+Beatport page, the ordinary action means “make this Spotify playlist now.” Chrome
+captures context and intent; durable `Transfer` owns source facts, matching,
+review, publication, recovery, and retained state. This continues the evidence
+already recorded in [Chrome discovery-to-Spotify workflow](2026-08-01-chrome-discovery-workflow.md)
+and [Simplest Chrome-to-DJ Support product boundary](2026-08-01-simplest-chrome-gui-boundary.md).
+
+### Later option: mobile capture inbox
+
+Treat mobile as a different job: “remember this source or selection for me.” A
+future adapter could submit a URL or explicit source reference to a private inbox,
+without starting Spotify mutation or inferring Snapshot, Mirror, following, or
+Approval. At the laptop, the owner would decide whether to start a Transfer.
+
+Before making that a release commitment, collect a lightweight personal diary:
+for each phone discovery, note the source, what was worth keeping, what action was
+taken, and where the owner expected it to appear later. This can reveal whether
+DJ Support needs a mobile intake at all, or whether importing/reusing a Beatport
+playlist is the simpler seam. No private diary evidence belongs in Git.
+
+## Wayfinder recommendation
+
+Keep both branches on the decision frontier, but put laptop immediate conversion
+first and make mobile capture conditional on personal evidence. Do not justify
+that order by claiming DJs rarely use Beatport on mobile, and do not revive the
+dropped standalone Mirror/Drift UX study or PR #76.
+
+The next plain-language question should be:
+
+> The next time you find music on your phone, what would be the least-effort way
+> to leave it for DJ Support: share the page, add it to a named Beatport playlist,
+> or simply copy the link?

--- a/docs/research/2026-08-01-simplest-chrome-gui-boundary.md
+++ b/docs/research/2026-08-01-simplest-chrome-gui-boundary.md
@@ -1,0 +1,153 @@
+# Simplest Chrome-to-DJ Support product boundary
+
+**Date:** 2026-08-01
+
+**Status:** Planning research only. No production code, live service call, private
+music data, or Chrome-project file was changed.
+
+## Decision in one sentence
+
+For the single-user product, the simplest credible path is **Chrome as a
+one-click capture and status surface, backed by the existing loopback web app
+and the durable `Transfer` authority**; open the local web UI only when setup,
+review, recovery, or richer management needs more room. Later, a packaged
+native launcher can remove the terminal/startup step without moving product
+policy into Chrome.
+
+The ordinary extension click means “make this playlist now.” It does not imply
+“follow this source,” “save for later,” or “make this a Mirror.” Those remain
+separate future intents.
+
+## Why this is the smallest coherent shape
+
+DJ Support already has most of the local application boundary needed for the
+journey: a FastAPI adapter creates a durable Transfer ID before background
+execution, exposes resumable progress and result routes, and delegates to
+`Transfer` ([web adapter](../../djsupport/web.py#L113-L206), [progress and
+resume](../../djsupport/web.py#L208-L255)). Its current web UI already checks
+Spotify connection, posts a Beatport URL, persists the active Transfer ID,
+reattaches after reload, streams progress, and opens the finished Spotify
+playlist ([web UI](../../djsupport/static/index.html#L507-L539), [start and
+progress](../../djsupport/static/index.html#L573-L652), [completion](../../djsupport/static/index.html#L660-L690)).
+
+The core boundary is explicit: adapters supply a `TransferRequest`, while
+`Transfer` owns matching, persistence ordering, Preview policy, and publication
+([Transfer seam](../../djsupport/transfer.py#L1-L6), [request](../../djsupport/transfer.py#L90-L105)).
+Private retained state already belongs in platform application data rather than
+the repository ([storage path](../../djsupport/transfer.py#L63-L71)).
+
+The Chrome project supplies the complementary interaction: its content script
+recognizes the current Beatport page and handles single-page navigation
+([content script](https://github.com/spontain112/djsupport-chrome/blob/e26bdcacdbe6d66725fad489ff29690e42dea808/src/entrypoints/content.ts#L8-L38));
+the side panel turns that context into a short ready-to-progress journey
+([side-panel state](https://github.com/spontain112/djsupport-chrome/blob/e26bdcacdbe6d66725fad489ff29690e42dea808/src/entrypoints/sidepanel/App.tsx#L5-L49),
+[one main action](https://github.com/spontain112/djsupport-chrome/blob/e26bdcacdbe6d66725fad489ff29690e42dea808/src/entrypoints/sidepanel/App.tsx#L172-L213)).
+But its service worker currently owns a second cache, matcher, Spotify login,
+and playlist writer ([background](https://github.com/spontain112/djsupport-chrome/blob/e26bdcacdbe6d66725fad489ff29690e42dea808/src/entrypoints/background.ts#L1-L8),
+[matching](https://github.com/spontain112/djsupport-chrome/blob/e26bdcacdbe6d66725fad489ff29690e42dea808/src/entrypoints/background.ts#L82-L170),
+[publication](https://github.com/spontain112/djsupport-chrome/blob/e26bdcacdbe6d66725fad489ff29690e42dea808/src/entrypoints/background.ts#L173-L181)).
+That is the duplication to retire, not the interaction to discard.
+
+## Options compared
+
+| Option | Setup and lifecycle | Auth/security | UX and evolution | Verdict |
+| --- | --- | --- | --- | --- |
+| **A. Full extension GUI + local DJ Support service** | Still requires installing and starting the local service; additionally duplicates a large UI and reconnect logic inside an extension service-worker lifecycle. | Can centralize Spotify tokens in the service, but adds a privileged extension-to-loopback API surface. | Keeps everything in the side panel, yet every richer Transfer/recovery capability needs two presentation adapters. | Credible, but not simplest. Use the panel only for small status and actions. |
+| **B. Chrome capture/status + existing local web UI** | Smallest current delta: the service and web UI already exist. The initial single-user version can require `djsupport web`; later packaging can hide startup. | One local authority can own OAuth tokens and Spotify mutation. Bind to `127.0.0.1`, accept only a narrow source-intent request, validate the expected extension origin, and require a per-install pairing secret. | Preserves the in-context click and feedback; opens the web UI only for connect/setup, exceptions, review, or recovery. It naturally grows into the full non-terminal GUI. | **Recommended now.** |
+| **C. Browser-only extension with duplicated logic** | One extension install and no companion process is superficially easiest. Store distribution can auto-update it. | It currently stores a Spotify refresh token in extension-local storage ([token storage](https://github.com/spontain112/djsupport-chrome/blob/e26bdcacdbe6d66725fad489ff29690e42dea808/src/lib/spotify-auth.ts#L174-L214)) and directly performs mutations. | Fast current journey, but matching knowledge, publication, recovery, and policy diverge from durable Transfer. Migration gets harder with every capability. | Reject as the product architecture. It is a useful interaction reference only. |
+| **D. Native-messaging launcher/bridge + local web UI** | Chrome can launch a native host per message or keep one alive, removing the manual server-start step. However, each OS needs host registration (manifest paths on macOS/Linux; registry on Windows) and an installed executable. | Native-host manifests allowlist exact extension origins; the protocol should still accept only a validated source and explicit intent. | Best eventual “click and it works” local-app experience while retaining one web GUI and Transfer authority. | **Best packaging evolution, not the first slice.** |
+
+## Platform facts that constrain the choice
+
+- Extension pages and service workers may make cross-origin requests only with
+  matching host permissions; content scripts remain subject to the page's
+  origin. A loopback integration should therefore use the extension worker and
+  a narrow `http://127.0.0.1/...` host permission, not arbitrary hosts
+  ([Chrome cross-origin requests](https://developer.chrome.com/docs/extensions/develop/concepts/network-requests)).
+- Chrome is also evolving Local Network Access controls and classifies loopback
+  as local-network access. A loopback bridge remains viable, but it must be
+  tested against current stable Chrome and should not be treated as permanently
+  friction-free browser transport ([Chrome Local Network Access](https://developer.chrome.com/blog/local-network-access),
+  [loopback transition note](https://developer.chrome.com/blog/pna-permission-prompt-ot-end)).
+- Native Messaging requires the `nativeMessaging` permission and an installed
+  host manifest. `sendNativeMessage()` starts a process for one response;
+  `connectNative()` keeps the process alive until its port closes. Host manifests
+  allowlist exact `chrome-extension://<id>/` origins
+  ([Chrome Native Messaging](https://developer.chrome.com/docs/extensions/develop/concepts/native-messaging),
+  [permission warning](https://developer.chrome.com/docs/extensions/reference/permissions-list)).
+- Loading an unpacked extension is adequate for this owner's experiment. A
+  broadly simple install eventually means Chrome Web Store distribution;
+  self-hosted installation on Windows and macOS is restricted to enterprise
+  policy. Store updates require a version bump, upload, and review
+  ([Chrome distribution](https://developer.chrome.com/docs/extensions/how-to/distribute),
+  [update lifecycle](https://developer.chrome.com/docs/extensions/develop/concepts/extensions-update-lifecycle),
+  [Web Store update](https://developer.chrome.com/docs/webstore/update/)).
+- Spotify recommends Authorization Code with PKCE where a client secret cannot
+  be safely stored, including browser and desktop clients. Loopback redirects
+  must use an explicit IP such as `http://127.0.0.1:PORT`; `localhost` is not
+  allowed under the current redirect rules
+  ([Spotify authorization](https://developer.spotify.com/documentation/web-api/concepts/authorization),
+  [PKCE](https://developer.spotify.com/documentation/web-api/tutorials/code-pkce-flow),
+  [redirect URIs](https://developer.spotify.com/documentation/web-api/concepts/redirect_uri)).
+  This reinforces keeping one OAuth owner in the local app instead of keeping
+  the extension's separate token lifecycle.
+
+## Recommended staged product
+
+### Stage 1 — prove the boundary for the owner
+
+Keep the unpacked extension. On a supported Beatport page, its ordinary click
+sends only the canonical page URL and explicit “start Snapshot now” intent to a
+loopback endpoint. DJ Support validates and re-reads the source, prepares the
+Transfer, and returns a durable Transfer ID. The panel shows detected source,
+progress, paused/error state, and “Open in Spotify” on straightforward
+completion. “Open DJ Support” hands setup, Spotify connection, exceptions,
+review, and recovery to the existing web UI.
+
+Do not send the extension's parsed track list as authority. It may use locally
+observed title/count as provisional feedback, but the Transfer must establish
+the source facts it will publish. Do not expose arbitrary URL fetching,
+commands, filesystem paths, or Spotify credentials through the bridge.
+
+Before calling even this owner-only slice complete, decide and test: fixed
+loopback address/port discovery, extension pairing/rotation, expected-Origin
+checks, no permissive CORS, URL allowlisting, service-unavailable guidance, and
+reattachment by Transfer ID after panel/browser closure. These are planning
+gates, not implementation authorization.
+
+### Stage 2 — remove terminal setup
+
+Package DJ Support as a small first-party local application that installs and
+starts the web service, opens the setup UI, and owns updates/data migration.
+Only after that installer exists, add a Native Messaging launcher/bridge so an
+extension click can wake the app when it is not running. Native messaging is
+the cleaner eventual launcher, but implementing its OS-specific registration
+before the product boundary is proven would front-load packaging work.
+
+### Stage 3 — let the web UI become the GUI
+
+Grow the local web UI—not the extension—into the non-terminal home for Transfer
+history, Rekordbox selection, Approval/Correction, recovery, and later explicit
+following or enrichment workflows. Keep Chrome specialized around the moment
+of browser discovery. A future mobile or other-site capture adapter can then
+use the same narrow intake contract without becoming another policy authority.
+
+## Decision tickets for the Wayfinder frontier
+
+1. **Define the browser capture contract:** exact supported URL kinds, explicit
+   Snapshot-now intent, provisional display facts, idempotency, and response.
+2. **Choose the owner-only pairing and reconnect model:** fixed or discovered
+   loopback port, secret lifecycle, expected extension ID/origin, Transfer-ID
+   persistence, and failure copy.
+3. **Define the handoff rule:** which completed states remain in the panel and
+   which review/setup/recovery states open the local web UI.
+4. **Choose the no-terminal release gate:** whether a first-party installer and
+   auto-start are required before calling the workflow generally usable.
+5. **Research native-host packaging only after that gate:** macOS, Windows, and
+   Linux registration/update/uninstall behavior, without changing Transfer's
+   authority.
+
+This recommendation deliberately does not revive the dropped standalone
+Mirror/Drift UX study or PR #76. It asks a broader product question: how can the
+browser remain the easiest doorway while the local application becomes the one
+durable place where DJ Support works?

--- a/docs/research/2026-08-01-third-party-spotify-playlist-watchlist.md
+++ b/docs/research/2026-08-01-third-party-spotify-playlist-watchlist.md
@@ -1,0 +1,128 @@
+# Third-party Spotify Playlist Watchlist feasibility
+
+**Date:** 2026-08-01
+
+**Status:** Read-only research; no Spotify calls were made.
+
+**Question:** Can DJ Support monitor roughly 50 playlists curated by other
+people, detect newly added tracks, and surface those tracks in a private
+Discovery Feed without mutating Spotify?
+
+## Decision summary
+
+Not with DJ Support's realistic Spotify access today. Under the current
+Development Mode contract, DJ Support may discover a followed playlist and
+observe playlist-level metadata such as `snapshot_id`, but it cannot read the
+items of a playlist unless the authenticated user owns or collaborates on it.
+That blocks the core promise: identifying which tracks were newly added to
+third-party playlists.
+
+Treat **Playlist Watchlist** as **fog**, represented by one bounded Wayfinder
+research/prototype ticket rather than next-release scope. A useful thin
+experiment could watch known playlist URLs for a changed `snapshot_id` and
+offer **Open in Spotify**. It must not claim to produce a new-track feed. The
+full feed becomes feasible only if Spotify restores suitable Development Mode
+access, DJ Support later qualifies for Extended Quota, or the user deliberately
+copies/shares tracks into an owned intake source.
+
+## Confirmed facts
+
+- In Development Mode, `GET /playlists/{id}/items` is limited to playlists the
+  authenticated user owns or collaborates on; other playlists return `403`.
+  This is the direct blocker for finding additions in third-party playlists
+  ([February 2026 migration guide](https://developer.spotify.com/documentation/web-api/tutorials/february-2026-migration-guide),
+  [Get Playlist Items](https://developer.spotify.com/documentation/web-api/reference/get-playlists-items)).
+- `GET /me/playlists` enumerates playlists the user owns or follows. It is
+  paginated with a maximum page size of 50 and returns simplified playlist
+  facts including `snapshot_id` and item count. Private playlist discovery uses
+  `playlist-read-private`; the arbitrary-user playlist endpoint was removed
+  from Development Mode in February 2026
+  ([current-user playlists](https://developer.spotify.com/documentation/web-api/reference/get-a-list-of-current-users-playlists),
+  [February 2026 changes](https://developer.spotify.com/documentation/web-api/references/changes/february-2026)).
+- `GET /playlists/{id}` still exposes playlist-level metadata including
+  `snapshot_id`, but its item content is available only for owned or
+  collaborative playlists. Consequently, a known public playlist can provide
+  a change signal without revealing the changed tracks
+  ([Get Playlist](https://developer.spotify.com/documentation/web-api/reference/get-playlist)).
+- Spotify now represents saving/following playlists through generic library
+  endpoints. Saving or checking playlist URIs supports up to 40 items per
+  request, while enumeration remains `GET /me/playlists`
+  ([Save Library Items](https://developer.spotify.com/documentation/web-api/reference/save-library-items),
+  [Check Library Items](https://developer.spotify.com/documentation/web-api/reference/check-library-contains)).
+- Development Mode requires a Premium app owner and supports at most five
+  allowlisted users. Extended Quota has higher rate limits and unlimited users
+  ([quota modes](https://developer.spotify.com/documentation/web-api/concepts/quota-modes)).
+- Rate limiting uses an unpublished, mode-dependent rolling 30-second window.
+  Clients must honor `429` and `Retry-After`; Spotify recommends caching
+  `snapshot_id` to avoid unnecessary item downloads
+  ([rate limits](https://developer.spotify.com/documentation/web-api/concepts/rate-limits)).
+- Spotify's Developer Terms prohibit robots, spiders, and retrieval tools used
+  to retrieve, duplicate, or index Spotify service content, explicitly
+  including playlist data. A browser extension or server-side scraper is not a
+  safe workaround. Displayed Spotify metadata also carries attribution,
+  link-back, privacy, and security obligations; Spotify content may not be
+  ingested into an AI/ML model
+  ([Developer Terms](https://developer.spotify.com/terms),
+  [Developer Policy](https://developer.spotify.com/policy)).
+
+## Conditional cases
+
+- Spotify says Extended Quota integrations are unaffected by the February 2026
+  restrictions, so third-party public playlist-item reads should remain
+  available there. Access is not a viable planning assumption for a personal
+  tool: applications are organization-only and require an established legal
+  entity, a launched service, at least 250,000 monthly active users, broad
+  market availability, commercial viability, and Spotify review
+  ([migration guide](https://developer.spotify.com/documentation/web-api/tutorials/february-2026-migration-guide),
+  [quota modes](https://developer.spotify.com/documentation/web-api/concepts/quota-modes)).
+- A Development Mode **change alert** appears technically possible: the user
+  supplies or follows a playlist, DJ Support periodically compares its cached
+  `snapshot_id`, then offers to open changed playlists in Spotify. Before this
+  becomes a promise, a synthetic read-only contract test should confirm that
+  arbitrary public playlist metadata is consistently accessible.
+- A true item feed is possible when the source playlist is owned or
+  collaborative. One lawful habit is to share or copy candidate tracks into an
+  owned intake playlist, which DJ Support can then read. This changes the
+  workflow from passive monitoring to explicit capture.
+- Equivalent discovery may come from curators, labels, or providers offering an
+  official API, RSS feed, notification, or licensed export. That is a separate
+  provider-by-provider research branch, not a Spotify workaround.
+
+## Unknowns
+
+- Spotify publishes no numerical safe polling interval and no webhook or push
+  contract for playlist changes was found. A polling design therefore needs a
+  bounded request budget, backoff, caching, and explicit validation.
+- The documentation does not guarantee that every arbitrary public playlist's
+  metadata will remain readable in Development Mode. Do not infer product
+  coverage until tested without user-derived evidence.
+- User-supplied playlist URLs solve selection and identity, not item access.
+  Export or notification workflows depend on what the curator or another
+  provider officially offers.
+
+## Fit with DJ Support
+
+The existing [playlist-management API review](2026-08-01-playlist-management-api-review.md)
+already records the owner/collaborator item-read boundary, pooled quotas,
+snapshot caching, and the need to migrate DJ Support's adapter and scopes. The
+current adapter requests only modification scopes and has no third-party
+playlist reader ([Spotify adapter](../../djsupport/spotify.py)). Any future
+watcher should return read-only discovery facts to a Discovery Feed; it is not
+a Mirror, Snapshot, Transfer, Approval, or Spotify publication action.
+
+## Recommended Wayfinder ticket
+
+**Research/prototype: validate a read-only Spotify playlist change alert.**
+
+Answer only whether Development Mode can reliably read `snapshot_id` for a
+small synthetic set of non-owned public playlist URLs, what request budget is
+safe, and whether “this playlist changed—open it” is useful enough without
+track-level additions. Keep the richer third-party new-track feed in fog until
+the access condition changes. Do not scrape Spotify and do not place this in
+the next release's committed scope.
+
+## Next user question
+
+If DJ Support could only tell you **which watched playlists changed** and open
+them in Spotify—not show the new tracks—would that still save you enough time
+to be worth building?

--- a/docs/research/2026-08-02-library-metadata-repair-landscape.md
+++ b/docs/research/2026-08-02-library-metadata-repair-landscape.md
@@ -1,0 +1,104 @@
+# Personal library metadata repair: build, buy, or orchestrate?
+
+**Status:** Wayfinder research note, 2026-08-02. No private library was read and
+no live service was called.
+
+## Conclusion
+
+Do **not** build a metadata identification/tagging engine. The useful frontier
+is a copied-file trial of existing tools, followed—only if it adds value—by a
+thin DJ Support suggestion/review/export seam. The leading trials are:
+
+1. **Yate** for inexpensive, Mac-native, scriptable repair spanning DJ stores,
+   MusicBrainz/AcoustID and Apple Music integration.
+2. **OneTagger** for DJ-store metadata and fill-empty behavior, with an explicit
+   maintenance/API-compatibility check because its public changelog currently
+   stops at 1.7.0 (2023-08-03).
+3. **MusicBrainz Picard** for acoustic-fingerprint recovery when title/artist
+   are absent or wrong.
+4. **Lexicon** only if direct Rekordbox/Apple Music round-trip, undo and library
+   management justify a subscription.
+
+The irreversible boundary is not lookup; it is applying a suggestion. DJ
+Support must never turn enrichment into an Approved Match, edit an audio file,
+or rewrite Rekordbox/Apple Music without a backup, per-field Preview, and an
+explicit user-approved Apply action.
+
+## What the host libraries permit
+
+- Rekordbox can export a collection as XML, and its documented developer bridge
+  can display playlists and track information from a supported XML file. Its
+  manual also documents **Reload Tag**, which rereads ID3/file tags into the
+  Rekordbox library. This supports an export/suggest/tag/reload workflow, not a
+  supported public API for arbitrary database mutation. Streaming-track
+  information cannot be edited. [Rekordbox developer XML](https://rekordbox.com/en/support/developer/),
+  [Rekordbox 7 manual](https://cdn.rekordbox.com/files/20240509141437/rekordbox7.0.0_manual_EN.pdf),
+  [Rekordbox 7 FAQ](https://rekordbox.com/en/support/faq/rekordbox7/)
+- Apple Music on Mac permits manual and batch editing of song information,
+  including artist, title, album, genre and BPM. It exports all Info-window
+  fields as text or library/playlist information as XML; playlist re-import
+  includes only media already in the library. [Edit song information](https://support.apple.com/guide/music/change-song-and-cd-information-mus2561f46f8/mac),
+  [export/import behavior](https://support.apple.com/en-nz/guide/music/-mus27cd5060f/mac)
+- MusicKit can search/read a permitted library and add content or create/edit
+  playlists, but its documented mutation surface does not expose arbitrary
+  local-song tag editing. A DJ Support integration should therefore prefer
+  reviewed exports or established desktop automation/tool integration over
+  assuming MusicKit can rewrite tags. [MusicKit](https://developer.apple.com/musickit/),
+  [MusicLibrary](https://developer.apple.com/documentation/musickit/musiclibrary)
+
+## Tool comparison
+
+| Option | Useful fields and identification | Target and safety | macOS / cost / integration |
+|---|---|---|---|
+| **Yate** | Broad tag editing; integrations include AcoustID/AcousticBrainz, Beatport, Discogs, MusicBrainz, last.fm and Music/iTunes. Suitable for title, artist, album, date, genre, IDs/art; BPM/key are primarily edit/import fields rather than its core analysis promise. | Audio-file tags; action scripting makes controlled batches possible. Trial only on copies and keep host-library backup. | macOS only; official price $20 perpetual with 14-day trial. Apple Music-aware and scriptable. [Yate](https://2manyrobots.com/yate/) |
+| **OneTagger** | Beatport, Traxsource, Juno, Discogs, iTunes, MusicBrainz, Beatsource and Spotify lookup; Shazam identification; includes remixer, label/store metadata, genre/subgenre, date, artwork and ISRC. User selects fields and **overwrite** versus **fill empty**. | Writes audio tags; batch folder/playlist input. Its fill-empty control is a good safety primitive, but not a substitute for copied-file Preview. Network lookup varies by selected source/account. | Free/open-source, macOS Catalina+; source/CLI offer orchestration potential. Public release freshness must be tested. [OneTagger](https://onetagger.github.io/) |
+| **MusicBrainz Picard** | Strong title/artist/release/album/date/genre/ISRC/label relationships and artwork; AcoustID/Chromaprint can identify audio with missing or incorrect tags. It is less DJ-store/version oriented than OneTagger/Yate. | Shows proposed metadata and writes only on **Save**; supports batch selection and broad formats. Lookup/fingerprint resolution and artwork use network services. | macOS/Windows/Linux, GPL-2.0-or-later; plugins/scripts are extensible, but embedding GPL code requires license care. [formats and Save behavior](https://picard-docs.musicbrainz.org/en/latest/faq/faq_file_formats.html), [license/development](https://picard.musicbrainz.org/docs/development/), [tag mapping](https://picard-docs.musicbrainz.org/en/latest/appendices/tag_mapping.html) |
+| **beets** | MusicBrainz autotagging plus plugins; Chromaprint/AcoustID can identify files with no useful tags; plugins can add sources and fields. | Can keep suggestions in its database without writing (`-W`/`import.write` off); timid mode asks for every decision. Best programmable substrate, but CLI-heavy. Fingerprints stay local unless the user separately submits them; lookup still uses AcoustID. | Cross-platform, MIT; current repository release v2.11.0 (2026-05-06). Strongest open-source integration API. [repository/license](https://github.com/beetbox/beets), [fingerprinting/privacy controls](https://beets.readthedocs.io/en/v2.1.0/plugins/chroma.html), [plugin API](https://beets.readthedocs.io/en/stable/dev/plugins/autotagger.html) |
+| **Lexicon** | DJ-library cleanup, missing tags/art, Track Matcher, custom fields and file-tag writing; Rekordbox 5/6/7 and Music/iTunes import/sync. Covers broad descriptive fields; its strength is library workflow rather than an open identification engine. | Native library conversion/sync, Undo History, archive and database/cloud backup. Still require an external Rekordbox backup and a synthetic/copied-library trial. | macOS/Windows; free conversion tier and paid library-management subscriptions (current amounts are dynamically presented). Local plugins/API are a possible integration, subject to tier and contract. [manual](https://www.lexicondj.com/manual/all), [pricing](https://www.lexicondj.com/pricing) |
+| **Mp3tag / Metadatics** | Excellent manual/batch tag editing, online Discogs/MusicBrainz-style lookup, artwork and transformations; no official acoustic-fingerprint claim found. | Audio tags, with previews/manual release alignment; host libraries must refresh/reimport. | Commercial Mac apps; useful buy-only comparators, not obvious DJ Support integration substrates. [Mp3tag](https://mp3tag.app/), [Metadatics](https://www.markvapps.com/metadatics) |
+| **Mixed In Key** | Best treated as complementary audio analysis for BPM, key and energy, plus cue points—not broad identity/label/ISRC recovery. | Writes analysis/tag data and documents Rekordbox XML/reload-tag workflow. | Commercial Mac/Windows desktop workflow; no reason to use it as the general metadata engine. [Rekordbox workflow](https://mixedinkey.com/workflows/use-mixed-in-key-with-rekordbox/), [integration overview](https://mixedinkey.com/integration/introduction/) |
+
+No single source is authoritative for every field. In particular, “mix” naming,
+genre and original release date are policy choices; BPM/key can be measured but
+may differ by analyzer; artwork and label/release attribution are edition
+specific; and ISRC is useful evidence, not guaranteed unique identity.
+
+## Build versus buy
+
+| Path | Judgment |
+|---|---|
+| Configure/buy an existing tool | **First.** Fastest evidence and already covers tagging, lookup and review. Run Yate, OneTagger and Picard against a tiny synthetic/copied set containing deliberate gaps; add Lexicon only to test native round-trip/undo. |
+| Build a thin DJ Support orchestrator/export | **Possible later.** Valuable only if it unifies source provenance, presents per-field alternatives/confidence, emits a reviewable sidecar/CSV, and delegates applying changes to a proven tool or an explicit narrow adapter. beets has the cleanest open plugin substrate; OneTagger has the closest DJ-store semantics. |
+| Build a full metadata engine | **Reject.** It duplicates fingerprinting, catalog normalization, format-specific tag writers, artwork handling and continuously changing provider adapters, while creating the highest corruption/privacy risk. |
+
+## Safe validation protocol
+
+Use only synthetic files or user-created copies. Before any real trial, export
+the Apple Music/Rekordbox library and back up the selected audio files. Compare
+per field: old value, proposed value, source, release/version, confidence and
+whether the value is missing versus conflicting. Default to suggestion-only;
+Apply must name its target (file tags, Rekordbox refresh/export, or Music
+library), recheck the file/library head, and produce a reversible audit record.
+Never scan directories or submit fingerprints without explicit authorization.
+
+## Relationship to existing work
+
+- [Evaluate recovery of missing and noisy source metadata](https://github.com/spontain112/djsupport/issues/32)
+  remains the umbrella; this note adds a separate **library repair** branch,
+  rather than changing lossless Transfer source intake.
+- [Evaluate ISRC-first matching from source metadata](https://github.com/spontain112/djsupport/issues/31)
+  remains matching research. A recovered ISRC can be presented as sourced
+  evidence, but cannot itself approve a match or authorize a library edit.
+- [Prototype: measure privacy-preserving ISRC feasibility and API cost](https://github.com/spontain112/djsupport/issues/42)
+  remains the bounded evidence gate. Any local-file or live phase still needs
+  separate consent; this tool trial does not bypass it.
+
+## Wayfinder disposition
+
+Put **full metadata engine** in the fog/rejected branch. Put **copied-file tool
+bake-off** on the near decision frontier. A successful bake-off may yield one
+narrow ticket for a suggestion artifact or tool handoff; it must not yield a
+general-purpose library writer by implication.
+
+**Next one-at-a-time question:** Which missing field causes you the most pain
+today: artist/title/version, label/date/genre, ISRC, artwork, or BPM/key?


### PR DESCRIPTION
## Summary

- retain five durable, primary-source Wayfinder research notes supporting the 0.5.0 map and post-foundation fog
- document the Chrome/Transfer boundary, mobile capture evidence, third-party Spotify playlist access limits, and metadata-repair build-versus-buy conclusion
- pin cross-project Chrome evidence to a committed baseline and remove user-specific filesystem references

## Why retain these notes

- the Chrome workflow and GUI-boundary notes support the post-foundation adapter boundary in [the canonical Wayfinder map](https://github.com/spontain112/djsupport/issues/77)
- the mobile and third-party playlist notes support the Discovery Feed and Playlist Watchlist fog without expanding [the 0.5.0 implementation spec](https://github.com/spontain112/djsupport/issues/85)
- the metadata-repair note records why DJ Support should not build a tagging engine and which bounded tool experiment informed that decision

## Verification

- `git diff --cached --check`
- privacy scan for local paths, private library identifiers, credential names, and token fields
- documentation-only change; no production code or user-derived fixtures
