### PR TITLE
Fix current-user Spotify playlist creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ Copy the example env file and fill in your credentials:
 cp .env.example .env
 ```
 
-You can obtain these values from the [Spotify Developer Dashboard](https://developer.spotify.com/dashboard) after creating an application. Make sure `http://localhost:8888/callback` is added as a Redirect URI in your app settings.
+You can obtain these values from the [Spotify Developer Dashboard](https://developer.spotify.com/dashboard) after creating an application. Make sure `http://127.0.0.1:8888/callback` is added as a Redirect URI in your app settings. Spotify does not accept `localhost` aliases; an existing app can allowlist this loopback callback alongside callbacks for other DJ Support clients.
 
 ### 2. Rekordbox XML export
 

--- a/djsupport/transfer.py
+++ b/djsupport/transfer.py
@@ -980,9 +980,11 @@ class SpotifyMatcher:
         return profile.get("account_id") or profile["id"]
 
     def create_playlist(self, name: str, description: str) -> str:
-        playlist = self._client.current_user_playlist_create(
-            name, public=False, description=description,
-        )
+        playlist = self._client._post("me/playlists", payload={
+            "name": name,
+            "public": False,
+            "description": description,
+        })
         return playlist["id"]
 
     def find_recovery_playlist(self, publication_key: str) -> str | None:

--- a/docs/release-notes-0.5.0.md
+++ b/docs/release-notes-0.5.0.md
@@ -30,7 +30,10 @@ Private publication data now writes schema 5 and durable Transfer data writes
 schema 2. Older supported schemas remain readable and backup-compatible. Back
 up local data before the first publication after upgrading.
 
-The default test suite is offline and synthetic. The separately gated live
-Spotify smoke test still requires explicit authorization, an allowlisted owner
-account, a disposable private playlist, and a fixed request budget; it is not
-run automatically.
+The default test suite is offline and synthetic. The separately authorized
+live Spotify release smoke test passed against an allowlisted owner account
+within its fixed eight-request budget. It covered identity, private playlist
+creation and discovery, head and ordered-item reads, publication mutation, and
+confirmed removal of the disposable playlist. No account, playlist, or item
+identifiers are retained in the repository. Live tests are not run
+automatically.

--- a/tests/test_spotify.py
+++ b/tests/test_spotify.py
@@ -153,19 +153,31 @@ def test_private_playlist_read_is_the_only_new_read_scope():
 
 
 def test_spotify_adapter_uses_current_account_and_playlist_contracts():
-    client = MagicMock()
-    client.current_user.return_value = {"id": "stable-account"}
-    client.current_user_playlist_create.return_value = {"id": "playlist-1"}
+    client = spotipy.Spotify(auth="synthetic-token")
+    client.current_user = MagicMock(return_value={"id": "stable-account"})
+    client._internal_call = MagicMock(return_value={"id": "playlist-1"})
 
     adapter = SpotifyMatcher(client)
     created = adapter.create_playlist("Name", "Description")
 
     assert adapter.account_id() == "stable-account"
     assert created == "playlist-1"
-    client.current_user_playlist_create.assert_called_once_with(
-        "Name", public=False, description="Description",
-    )
-    client.user_playlist_create.assert_not_called()
+    client._internal_call.assert_called_once_with("POST", "me/playlists", {
+        "name": "Name",
+        "public": False,
+        "description": "Description",
+    }, {})
+
+
+def test_spotify_playlist_creation_propagates_transport_failure():
+    client = spotipy.Spotify(auth="synthetic-token")
+    error = _make_429(60)
+    client._internal_call = MagicMock(side_effect=error)
+
+    with pytest.raises(spotipy.SpotifyException) as raised:
+        SpotifyMatcher(client).create_playlist("Name", "Description")
+
+    assert raised.value is error
 
 
 def test_ordered_playlist_facts_preserve_duplicates_and_unknown_shapes():

--- a/tests/test_transfer.py
+++ b/tests/test_transfer.py
@@ -3167,12 +3167,14 @@ class TestSpotifyApprovalAdapter:
             "items": list(playlists), "next": None,
         }
 
-        def create_playlist(name, public, description):
-            playlist = {"id": "mirror-1", "description": description}
+        def create_playlist(route, payload=None):
+            assert route == "me/playlists"
+            assert payload["public"] is False
+            playlist = {"id": "mirror-1", "description": payload["description"]}
             playlists.append(playlist)
             return playlist
 
-        client.current_user_playlist_create.side_effect = create_playlist
+        client._post.side_effect = create_playlist
 
         first_id = SpotifyMatcher(client).publish_provisional_snapshot(
             "Fixture Mirror", ["spotify:track:first"], "description", "stable-key",
@@ -3182,8 +3184,7 @@ class TestSpotifyApprovalAdapter:
         )
 
         assert first_id == second_id == "mirror-1"
-        assert client.current_user_playlist_create.call_count == 1
-        client.user_playlist_create.assert_not_called()
+        assert client._post.call_count == 1
         assert client.playlist_replace_items.call_args.args == (
             "mirror-1", ["spotify:track:second"],
         )


### PR DESCRIPTION
Closes #88

## Summary
- create private playlists through Spotify’s supported `POST /me/playlists` contract
- replace the invented Spotipy convenience-method mock with a real-client transport contract test
- align README OAuth callback guidance with the secure loopback configuration
- record the sanitized successful 0.5 live release gate

## Validation
- 504 offline tests passed (two existing ZIP duplicate-entry warnings)
- 18 repository privacy tests passed
- Python compilation passed
- whitespace validation passed
- bounded live Spotify smoke test passed 8/8 requests
- disposable private playlist was removed
- standards review passed after resolving one test-strength finding
- specification and privacy reviews passed with no blockers

No account IDs, playlist IDs, item IDs, tokens, raw responses, or user music data are retained.