### PR TITLE
DJ Support 0.5.0 — Trustworthy Spotify Foundation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,33 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [0.5.0] - 2026-08-02
+
+### Added
+
+- Typed Spotify playlist-head, ordered-item, page, and mutation facts.
+- Durable mutation snapshots and completed 100-item chunk identities for
+  resumable publication, with changed-head stop conditions.
+- Private-playlist read consent using only `playlist-read-private` in addition
+  to the existing playlist modification permissions.
+
+### Changed
+
+- Playlist creation uses Spotify's current-user route and item reads/writes use
+  the current playlist-item contract.
+- Approval verifies one stable playlist head around its complete ordered read.
+- Publication and Approval preserve duplicate occurrences and explicitly
+  classify null, local, episode, unsupported, restricted, and relinked items.
+- Private publication state writes schema 5 and Transfer state writes schema 2;
+  previous supported schemas remain readable and backup-compatible.
+
+### Fixed
+
+- Beatport chart curator provenance survives intake, durable resume, playlist
+  title construction, manifests, and approved Snapshot or Mirror copy.
+- Recovery markers are removed immediately after playlist ID retention, and
+  settled descriptions no longer expose opaque Transfer IDs or timestamps.
+
 ## [0.4.0] - 2026-08-01
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -52,6 +52,31 @@ python -m pip install -e ".[dev,web]"
 > named `djsupport-main`. Also note that `pipx` does not support editable
 > installs (`-e`); use `pip` instead.
 
+### Upgrading to 0.5.0
+
+Spotify authorization now includes only one additional permission,
+`playlist-read-private`, so DJ Support can inspect a private Provisional
+Playlist reliably during Approval. Sign in again when prompted; denying that
+permission leaves private-playlist inspection unavailable and DJ Support will
+not broaden permissions automatically.
+
+Existing publication schema versions 1–4 and Transfer schema version 1 remain
+readable. The next durable write upgrades them to publication schema 5 and
+Transfer schema 2, retaining account ownership, resumable work, ordered chunk
+evidence, Mirrors, and Approval history. Create a local-data backup before the
+first 0.5.0 publication.
+
+If retained state uses a previous Spotify profile identity, apply the explicit
+backup-first migration with the old and stable account identities supplied by
+your Spotify account details:
+
+```bash
+djsupport migrate-0-5 --legacy-account-id <old> --account-id <stable>
+```
+
+The command verifies its backup, stops on conflicting ownership, reports only
+aggregate counts, and is safe to repeat.
+
 ### Upgrading from 0.3.0
 
 Install 0.4.0, keep the old working directory intact, and use the explicit
@@ -286,7 +311,7 @@ default durable Transfer data is stored under the platform data directory
 Rekordbox XML path remains in the local configuration file created by
 `djsupport library set`.
 
-See [the 0.4.0 release notes](docs/release-notes-0.4.0.md) for the complete
+See [the 0.5.0 release notes](docs/release-notes-0.5.0.md) for the complete
 upgrade summary and known limitations.
 
 ### Playlist naming

--- a/agent.md
+++ b/agent.md
@@ -65,6 +65,7 @@ djsupport restore <archive>     # Validate and preview an archive
 djsupport restore <archive> --apply  # Apply a conflict-free restore
 djsupport migrate-0-3 <directory>    # Preview 0.3.0 local-data migration
 djsupport migrate-0-3 <directory> --apply  # Back up, verify, and apply migration
+djsupport migrate-0-5 --legacy-account-id <old> --account-id <stable>  # Back up and migrate retained account ownership
 
 # Rekordbox Transfer flags
 djsupport sync --playlist "My Playlist"  # Select a playlist (repeat for a Batch)
@@ -129,7 +130,7 @@ pytest --cov=djsupport     # Run with coverage
   credentials, local paths, and playlist state stay in private application
   storage. Repository matcher tests are synthetic unless a user explicitly
   exports and consents to a privacy-reviewed contribution.
-- Version tracked in `pyproject.toml` (`version = "0.4.0"`)
+- Version tracked in `pyproject.toml` (`version = "0.5.0"`)
 - Changelog follows Keep a Changelog format in `CHANGELOG.md`
 - `docs/` contains canonical guidance, core implementation history, and solutions;
   generated reports and out-of-scope product plans do not belong in Git

--- a/djsupport/backup.py
+++ b/djsupport/backup.py
@@ -18,11 +18,12 @@ from typing import Callable
 BACKUP_VERSION = 1
 SUPPORTED_SCHEMAS = {
     "matching-knowledge.json": (1,),
-    "transfers.json": (1,),
-    "publication-manifests.transfers.json": (1,),
-    "publication-manifests.json": (1, 2, 3, 4),
+    "transfers.json": (1, 2),
+    "publication-manifests.transfers.json": (1, 2),
+    "publication-manifests.json": (1, 2, 3, 4, 5),
     "playlist-state.json": (1, 2),
     "legacy-migration.json": (1,),
+    "foundation-migration.json": (1,),
 }
 DATA_FILES = tuple(SUPPORTED_SCHEMAS)
 SECRET_KEYS = {

--- a/djsupport/beatport.py
+++ b/djsupport/beatport.py
@@ -11,7 +11,7 @@ BEATPORT_CHART_URL_PREFIX = "beatport.com/chart/"
 BEATPORT_CHART_PATTERN = re.compile(
     r"^https://(www\.)?beatport\.com/chart/[\w-]+/\d+/?$"
 )
-USER_AGENT = "Mozilla/5.0 (compatible; djsupport/0.4.0)"
+USER_AGENT = "Mozilla/5.0 (compatible; djsupport/0.5.0)"
 REQUEST_TIMEOUT = (5, 30)  # (connect, read) seconds
 MAX_RESPONSE_SIZE = 5 * 1024 * 1024  # 5 MB
 
@@ -27,7 +27,7 @@ class InvalidBeatportURL(ValueError):
 def compose_chart_playlist_name(chart_name: str, curator: str | None) -> str:
     """Compose playlist name from chart name and curator."""
     if curator and curator != "Unknown":
-        return f"{curator} - {chart_name}"
+        return f"{chart_name} — {curator}"
     return chart_name
 
 

--- a/djsupport/cli.py
+++ b/djsupport/cli.py
@@ -191,6 +191,29 @@ def migrate_0_3(legacy_directory: str, apply: bool) -> None:
     click.echo("Migration completed; legacy files were left unchanged.")
 
 
+@cli.command("migrate-0-5")
+@click.option("--legacy-account-id", required=True)
+@click.option("--account-id", required=True)
+def migrate_0_5(legacy_account_id: str, account_id: str) -> None:
+    """Back up and migrate retained state to stable Spotify account identity."""
+    from djsupport.backup import default_app_data_path
+    from djsupport.migration import FoundationMigration
+
+    try:
+        result = FoundationMigration(default_app_data_path()).apply(
+            legacy_account_id, account_id,
+        )
+    except ValueError as exc:
+        raise click.ClickException(str(exc)) from exc
+    if result.applied:
+        click.echo(
+            "Foundation migration completed after verified backup. "
+            f"Updated records: {result.changed_records}"
+        )
+    else:
+        click.echo("Foundation migration already applied; no changes made.")
+
+
 @cli.command()
 @click.argument("xml_path", required=False, type=click.Path(exists=True, dir_okay=False))
 @click.option(

--- a/djsupport/migration.py
+++ b/djsupport/migration.py
@@ -25,7 +25,7 @@ LEGACY_STATE_FILES = (
 )
 MIGRATION_VERSION = 1
 MATCHING_KNOWLEDGE_VERSION = 1
-SUPPORTED_PUBLICATION_VERSIONS = (1, 2, 3, 4)
+SUPPORTED_PUBLICATION_VERSIONS = (1, 2, 3, 4, 5)
 SPOTIFY_TRACK_URI = re.compile(r"^spotify:track:[A-Za-z0-9]{22}$")
 CACHE_FIELDS = {
     "spotify_uri", "spotify_name", "spotify_artist", "score", "matched",
@@ -408,3 +408,105 @@ class LegacyMigration:
                     else:
                         target.unlink(missing_ok=True)
                 raise
+
+
+@dataclass(frozen=True)
+class FoundationMigrationResult:
+    applied: bool
+    changed_records: int
+    backup_created: bool
+
+
+class FoundationMigration:
+    """Backup-first, repeatable migration to stable Spotify account identity."""
+
+    FILES = ("publication-manifests.json", "transfers.json",
+             "publication-manifests.transfers.json")
+
+    def __init__(self, app_data: str | Path) -> None:
+        self.app_data = Path(app_data)
+
+    def apply(
+        self, legacy_account_id: str, account_id: str,
+    ) -> FoundationMigrationResult:
+        if not legacy_account_id or not account_id:
+            raise ValueError("Both legacy and stable account identities are required")
+        marker = self.app_data / "foundation-migration.json"
+        if marker.exists():
+            value = json.loads(marker.read_text())
+            if value == {"version": 1, "account_id": account_id}:
+                return FoundationMigrationResult(False, 0, False)
+            raise ValueError("A different Spotify account migration is already retained")
+
+        planned: dict[Path, bytes] = {}
+        changed = 0
+        for name in self.FILES:
+            path = self.app_data / name
+            if not path.exists():
+                continue
+            value = json.loads(path.read_text())
+            migrated, count = self._replace_account_ids(
+                value, legacy_account_id, account_id,
+            )
+            changed += count
+            if count:
+                planned[path] = json.dumps(migrated, indent=2).encode()
+
+        self.app_data.mkdir(parents=True, exist_ok=True)
+        backup_dir = self.app_data / "backups"
+        archive = LocalDataBackup(self.app_data).create(backup_dir)
+        if not LocalDataBackup(self.app_data).preview(archive).valid:
+            raise ValueError("Foundation migration backup verification failed")
+        planned[marker] = json.dumps(
+            {"version": 1, "account_id": account_id}, indent=2,
+        ).encode()
+        self._atomic_commit(planned)
+        return FoundationMigrationResult(True, changed, True)
+
+    @classmethod
+    def _replace_account_ids(
+        cls, value, legacy_account_id: str, account_id: str,
+    ):
+        changed = 0
+        if isinstance(value, list):
+            result = []
+            for item in value:
+                migrated, count = cls._replace_account_ids(
+                    item, legacy_account_id, account_id,
+                )
+                result.append(migrated)
+                changed += count
+            return result, changed
+        if not isinstance(value, dict):
+            return value, 0
+        result = dict(value)
+        retained = result.get("account_id")
+        legacy = result.get("spotify_user_id")
+        if retained not in (None, legacy_account_id, account_id):
+            raise ValueError("Current account ownership conflicts with migration")
+        if legacy not in (None, legacy_account_id, account_id):
+            raise ValueError("Legacy account ownership conflicts with migration")
+        result.pop("spotify_user_id", None)
+        if retained == legacy_account_id or legacy == legacy_account_id:
+            result["account_id"] = account_id
+            changed += 1
+        for key, item in list(result.items()):
+            migrated, count = cls._replace_account_ids(
+                item, legacy_account_id, account_id,
+            )
+            result[key] = migrated
+            changed += count
+        return result, changed
+
+    def _atomic_commit(self, writes: dict[Path, bytes]) -> None:
+        staged: list[tuple[Path, Path]] = []
+        try:
+            for target, content in writes.items():
+                temporary = target.with_suffix(f"{target.suffix}.migration.tmp")
+                temporary.write_bytes(content)
+                staged.append((temporary, target))
+            for temporary, target in staged:
+                os.replace(temporary, target)
+        finally:
+            for temporary, _ in staged:
+                temporary.unlink(missing_ok=True)

--- a/djsupport/spotify.py
+++ b/djsupport/spotify.py
@@ -9,7 +9,7 @@ from typing import Any
 import spotipy
 from spotipy.oauth2 import SpotifyOAuth
 
-SCOPES = "playlist-modify-public playlist-modify-private"
+SCOPES = "playlist-read-private playlist-modify-public playlist-modify-private"
 
 MAX_RATE_LIMIT_WAIT = 60  # seconds — abort if Spotify asks us to wait longer
 
@@ -30,6 +30,21 @@ class RateLimitError(Exception):
         super().__init__(
             f"Spotify rate limit exceeded. Retry after {wait_str}. "
             f"Aborting — resume later to continue where you left off."
+        )
+
+
+class QuotaExceededError(Exception):
+    """Spotify account quota is exhausted; retrying cannot make progress."""
+
+
+class SpotifyCapabilityError(Exception):
+    """A required Spotify permission or account capability is unavailable."""
+
+    def __init__(self, capability: str):
+        self.capability = capability
+        super().__init__(
+            f"Spotify capability unavailable: {capability}. Re-consent with "
+            "playlist-read-private; DJ Support will not broaden permissions."
         )
 
 
@@ -62,6 +77,10 @@ def _api_call_with_rate_limit(func: Callable[..., Any], *args: Any, **kwargs: An
         return func(*args, **kwargs)
     except spotipy.SpotifyException as e:
         if e.http_status == 429:
+            if "QUOTA_EXCEEDED" in str(e).upper():
+                raise QuotaExceededError(
+                    "Spotify quota exhausted; Transfer checkpointed and paused"
+                ) from e
             retry_after = _parse_retry_after(e)
             if retry_after <= MAX_RATE_LIMIT_WAIT:
                 time.sleep(retry_after)
@@ -72,6 +91,8 @@ def _api_call_with_rate_limit(func: Callable[..., Any], *args: Any, **kwargs: An
                         raise RateLimitError(_parse_retry_after(e2)) from e2
                     raise
             raise RateLimitError(retry_after) from e
+        if e.http_status == 403:
+            raise SpotifyCapabilityError("playlist-read-private") from e
         raise
 
 

--- a/djsupport/transfer.py
+++ b/djsupport/transfer.py
@@ -17,7 +17,7 @@ import tempfile
 import time
 from collections import Counter
 from contextlib import contextmanager
-from dataclasses import asdict, dataclass, replace
+from dataclasses import asdict, dataclass, field, replace
 from datetime import datetime
 from enum import Enum
 from pathlib import Path
@@ -47,11 +47,17 @@ from djsupport.report import (
     UnmatchedAlternatives,
     UnavailableApprovedMatch,
 )
-from djsupport.spotify import MAX_RATE_LIMIT_WAIT, RateLimitError, _parse_retry_after
+from djsupport.spotify import (
+    MAX_RATE_LIMIT_WAIT,
+    QuotaExceededError,
+    RateLimitError,
+    SpotifyCapabilityError,
+    _parse_retry_after,
+)
 
 
-PUBLICATION_MANIFEST_VERSION = 4
-TRANSFER_STATE_VERSION = 1
+PUBLICATION_MANIFEST_VERSION = 5
+TRANSFER_STATE_VERSION = 2
 EXPENSIVE_BATCH_LOOKUP_THRESHOLD = 100
 SPOTIFY_TRACK_URI = re.compile(r"^spotify:track:([A-Za-z0-9]{22})$")
 SPOTIFY_TRACK_URL = re.compile(
@@ -254,6 +260,42 @@ class ApprovalStatus(str, Enum):
     NEEDS_REVIEW = "needs review"
 
 
+class SpotifyItemKind(str, Enum):
+    """Explicit classification of one ordered Spotify playlist occurrence."""
+
+    TRACK = "track"
+    NULL = "null"
+    LOCAL = "local"
+    EPISODE = "episode"
+    UNSUPPORTED = "unsupported"
+
+
+@dataclass(frozen=True)
+class SpotifyPlaylistHead:
+    snapshot_id: str
+
+
+@dataclass(frozen=True)
+class SpotifyPlaylistItem:
+    position: int
+    kind: SpotifyItemKind
+    uri: str | None
+    is_local: bool = False
+    is_playable: bool | None = None
+    restrictions: dict | None = None
+    linked_from_uri: str | None = None
+
+
+@dataclass(frozen=True)
+class SpotifyPlaylistPage:
+    items: tuple[SpotifyPlaylistItem, ...]
+
+
+@dataclass(frozen=True)
+class SpotifyMutationResult:
+    snapshot_id: str
+
+
 @dataclass(frozen=True)
 class RetryPolicy:
     """Bound retries for transient Spotify failures and short rate limits."""
@@ -271,6 +313,11 @@ class RetryPolicy:
                 retryable_error: Exception = exc
                 status = exc.http_status
                 if status == 429:
+                    if "QUOTA_EXCEEDED" in str(exc).upper():
+                        raise QuotaExceededError(
+                            "Spotify quota exhausted; Transfer checkpointed "
+                            "and paused"
+                        ) from exc
                     delay = _parse_retry_after(exc)
                     if delay > self.max_rate_limit_wait:
                         raise RateLimitError(delay) from exc
@@ -289,6 +336,14 @@ class RetryPolicy:
 
 class PublishingTransferConflict(RuntimeError):
     """Raised when another publishing Transfer owns an account guard."""
+
+
+class SpotifyPlaylistChanged(RuntimeError):
+    """Spotify's playlist head no longer matches retained Transfer evidence."""
+
+
+class SpotifyPlaylistReviewRequired(RuntimeError):
+    """Approval encountered playlist facts requiring an explicit user decision."""
 
 
 class SourceNotFound(ValueError):
@@ -362,11 +417,14 @@ class TransferState:
     spotify_playlist_name: str | None = None
     publication_manifest: dict | None = None
     outcome: str | None = None
+    mutation_snapshots: list[str] = field(default_factory=list)
+    completed_chunks: list[str] = field(default_factory=list)
 
     @classmethod
     def from_dict(cls, value: dict) -> TransferState:
         return cls(**{
-            "alternatives": [], **value,
+            "alternatives": [], "mutation_snapshots": [],
+            "completed_chunks": [], **value,
             "status": TransferStatus(value["status"]),
         })
 
@@ -378,6 +436,8 @@ class SourceSelection:
     name: str
     reference: str
     tracks: list[Track]
+    chart_title: str | None = None
+    curator: str | None = None
 
 
 @dataclass(frozen=True)
@@ -410,6 +470,8 @@ class PublicationManifest:
     items: tuple[PublicationItem, ...]
     mode: TransferMode = TransferMode.SNAPSHOT
     managed_items: tuple[PublicationItem, ...] = ()
+    chart_title: str | None = None
+    curator: str | None = None
 
 
 @dataclass(frozen=True)
@@ -477,6 +539,10 @@ class SpotifyAdapter(Protocol):
         self, playlist_id: str, track_uris: list[str],
     ) -> None: ...
 
+    def set_playlist_description(
+        self, playlist_id: str, description: str,
+    ) -> None: ...
+
     def spotify_track(self, uri: str) -> dict: ...
 
 
@@ -524,7 +590,7 @@ class FilePublicationStorage:
             data = json.loads(self.path.read_text())
         except (json.JSONDecodeError, OSError):
             return
-        if data.get("version") not in (1, 2, 3, PUBLICATION_MANIFEST_VERSION):
+        if data.get("version") not in (1, 2, 3, 4, PUBLICATION_MANIFEST_VERSION):
             return
         self.manifests = data.get("manifests", [])
         self.approvals = data.get("approvals", data.get("reviews", []))
@@ -712,7 +778,7 @@ class FileTransferStorage:
             data = json.loads(self.path.read_text())
         except (json.JSONDecodeError, OSError):
             return
-        if data.get("version") == TRANSFER_STATE_VERSION:
+        if data.get("version") in (1, TRANSFER_STATE_VERSION):
             for transfer_id, state in data.get("transfers", {}).items():
                 try:
                     self.transfers[transfer_id] = TransferState.from_dict(state)
@@ -796,6 +862,8 @@ class BeatportChartSource:
             name=compose_chart_playlist_name(chart_name, curator),
             reference=url,
             tracks=tracks,
+            chart_title=chart_name,
+            curator=curator if curator != "Unknown" else None,
         )
 
 
@@ -908,7 +976,85 @@ class SpotifyMatcher:
         self._client = client
 
     def account_id(self) -> str:
-        return self._client.current_user()["id"]
+        profile = self._client.current_user()
+        return profile.get("account_id") or profile["id"]
+
+    def create_playlist(self, name: str, description: str) -> str:
+        playlist = self._client.current_user_playlist_create(
+            name, public=False, description=description,
+        )
+        return playlist["id"]
+
+    def find_recovery_playlist(self, publication_key: str) -> str | None:
+        return self._find_publication(f"djsupport-transfer:{publication_key}")
+
+    def playlist_head(self, playlist_id: str) -> SpotifyPlaylistHead:
+        try:
+            playlist = self._client.playlist(playlist_id, fields="snapshot_id")
+        except spotipy.SpotifyException as exc:
+            if exc.http_status == 403:
+                raise SpotifyCapabilityError("playlist-read-private") from exc
+            raise
+        return SpotifyPlaylistHead(snapshot_id=playlist["snapshot_id"])
+
+    def ordered_playlist_items(self, playlist_id: str) -> SpotifyPlaylistPage:
+        try:
+            page = self._client.playlist_items(playlist_id)
+        except spotipy.SpotifyException as exc:
+            if exc.http_status == 403:
+                raise SpotifyCapabilityError("playlist-read-private") from exc
+            raise
+        items: list[SpotifyPlaylistItem] = []
+        position = 0
+        while page:
+            for wrapper in page.get("items", []):
+                value = wrapper.get("track") or wrapper.get("item")
+                if value is None:
+                    kind = SpotifyItemKind.NULL
+                elif value.get("is_local"):
+                    kind = SpotifyItemKind.LOCAL
+                elif value.get("type") == "track":
+                    kind = SpotifyItemKind.TRACK
+                elif value.get("type") == "episode":
+                    kind = SpotifyItemKind.EPISODE
+                else:
+                    kind = SpotifyItemKind.UNSUPPORTED
+                items.append(SpotifyPlaylistItem(
+                    position=position,
+                    kind=kind,
+                    uri=value.get("uri") if value else None,
+                    is_local=bool(value and value.get("is_local")),
+                    is_playable=value.get("is_playable") if value else None,
+                    restrictions=value.get("restrictions") if value else None,
+                    linked_from_uri=(
+                        (value.get("linked_from") or {}).get("uri")
+                        if value else None
+                    ),
+                ))
+                position += 1
+            if not page.get("next"):
+                break
+            try:
+                page = self._client.next(page)
+            except spotipy.SpotifyException as exc:
+                if exc.http_status == 403:
+                    raise SpotifyCapabilityError(
+                        "playlist-read-private"
+                    ) from exc
+                raise
+        return SpotifyPlaylistPage(tuple(items))
+
+    def replace_items(
+        self, playlist_id: str, uris: list[str],
+    ) -> SpotifyMutationResult:
+        result = self._client.playlist_replace_items(playlist_id, uris)
+        return SpotifyMutationResult(result["snapshot_id"])
+
+    def add_items(
+        self, playlist_id: str, uris: list[str],
+    ) -> SpotifyMutationResult:
+        result = self._client.playlist_add_items(playlist_id, uris)
+        return SpotifyMutationResult(result["snapshot_id"])
 
     def match(self, track: Track, threshold: int) -> dict | None:
         return match_track_with_alternatives(
@@ -926,10 +1072,7 @@ class SpotifyMatcher:
         description = f"{description} {marker}"
         playlist_id = self._find_publication(marker)
         if playlist_id is None:
-            playlist = self._client.user_playlist_create(
-                self.account_id(), name, public=False, description=description,
-            )
-            playlist_id = playlist["id"]
+            playlist_id = self.create_playlist(name, description)
         try:
             if track_uris:
                 self._client.playlist_replace_items(playlist_id, track_uris[:100])
@@ -987,6 +1130,13 @@ class SpotifyMatcher:
             self._client.playlist_add_items(
                 playlist_id, track_uris[offset:offset + 100],
             )
+
+    def set_playlist_description(
+        self, playlist_id: str, description: str,
+    ) -> None:
+        self._client.playlist_change_details(
+            playlist_id, description=description,
+        )
 
     def spotify_track(self, uri: str) -> dict:
         track = self._client.track(uri)
@@ -1526,9 +1676,54 @@ class Transfer:
             )
         with self._publishing_guards.acquire(account_id):
             corrected_items = self._read_corrections(corrections, manifest)
-            current_uris = self._retry_policy.run(
-                lambda: self._spotify.provisional_playlist_track_uris(playlist_id)
-            )
+            if all(hasattr(self._spotify, method) for method in (
+                "playlist_head", "ordered_playlist_items",
+            )):
+                try:
+                    before = self._retry_policy.run(
+                        lambda: self._spotify.playlist_head(playlist_id)
+                    )
+                    ordered = self._retry_policy.run(
+                        lambda: self._spotify.ordered_playlist_items(playlist_id)
+                    )
+                    after = self._retry_policy.run(
+                        lambda: self._spotify.playlist_head(playlist_id)
+                    )
+                    if before.snapshot_id != after.snapshot_id:
+                        raise SpotifyPlaylistChanged(
+                            "Spotify playlist changed during Approval; "
+                            "re-review required"
+                        )
+                    review_required = [
+                        item for item in ordered.items
+                        if item.kind != SpotifyItemKind.TRACK
+                        or item.is_playable is False
+                        or item.restrictions is not None
+                        or item.linked_from_uri is not None
+                    ]
+                    if review_required:
+                        positions = ", ".join(
+                            str(item.position) for item in review_required
+                        )
+                        raise SpotifyPlaylistReviewRequired(
+                            "Spotify playlist contains unavailable, local, "
+                            "episode, unsupported, restricted, or relinked "
+                            f"items at positions {positions}; explicit review required"
+                        )
+                    current_uris = [
+                        item.uri for item in ordered.items
+                        if item.kind == SpotifyItemKind.TRACK and item.uri
+                    ]
+                except spotipy.SpotifyException as exc:
+                    if exc.http_status != 404:
+                        raise
+                    current_uris = None
+            else:
+                current_uris = self._retry_policy.run(
+                    lambda: self._spotify.provisional_playlist_track_uris(
+                        playlist_id
+                    )
+                )
             if current_uris is None:
                 outcome = ApprovalOutcome(
                     account_id=account_id,
@@ -1633,8 +1828,30 @@ class Transfer:
                         spotify_playlist_name=manifest.spotify_playlist_name,
                         approved_at=outcome.reviewed_at,
                     ))
+                if (
+                    outcome.status == ApprovalStatus.APPROVED
+                    and hasattr(self._spotify, "set_playlist_description")
+                ):
+                    self._retry_policy.run(
+                        lambda: self._spotify.set_playlist_description(
+                            playlist_id, self._approved_description(manifest),
+                        )
+                    )
             self._publication_storage.retain_approval(outcome)
             return outcome
+
+    @staticmethod
+    def _approved_description(manifest: PublicationManifest) -> str:
+        relationship = (
+            "managed Mirror relationship" if manifest.mode == TransferMode.MIRROR
+            else "approved Snapshot provenance"
+        )
+        chart = manifest.chart_title or manifest.source_label
+        curator = f" by {manifest.curator}" if manifest.curator else ""
+        return (
+            f"{chart}{curator}; {relationship}. Source: "
+            f"{manifest.source_reference}"
+        )
 
     def _read_corrections(
         self, corrections: str | Path | None, manifest: PublicationManifest,
@@ -1902,6 +2119,8 @@ class Transfer:
                     "name": selection.name,
                     "reference": selection.reference,
                     "tracks": [asdict(track) for track in selection.tracks],
+                    "chart_title": selection.chart_title,
+                    "curator": selection.curator,
                 },
                 created_at=created_at.isoformat(),
                 next_track_index=0,
@@ -1945,6 +2164,8 @@ class Transfer:
             selection = SourceSelection(
                 stored_selection["name"], stored_selection["reference"],
                 [Track(**track) for track in stored_selection["tracks"]],
+                chart_title=stored_selection.get("chart_title"),
+                curator=stored_selection.get("curator"),
             )
             created_at = datetime.fromisoformat(state.created_at)
 
@@ -2301,32 +2522,46 @@ class Transfer:
                         snapshot_name = f"{selection.name} — {discriminator}"
                     if request.playlist_prefix:
                         snapshot_name = f"{request.playlist_prefix} / {snapshot_name}"
-                    description = (
-                        f"Provisional {request.mode.value.title()} from "
-                        f"{self._source.source_label}: "
-                        f"{selection.reference}. Created {created_at.isoformat()}."
+                    description = self._provisional_description(
+                        request.mode, selection,
                     )
                     publication_key = transfer_id
                     if request.mode == TransferMode.MIRROR:
                         publication_key = hashlib.sha256(
                             f"{state.account_id}\0{selection.reference}".encode()
                         ).hexdigest()
-                    playlist_id = self._retry_policy.run(
-                        lambda: self._spotify.publish_provisional_snapshot(
-                            snapshot_name,
-                            list(dict.fromkeys(
-                                item.spotify_uri for item in publication_items
-                                if item.spotify_uri
-                                and item.spotify_uri not in collision_uris
-                            )),
-                            description,
-                            publication_key,
+                    publish_uris = [
+                        item.spotify_uri for item in publication_items
+                        if item.spotify_uri
+                        and item.spotify_uri not in collision_uris
+                    ]
+                    if all(hasattr(self._spotify, method) for method in (
+                        "create_playlist", "find_recovery_playlist",
+                        "replace_items", "add_items", "playlist_head",
+                    )):
+                        playlist_id = self._publish_checkpointed(
+                            transfer_id, state, snapshot_name, description,
+                            publication_key, publish_uris,
                         )
-                    )
+                    else:
+                        playlist_id = self._retry_policy.run(
+                            lambda: self._spotify.publish_provisional_snapshot(
+                                snapshot_name, publish_uris, description,
+                                publication_key,
+                            )
+                        )
                     state.spotify_playlist_id = playlist_id
                     state.spotify_playlist_name = snapshot_name
                     state.status = TransferStatus.RETAINING_PUBLICATION
                     self._save_transfer(transfer_id, state)
+                    # The recovery key is permitted only until the returned ID
+                    # has crossed the durable local checkpoint above.
+                    if hasattr(self._spotify, "set_playlist_description"):
+                        self._retry_policy.run(
+                            lambda: self._spotify.set_playlist_description(
+                                playlist_id, description,
+                            )
+                        )
                     if self._pause_requested:
                         self._pause_requested = False
                         state.status = TransferStatus.PAUSED
@@ -2347,11 +2582,35 @@ class Transfer:
                             )),
                         )
                     )
+                elif (
+                    state.publication_manifest is None
+                    and all(hasattr(self._spotify, method) for method in (
+                        "create_playlist", "find_recovery_playlist",
+                        "replace_items", "add_items", "playlist_head",
+                    ))
+                ):
+                    description = self._provisional_description(
+                        request.mode, selection,
+                    )
+                    publication_key = transfer_id
+                    if request.mode == TransferMode.MIRROR:
+                        publication_key = hashlib.sha256(
+                            f"{state.account_id}\0{selection.reference}".encode()
+                        ).hexdigest()
+                    publish_uris = [
+                        item.spotify_uri for item in publication_items
+                        if item.spotify_uri
+                        and item.spotify_uri not in collision_uris
+                    ]
+                    playlist_id = self._publish_checkpointed(
+                        transfer_id, state, snapshot_name, description,
+                        publication_key, publish_uris,
+                    )
                 assert snapshot_name is not None
-                managed_items_by_uri: dict[str, PublicationItem] = {}
-                for item in publication_items:
-                    if item.spotify_uri and item.spotify_uri not in collision_uris:
-                        managed_items_by_uri.setdefault(item.spotify_uri, item)
+                managed_items = tuple(
+                    item for item in publication_items
+                    if item.spotify_uri and item.spotify_uri not in collision_uris
+                )
                 manifest = PublicationManifest(
                     account_id=state.account_id,
                     spotify_playlist_id=playlist_id,
@@ -2364,7 +2623,9 @@ class Transfer:
                         if not item.authoritative
                     ),
                     mode=request.mode,
-                    managed_items=tuple(managed_items_by_uri.values()),
+                    managed_items=managed_items,
+                    chart_title=selection.chart_title,
+                    curator=selection.curator,
                 )
                 stored_manifest = asdict(manifest)
                 stored_manifest["created_at"] = manifest.created_at.isoformat()
@@ -2391,6 +2652,11 @@ class Transfer:
                     else:
                         self._publication_storage.retain_publication(manifest)
                 except Exception:
+                    if state.completed_chunks:
+                        # Remote mutation evidence and playlist identity are
+                        # authoritative recovery facts. Keep them intact so a
+                        # resume retries only local manifest retention.
+                        raise
                     if created_playlist:
                         self._spotify.delete_provisional_snapshot(playlist_id)
                     elif relink_original_uris is not None:
@@ -2420,7 +2686,10 @@ class Transfer:
             state.status = TransferStatus.COMPLETED
             self._save_transfer(transfer_id, state)
             report.status = "completed"
-        except (RateLimitError, requests.Timeout, requests.ConnectionError) as exc:
+        except (
+            QuotaExceededError, RateLimitError, requests.Timeout,
+            requests.ConnectionError,
+        ) as exc:
             state.status = TransferStatus.PAUSED
             state.outcome = str(exc)
             self._save_transfer(transfer_id, state)
@@ -2450,6 +2719,87 @@ class Transfer:
             self._knowledge.checkpoint()
 
         return report
+
+    def _publish_checkpointed(
+        self,
+        transfer_id: str,
+        state: TransferState,
+        name: str,
+        description: str,
+        publication_key: str,
+        uris: list[str],
+    ) -> str:
+        """Publish ordered chunks with durable mutation evidence.
+
+        Spotify has no atomic multi-chunk replace. An edit may still land
+        between the fresh head read and the next write; every observable head
+        mismatch stops publication for explicit review.
+        """
+        playlist_id = state.spotify_playlist_id
+        if playlist_id is None:
+            playlist_id = self._retry_policy.run(
+                lambda: self._spotify.find_recovery_playlist(publication_key)
+            )
+        if playlist_id is None:
+            marker = f"djsupport-transfer:{publication_key}"
+            playlist_id = self._retry_policy.run(
+                lambda: self._spotify.create_playlist(
+                    name, f"{description} {marker}",
+                )
+            )
+        state.spotify_playlist_id = playlist_id
+        state.spotify_playlist_name = name
+        state.status = TransferStatus.RETAINING_PUBLICATION
+        self._save_transfer(transfer_id, state)
+        if hasattr(self._spotify, "set_playlist_description"):
+            self._retry_policy.run(
+                lambda: self._spotify.set_playlist_description(
+                    playlist_id, description,
+                )
+            )
+
+        chunks = [uris[:100]] + [
+            uris[offset:offset + 100] for offset in range(100, len(uris), 100)
+        ]
+        for index, chunk in enumerate(chunks):
+            chunk_id = hashlib.sha256(
+                json.dumps([index, chunk], separators=(",", ":")).encode()
+            ).hexdigest()
+            if chunk_id in state.completed_chunks:
+                continue
+            if state.mutation_snapshots:
+                current = self._retry_policy.run(
+                    lambda: self._spotify.playlist_head(playlist_id)
+                )
+                if current.snapshot_id != state.mutation_snapshots[-1]:
+                    raise SpotifyPlaylistChanged(
+                        "Spotify playlist changed during publication; "
+                        "publication paused for explicit review"
+                    )
+            result = self._retry_policy.run(
+                lambda: (
+                    self._spotify.replace_items(playlist_id, chunk)
+                    if index == 0 else self._spotify.add_items(playlist_id, chunk)
+                )
+            )
+            state.mutation_snapshots.append(result.snapshot_id)
+            state.completed_chunks.append(chunk_id)
+            self._save_transfer(transfer_id, state)
+        return playlist_id
+
+    def _provisional_description(
+        self, mode: TransferMode, selection: SourceSelection,
+    ) -> str:
+        if self._source.source_label == "Beatport":
+            curator = f" by {selection.curator}" if selection.curator else ""
+            return (
+                f"Provisional Beatport chart{curator}; awaiting review and "
+                f"Approval as a {mode.value.title()}. Source: {selection.reference}"
+            )
+        return (
+            f"Provisional {mode.value.title()} from {self._source.source_label}; "
+            f"awaiting review and Approval. Source: {selection.reference}"
+        )
 
     def _save_transfer(self, transfer_id: str, state: TransferState) -> None:
         if self._transfer_storage is not None:

--- a/docs/release-notes-0.5.0.md
+++ b/docs/release-notes-0.5.0.md
@@ -1,0 +1,36 @@
+# DJ Support 0.5.0 — Trustworthy Spotify Foundation
+
+DJ Support 0.5.0 updates the Spotify boundary while keeping `Transfer` as the
+sole publication and Approval authority.
+
+Spotify sign-in now asks for `playlist-read-private` alongside the existing
+public/private playlist modification permissions. This is required to inspect
+private Provisional Playlists; DJ Support does not request collaborative,
+library, playback, image, or other permissions.
+
+Approval reads a playlist head, every ordered item page, and the head again. A
+changed head stops Approval without retaining Approved Matches. Ordered facts
+preserve duplicate occurrences and classify null, local, episode, unsupported,
+restricted, unavailable, and relinked shapes rather than silently dropping
+them.
+
+Publication replaces the first 100 items and adds later chunks in order. Every
+returned mutation snapshot and completed chunk identity is retained before the
+next operation, and an unexpected head pauses the Transfer. Spotify provides no
+atomic multi-chunk mutation, so an external edit can still occur between a
+fresh head check and the following write; 0.5.0 does not claim otherwise.
+
+A recovery marker exists only during the narrow playlist-create checkpoint.
+After the Spotify playlist ID is durable, the marker is replaced by clean
+provisional copy. Approval applies durable Snapshot or managed Mirror copy.
+Beatport chart title, curator, and source URL survive Preview, resume,
+publication, and Approval.
+
+Private publication data now writes schema 5 and durable Transfer data writes
+schema 2. Older supported schemas remain readable and backup-compatible. Back
+up local data before the first publication after upgrading.
+
+The default test suite is offline and synthetic. The separately gated live
+Spotify smoke test still requires explicit authorization, an allowlisted owner
+account, a disposable private playlist, and a fixed request budget; it is not
+run automatically.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ djsupport = ["static/*.html", "static/*.png"]
 
 [project]
 name = "djsupport"
-version = "0.4.0"
+version = "0.5.0"
 description = "Transfer Rekordbox and Beatport selections to Spotify"
 readme = "README.md"
 license = "MIT"

--- a/tests/test_beatport.py
+++ b/tests/test_beatport.py
@@ -19,8 +19,12 @@ from djsupport.rekordbox import Track
 
 
 class TestComposeChartPlaylistName:
+    def test_chart_title_precedes_curator_for_provenance(self):
+        assert compose_chart_playlist_name("Synthetic Chart", "Ada DJ") == (
+            "Synthetic Chart — Ada DJ"
+        )
     def test_with_curator(self):
-        assert compose_chart_playlist_name("Tech House Vibes", "Adam Beyer") == "Adam Beyer - Tech House Vibes"
+        assert compose_chart_playlist_name("Tech House Vibes", "Adam Beyer") == "Tech House Vibes — Adam Beyer"
 
     def test_unknown_curator(self):
         assert compose_chart_playlist_name("Vibes", "Unknown") == "Vibes"

--- a/tests/test_migration.py
+++ b/tests/test_migration.py
@@ -8,7 +8,7 @@ from click.testing import CliRunner
 
 from djsupport.backup import LocalDataBackup
 from djsupport.cli import cli
-from djsupport.migration import LegacyMigration
+from djsupport.migration import FoundationMigration, LegacyMigration
 
 
 def _write_json(path, value):
@@ -435,3 +435,56 @@ class TestLegacyMigration:
         assert result.applied
         archive = next((app_data / "backups").glob("*.zip"))
         assert LocalDataBackup(app_data).preview(archive).valid
+
+
+def test_foundation_migration_is_backup_first_and_idempotent(tmp_path):
+    app_data = tmp_path / "app-data"
+    _write_json(app_data / "publication-manifests.json", {
+        "version": 4,
+        "manifests": [{"account_id": "legacy-profile", "spotify_playlist_id": "p"}],
+        "approvals": [],
+        "mirrors": [{"spotify_user_id": "legacy-profile"}],
+    })
+
+    migration = FoundationMigration(app_data)
+    first = migration.apply("legacy-profile", "stable-account")
+    second = migration.apply("legacy-profile", "stable-account")
+
+    stored = json.loads((app_data / "publication-manifests.json").read_text())
+    assert first.applied and first.backup_created and first.changed_records == 2
+    assert not second.applied and not second.backup_created
+    assert stored["manifests"][0]["account_id"] == "stable-account"
+    assert stored["mirrors"][0]["account_id"] == "stable-account"
+    archive = next((app_data / "backups").glob("*.zip"))
+    assert LocalDataBackup(app_data).preview(archive).valid
+
+
+def test_foundation_migration_stops_on_account_conflict_before_backup(tmp_path):
+    app_data = tmp_path / "app-data"
+    _write_json(app_data / "publication-manifests.json", {
+        "version": 4,
+        "manifests": [{"account_id": "another-account"}],
+        "approvals": [], "mirrors": [],
+    })
+
+    with pytest.raises(ValueError, match="ownership conflicts"):
+        FoundationMigration(app_data).apply("legacy-profile", "stable-account")
+
+    assert not (app_data / "backups").exists()
+
+
+def test_foundation_migration_preserves_conflicting_legacy_ownership(tmp_path):
+    app_data = tmp_path / "app-data"
+    original = {
+        "version": 4,
+        "manifests": [{"spotify_user_id": "another-account"}],
+        "approvals": [], "mirrors": [],
+    }
+    _write_json(app_data / "publication-manifests.json", original)
+
+    with pytest.raises(ValueError, match="Legacy account ownership conflicts"):
+        FoundationMigration(app_data).apply("legacy-profile", "stable-account")
+
+    assert json.loads(
+        (app_data / "publication-manifests.json").read_text()
+    ) == original

--- a/tests/test_spotify.py
+++ b/tests/test_spotify.py
@@ -7,9 +7,11 @@ import spotipy
 
 from djsupport.spotify import (
     RateLimitError,
+    SCOPES,
     _api_call_with_rate_limit,
     _parse_retry_after,
 )
+from djsupport.transfer import SpotifyMatcher, SpotifyItemKind
 
 
 def _make_429(retry_after: int) -> spotipy.SpotifyException:
@@ -140,3 +142,58 @@ class TestParseRetryAfter:
         exc.http_status = 429
         exc.headers = None
         assert _parse_retry_after(exc) == 1
+
+
+def test_private_playlist_read_is_the_only_new_read_scope():
+    assert set(SCOPES.split()) == {
+        "playlist-read-private",
+        "playlist-modify-public",
+        "playlist-modify-private",
+    }
+
+
+def test_spotify_adapter_uses_current_account_and_playlist_contracts():
+    client = MagicMock()
+    client.current_user.return_value = {"id": "stable-account"}
+    client.current_user_playlist_create.return_value = {"id": "playlist-1"}
+
+    adapter = SpotifyMatcher(client)
+    created = adapter.create_playlist("Name", "Description")
+
+    assert adapter.account_id() == "stable-account"
+    assert created == "playlist-1"
+    client.current_user_playlist_create.assert_called_once_with(
+        "Name", public=False, description="Description",
+    )
+    client.user_playlist_create.assert_not_called()
+
+
+def test_ordered_playlist_facts_preserve_duplicates_and_unknown_shapes():
+    client = MagicMock()
+    client.playlist.return_value = {"snapshot_id": "head-1"}
+    client.playlist_items.return_value = {
+        "items": [
+            {"track": {"type": "track", "uri": "spotify:track:one"}},
+            {"track": {"type": "track", "uri": "spotify:track:one"}},
+            {"track": None},
+            {"track": {"type": "episode", "uri": "spotify:episode:e"}},
+            {"track": {"type": "future", "uri": "spotify:future:f"}},
+        ],
+        "next": None,
+    }
+
+    adapter = SpotifyMatcher(client)
+
+    assert adapter.playlist_head("playlist-1").snapshot_id == "head-1"
+    page = adapter.ordered_playlist_items("playlist-1")
+    assert [item.position for item in page.items] == [0, 1, 2, 3, 4]
+    assert [item.kind for item in page.items] == [
+        SpotifyItemKind.TRACK,
+        SpotifyItemKind.TRACK,
+        SpotifyItemKind.NULL,
+        SpotifyItemKind.EPISODE,
+        SpotifyItemKind.UNSUPPORTED,
+    ]
+    assert [item.uri for item in page.items[:2]] == [
+        "spotify:track:one", "spotify:track:one",
+    ]

--- a/tests/test_transfer.py
+++ b/tests/test_transfer.py
@@ -19,7 +19,7 @@ from djsupport.cache import MatchCache
 from djsupport.rekordbox import Track
 from djsupport.regression import load_local_regressions
 from djsupport.report import PlaylistReport, SyncReport, save_report, save_review_csv
-from djsupport.spotify import RateLimitError
+from djsupport.spotify import QuotaExceededError, RateLimitError
 from djsupport.transfer import (
     AccountPublishingGuards,
     BatchPlan,
@@ -30,6 +30,10 @@ from djsupport.transfer import (
     PublishingTransferConflict,
     RetryPolicy,
     SpotifyMatcher,
+    SpotifyItemKind,
+    SpotifyPlaylistHead,
+    SpotifyPlaylistItem,
+    SpotifyPlaylistPage,
     SourceSelection,
     Transfer,
     TransferMode,
@@ -272,6 +276,23 @@ def _spotify_error(status, *, retry_after=None):
     return spotipy.SpotifyException(
         status, -1, "Spotify failure", headers=headers,
     )
+
+
+def test_transfer_retry_policy_distinguishes_quota_exhaustion():
+    error = spotipy.SpotifyException(
+        429, -1, "QUOTA_EXCEEDED", headers={"Retry-After": "1"},
+    )
+    calls = 0
+
+    def operation():
+        nonlocal calls
+        calls += 1
+        raise error
+
+    with pytest.raises(QuotaExceededError):
+        RetryPolicy(sleep=lambda _: None).run(operation)
+
+    assert calls == 1
 
 
 def test_preview_reuses_and_retains_matching_knowledge_without_playlist_writes():
@@ -1241,7 +1262,7 @@ class TestRekordboxMirror:
             "spotify:track:first", "spotify:track:second",
         ]
 
-    def test_refresh_deduplicates_orders_and_reports_genuine_source_removals(
+    def test_refresh_preserves_occurrences_order_and_reports_genuine_source_removals(
         self, tmp_path,
     ):
         fixture = json.loads(MIRROR_REFRESH_FIXTURE.read_text())
@@ -1289,6 +1310,7 @@ class TestRekordboxMirror:
 
         assert spotify.playlists[playlist.spotify_playlist_id]["tracks"] == [
             "spotify:track:second", "spotify:track:third",
+            "spotify:track:second",
         ]
         assert [removal.source_track_id for removal in playlist.source_removals] == [
             "rb-1"
@@ -1302,7 +1324,7 @@ class TestRekordboxMirror:
         final = transfer.execute(TransferRequest(source=fixture["reference"]))
 
         assert [removal.source_track_id for removal in final.playlists[0].source_removals] == [
-            "rb-2"
+            "rb-2", "rb-2-copy",
         ]
 
     def test_missing_rekordbox_track_stops_before_matching_or_publication(self):
@@ -1851,6 +1873,40 @@ class TestRekordboxBatchExecution:
 
 
 class TestTransferPublicationLifecycle:
+    def test_settled_playlist_copy_hides_recovery_key_and_retains_curator(self, tmp_path):
+        class LifecycleSpotify(StatefulSpotify):
+            def set_playlist_description(self, playlist_id, description):
+                self.playlists[playlist_id]["description"] = description
+
+        class ChartSource(FixtureBeatportSource):
+            def consume(self, reference):
+                selection = super().consume(reference)
+                return SourceSelection(
+                    "Synthetic Chart — Ada DJ", selection.reference, selection.tracks,
+                    chart_title="Synthetic Chart", curator="Ada DJ",
+                )
+
+        spotify = LifecycleSpotify({
+            ("Known Artist", "Known Track"): _match(
+                "spotify:track:known", "Known Track", "Known Artist",
+            ),
+        })
+        report = Transfer(
+            publishing_guards=TEST_PUBLISHING_GUARDS,
+            source=ChartSource(FIXTURE), spotify=spotify,
+            matching_knowledge=InMemoryStorage(),
+            publication_storage=InMemoryStorage(),
+            transfer_storage=FileTransferStorage(tmp_path / "transfers.json"),
+        ).execute(TransferRequest(source="fixture", transfer_id="transfer-private"))
+
+        playlist = spotify.playlists[report.playlists[0].spotify_playlist_id]
+        assert report.playlists[0].name.startswith(
+            "djsupport / Synthetic Chart — Ada DJ"
+        )
+        assert "awaiting review and Approval" in playlist["description"]
+        assert "fixture" in playlist["description"]
+        assert "transfer-private" not in playlist["description"]
+        assert "Created " not in playlist["description"]
     def test_mixed_publication_retains_one_review_entry_per_source_track(
         self, tmp_path,
     ):
@@ -2478,7 +2534,7 @@ class TestTransferPublicationLifecycle:
             approved_at=datetime(2026, 8, 1),
         ))
 
-        assert json.loads(path.read_text())["version"] == 4
+        assert json.loads(path.read_text())["version"] == 5
         assert len(FilePublicationStorage(path).mirrors_for_account(
             "spotify-user-1"
         )) == 1
@@ -2523,6 +2579,22 @@ class TestTransferPublicationLifecycle:
         assert manifest.managed_items == manifest.items
 
 class TestProvisionalPlaylistApproval:
+    def test_changed_head_discards_ordered_approval_read(self):
+        transfer, spotify, storage, playlist_id = self.publish()
+        spotify.playlist_head = MagicMock(side_effect=[
+            SpotifyPlaylistHead("before"), SpotifyPlaylistHead("after"),
+        ])
+        spotify.ordered_playlist_items = MagicMock(return_value=SpotifyPlaylistPage((
+            SpotifyPlaylistItem(
+                0, SpotifyItemKind.TRACK, "spotify:track:known",
+            ),
+        )))
+
+        with pytest.raises(Exception, match="changed during Approval"):
+            transfer.approve(playlist_id)
+
+        assert storage.approvals == []
+        assert storage.approved_matches == []
     def publish(self):
         matches = {
             ("Known Artist", "Known Track"): _match(
@@ -3095,12 +3167,12 @@ class TestSpotifyApprovalAdapter:
             "items": list(playlists), "next": None,
         }
 
-        def create_playlist(user_id, name, public, description):
+        def create_playlist(name, public, description):
             playlist = {"id": "mirror-1", "description": description}
             playlists.append(playlist)
             return playlist
 
-        client.user_playlist_create.side_effect = create_playlist
+        client.current_user_playlist_create.side_effect = create_playlist
 
         first_id = SpotifyMatcher(client).publish_provisional_snapshot(
             "Fixture Mirror", ["spotify:track:first"], "description", "stable-key",
@@ -3110,7 +3182,8 @@ class TestSpotifyApprovalAdapter:
         )
 
         assert first_id == second_id == "mirror-1"
-        assert client.user_playlist_create.call_count == 1
+        assert client.current_user_playlist_create.call_count == 1
+        client.user_playlist_create.assert_not_called()
         assert client.playlist_replace_items.call_args.args == (
             "mirror-1", ["spotify:track:second"],
         )


### PR DESCRIPTION
## Summary
- move Spotify playlist work to current account/item contracts with typed ordered facts
- checkpoint every publication chunk and guard Approval/publication with playlist heads
- add clean recovery-marker lifecycle, Beatport curator provenance, and final Snapshot/Mirror copy
- add backup-first stable-account migration, minimal private-playlist consent, and schema 5/2 compatibility
- release version 0.5.0 with offline, privacy, and packaging evidence

## Validation
- 503 offline synthetic tests passed
- 18 focused repository privacy tests passed
- Python compilation and diff/whitespace checks passed
- isolated wheel build produced djsupport-0.5.0-py3-none-any.whl
- parallel Standards and Spec reviews passed after blocking findings were resolved

## Gated evidence
The live Spotify smoke test was not run: it requires fresh explicit authorization, an allowlisted owner account, a disposable private playlist, and a fixed request budget. No live/private data was accessed.

Closes #85