### PR TITLE
Flag materially shorter Spotify versions for review

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [Unreleased]
+
+### Fixed
+
+- Materially shorter Spotify substitutes remain eligible for Approval but are
+  identified for review with their duration difference instead of being
+  labelled exact.
+
 ## [0.5.0] - 2026-08-02
 
 ### Added
@@ -94,8 +102,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - Provisional Playlist descriptions retain an opaque Transfer marker and
   machine timestamp because crash recovery and duplicate-publication prevention
   currently depend on that marker (#61).
-- Material duration differences can still be classified as exact (#56). Review
-  proposals before Approval and use a Correction when needed.
 - Broader Spotify candidate recall, noisy-source cleanup, and ISRC-first lookup
   remain research work rather than release behavior (#31, #32, #39, #42).
 

--- a/djsupport/cache.py
+++ b/djsupport/cache.py
@@ -25,6 +25,10 @@ class CacheEntry:
     match_type: str | None = None
     approval_status: str | None = None
     source_duration: int = 0
+    score_reasons: tuple[str, ...] = ()
+
+    def __post_init__(self) -> None:
+        self.score_reasons = tuple(self.score_reasons)
 
 
 class MatchCache:
@@ -113,6 +117,7 @@ class MatchCache:
                 spotify_artist=result["artist"],
                 score=result["score"],
                 match_type=result.get("match_type"),
+                score_reasons=tuple(result.get("score_reasons", ())),
                 matched=True,
                 timestamp=datetime.now().isoformat(),
                 threshold=threshold,
@@ -168,6 +173,7 @@ class MatchCache:
                 timestamp=datetime.now().isoformat(),
                 threshold=0,
                 match_type=result.get("match_type"),
+                score_reasons=tuple(result.get("score_reasons", ())),
                 source_duration=source_duration,
             )
             self.entries[key] = entry

--- a/djsupport/matcher.py
+++ b/djsupport/matcher.py
@@ -194,12 +194,43 @@ def _classify_version_match(track: Track, result: dict) -> str:
             result_text = _normalize(f'{result["artist"]} {result["name"]}')
             if remixer and remixer not in result_text:
                 return "fallback_version"
-        return "exact"
+        return _classify_duration_version(track, result)
 
     # Track appears to be original/default version. Named remix/edit on Spotify is a fallback.
     if result_named_variant:
         return "fallback_version"
+    return _classify_duration_version(track, result)
+
+
+def _classify_duration_version(track: Track, result: dict) -> str:
+    """Flag a known Spotify representation over 30 seconds shorter."""
+    result_duration_ms = result.get("duration_ms", 0)
+    if track.duration <= 0 or result_duration_ms <= 0:
+        return "exact"
+    if track.duration - (result_duration_ms / 1000) > 30:
+        return "shorter_version"
     return "exact"
+
+
+def _format_duration(seconds: int) -> str:
+    minutes, remaining_seconds = divmod(seconds, 60)
+    return f"{minutes}:{remaining_seconds:02d}"
+
+
+def _shorter_version_reason(track: Track, result: dict) -> str:
+    spotify_seconds = result["duration_ms"] // 1000
+    delta = track.duration - spotify_seconds
+    return (
+        f"Spotify version is {delta}s shorter than source "
+        f"({_format_duration(spotify_seconds)} vs {_format_duration(track.duration)})"
+    )
+
+
+def _known_duration_delta(track: Track, result: dict) -> float:
+    result_duration_ms = result.get("duration_ms", 0)
+    if track.duration <= 0 or result_duration_ms <= 0:
+        return float("inf")
+    return abs(track.duration - (result_duration_ms / 1000))
 
 
 def _duration_penalty(track_duration_s: int, result_duration_ms: int) -> float:
@@ -274,25 +305,37 @@ def _select_best(track: Track, results: list[dict], threshold: int) -> dict | No
         match_type = _classify_version_match(track, r)
         scored.append((r, exact_score, base_score, components, match_type))
 
-    # First pass: exact version matches only.
-    exact_candidates = [s for s in scored if s[4] == "exact"]
-    exact_candidates.sort(key=lambda x: x[1], reverse=True)
+    # First pass: matching/default versions, including shorter representations
+    # that must remain eligible for human review.
+    exact_candidates = [s for s in scored if s[4] in {"exact", "shorter_version"}]
+    exact_candidates.sort(
+        key=lambda candidate: (
+            -candidate[1], _known_duration_delta(track, candidate[0]),
+        ),
+    )
     if exact_candidates:
-        best, best_score, _base_score, components, _match_type = exact_candidates[0]
+        best, best_score, _base_score, components, match_type = exact_candidates[0]
         if best_score >= threshold:
             _artist_score_value, artist_score_reason = _artist_score(track, best)
+            score_reasons = [artist_score_reason]
+            if match_type == "shorter_version":
+                score_reasons.append(_shorter_version_reason(track, best))
             return {
                 **best,
                 "score": best_score,
-                "match_type": "exact",
-                "score_reasons": [artist_score_reason],
+                "match_type": match_type,
+                "score_reasons": score_reasons,
             }
 
     # Second pass: fallback to a different version if the base track is strong.
     # This preserves the user's track intent in reporting while avoiding silent
     # "exact" classifications for remix/version substitutions.
     fallback_candidates = [s for s in scored if s[4] == "fallback_version"]
-    fallback_candidates.sort(key=lambda x: x[2], reverse=True)
+    fallback_candidates.sort(
+        key=lambda candidate: (
+            -candidate[2], _known_duration_delta(track, candidate[0]),
+        ),
+    )
     if fallback_candidates:
         best, _exact_score, base_score, components, _match_type = fallback_candidates[0]
         if (
@@ -328,7 +371,7 @@ def _search_candidates(sp, track: Track, threshold: int) -> list[dict]:
 
     search(track.artist, track.name)
     early = _select_best(track, all_results, EARLY_EXIT_THRESHOLD)
-    if early is not None and early["match_type"] == "exact":
+    if early is not None and early["match_type"] in {"exact", "shorter_version"}:
         return all_results
     stripped = _strip_mix_info(track.name)
     if stripped != track.name:
@@ -410,6 +453,7 @@ def match_track_cached(
                 "artist": entry.spotify_artist,
                 "score": entry.score,
                 "match_type": entry.match_type or "exact",
+                "score_reasons": list(entry.score_reasons),
             }, "cache"
         else:
             if not cache.is_retry_eligible(track.artist, track.name,

--- a/djsupport/report.py
+++ b/djsupport/report.py
@@ -35,6 +35,7 @@ class ReviewTrack:
     spotify_artist: str = ""
     score: float = 0.0
     match_type: str = "unmatched"
+    score_reasons: tuple[str, ...] = ()
 
 
 @dataclass(frozen=True)
@@ -340,18 +341,27 @@ def save_report(report: SyncReport, path: str) -> None:
     low_confidence = []
     for pl in report.playlists:
         for m in pl.matched:
-            if m.score < 90 or m.match_type == "fallback_version":
+            if m.score < 90 or m.match_type in {
+                "fallback_version", "shorter_version",
+            }:
                 low_confidence.append((pl.path, m))
 
     if low_confidence:
-        lines.append("## Low Confidence Matches (score < 90)")
+        lines.append("## Low Confidence and Version Review Matches")
         lines.append("")
-        lines.append(f"| Playlist | {report.source_label} | Spotify Match | Score | Match Type |")
-        lines.append("|----------|-----------|---------------|-------|------------|")
+        lines.append(
+            f"| Playlist | {report.source_label} | Spotify Match | Score"
+            " | Match Type | Reasons |"
+        )
+        lines.append(
+            "|----------|-----------|---------------|-------|------------|---------|"
+        )
         for pl_path, m in low_confidence:
+            reasons = "; ".join(m.score_reasons)
             lines.append(
                 f"| {pl_path} | {m.source_name}"
-                f" | {m.spotify_artist} - {m.spotify_name} | {m.score:.1f} | {m.match_type} |"
+                f" | {m.spotify_artist} - {m.spotify_name} | {m.score:.1f}"
+                f" | {m.match_type} | {reasons} |"
             )
         lines.append("")
 
@@ -385,7 +395,7 @@ def save_review_csv(report: SyncReport, path: str) -> None:
         writer = csv.writer(csv_file)
         writer.writerow([
             "source_track_id", "source_track", "spotify_url", "spotify_track",
-            "score", "match_type", "source_artist", "source_title",
+            "score", "match_type", "score_reasons", "source_artist", "source_title",
             "source_duration",
         ])
         for playlist in report.playlists:
@@ -408,6 +418,7 @@ def save_review_csv(report: SyncReport, path: str) -> None:
                         ),
                         f"{item.score:.1f}" if item.spotify_uri else "",
                         item.match_type,
+                        "; ".join(item.score_reasons),
                         item.source_artist,
                         item.source_title,
                         item.source_duration,
@@ -421,6 +432,7 @@ def save_review_csv(report: SyncReport, path: str) -> None:
                     f"{match.spotify_artist} - {match.spotify_name}",
                     f"{match.score:.1f}",
                     match.match_type,
+                    "; ".join(match.score_reasons),
                     "",
                     "",
                     "",

--- a/djsupport/transfer.py
+++ b/djsupport/transfer.py
@@ -453,6 +453,7 @@ class PublicationItem:
     spotify_artist: str = ""
     score: float = 0.0
     match_type: str = "unmatched"
+    score_reasons: tuple[str, ...] = ()
     source_duration: int = 0
     authoritative: bool = False
 
@@ -1169,6 +1170,7 @@ class MatchCacheKnowledge:
             "artist": entry.spotify_artist,
             "score": entry.score,
             "match_type": entry.match_type or "exact",
+            "score_reasons": list(entry.score_reasons),
             "authoritative": entry.approval_status == "approved",
         }
 
@@ -1199,6 +1201,7 @@ class MatchCacheKnowledge:
                 "artist": item.spotify_artist,
                 "score": item.score,
                 "match_type": item.match_type,
+                "score_reasons": list(item.score_reasons),
             }, item.source_duration,
         )
         return ApprovalConflict(**conflict) if conflict else None
@@ -1212,6 +1215,7 @@ class MatchCacheKnowledge:
                 "artist": item.spotify_artist,
                 "score": item.score,
                 "match_type": item.match_type,
+                "score_reasons": list(item.score_reasons),
             }, item.source_duration,
         )
 
@@ -2274,6 +2278,7 @@ class Transfer:
                             spotify_artist=result["artist"],
                             score=result["score"],
                             match_type=result.get("match_type", "exact"),
+                            score_reasons=tuple(result.get("score_reasons", ())),
                             source_duration=track.duration,
                             authoritative=True,
                         ))
@@ -2331,6 +2336,7 @@ class Transfer:
                         spotify_artist=result["artist"],
                         score=result["score"],
                         match_type=result.get("match_type", "exact"),
+                        score_reasons=tuple(result.get("score_reasons", ())),
                         source_track_id=track.track_id,
                         spotify_uri=result["uri"],
                     )
@@ -2346,6 +2352,7 @@ class Transfer:
                             spotify_artist=matched_track.spotify_artist,
                             score=matched_track.score,
                             match_type=matched_track.match_type,
+                            score_reasons=matched_track.score_reasons,
                             source_duration=track.duration,
                             authoritative=bool(result.get("authoritative")),
                         ))
@@ -2821,6 +2828,7 @@ class Transfer:
                 spotify_artist=item.spotify_artist,
                 score=item.score,
                 match_type=item.match_type,
+                score_reasons=item.score_reasons,
             )
             for item in items
         ]

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -101,6 +101,22 @@ class TestMatchCacheStore:
         key = cache.cache_key("Artist", "Track")
         assert cache.entries[key].match_type == "fallback_version"
 
+    def test_roundtrips_shorter_version_review_reason(self, tmp_path):
+        path = str(tmp_path / "cache.json")
+        reason = "Spotify version is 31s shorter than source (4:29 vs 5:00)"
+        result = _matched_result(match_type="shorter_version")
+        result["score_reasons"] = [reason]
+        first = MatchCache(path)
+        first.store("Synthetic Artist", "Synthetic Signal", 80, result)
+        first.save()
+
+        restored = MatchCache(path)
+        restored.load()
+
+        entry = restored.lookup("Synthetic Artist", "Synthetic Signal", 80)
+        assert entry is not None
+        assert entry.score_reasons == (reason,)
+
     def test_cache_key_is_normalized(self, cache):
         key1 = cache.cache_key("Solomun", "Vultora (Original Mix)")
         key2 = cache.cache_key("SOLOMUN", "VULTORA (ORIGINAL MIX)")

--- a/tests/test_matcher.py
+++ b/tests/test_matcher.py
@@ -285,6 +285,151 @@ class TestMatchTrack:
         assert result["score"] >= 80
         assert result["match_type"] == "exact"
 
+    def test_materially_shorter_candidate_is_reviewable_not_exact(self):
+        sp = self._mock_sp([
+            make_spotify_item(
+                "Synthetic Signal", "Synthetic Artist",
+                "spotify:track:shorter", duration_ms=269000,
+            ),
+        ])
+        track = make_track(
+            "Synthetic Signal", "Synthetic Artist", duration=300,
+        )
+
+        result = match_track(sp, track, threshold=80)
+
+        assert result is not None
+        assert result["match_type"] == "shorter_version"
+        assert (
+            "Spotify version is 31s shorter than source (4:29 vs 5:00)"
+            in result["score_reasons"]
+        )
+
+    def test_high_confidence_shorter_version_does_not_expand_search(self):
+        sp = self._mock_sp([
+            make_spotify_item(
+                "Synthetic Signal (Original Mix)", "Synthetic Artist",
+                "spotify:track:shorter", duration_ms=269000,
+            ),
+        ])
+
+        result = match_track(
+            sp,
+            make_track(
+                "Synthetic Signal (Original Mix)",
+                "Synthetic Artist",
+                duration=300,
+            ),
+            threshold=80,
+        )
+
+        assert result is not None
+        assert result["match_type"] == "shorter_version"
+        assert sp.search.call_count == 1
+
+    def test_candidate_exactly_thirty_seconds_shorter_remains_exact(self):
+        sp = self._mock_sp([
+            make_spotify_item(
+                "Synthetic Signal", "Synthetic Artist",
+                "spotify:track:boundary", duration_ms=270000,
+            ),
+        ])
+
+        result = match_track(
+            sp,
+            make_track("Synthetic Signal", "Synthetic Artist", duration=300),
+            threshold=80,
+        )
+
+        assert result is not None
+        assert result["match_type"] == "exact"
+
+    def test_equal_candidates_prefer_smallest_known_duration_delta(self):
+        sp = self._mock_sp([
+            make_spotify_item(
+                "Synthetic Signal", "Synthetic Artist",
+                "spotify:track:first", duration_ms=270000,
+            ),
+            make_spotify_item(
+                "Synthetic Signal", "Synthetic Artist",
+                "spotify:track:closest", duration_ms=295000,
+            ),
+        ])
+
+        result = match_track(
+            sp,
+            make_track("Synthetic Signal", "Synthetic Artist", duration=300),
+            threshold=80,
+        )
+
+        assert result is not None
+        assert result["uri"] == "spotify:track:closest"
+        assert sp.search.call_count == 1
+
+    def test_existing_candidates_choose_closer_duration_without_extra_search(self):
+        sp = self._mock_sp([
+            make_spotify_item(
+                "Synthetic Signal", "Synthetic Artist",
+                "spotify:track:short", duration_ms=240000,
+            ),
+            make_spotify_item(
+                "Synthetic Signal", "Synthetic Artist",
+                "spotify:track:close", duration_ms=295000,
+            ),
+        ])
+
+        result = match_track(
+            sp,
+            make_track("Synthetic Signal", "Synthetic Artist", duration=300),
+            threshold=80,
+        )
+
+        assert result is not None
+        assert result["uri"] == "spotify:track:close"
+        assert sp.search.call_count == 1
+
+    @pytest.mark.parametrize(
+        ("source_duration", "spotify_duration_ms"),
+        [(0, 269000), (300, 0)],
+    )
+    def test_unknown_duration_does_not_infer_a_shorter_version(
+        self, source_duration, spotify_duration_ms,
+    ):
+        sp = self._mock_sp([
+            make_spotify_item(
+                "Synthetic Signal", "Synthetic Artist",
+                "spotify:track:unknown", duration_ms=spotify_duration_ms,
+            ),
+        ])
+
+        result = match_track(
+            sp,
+            make_track(
+                "Synthetic Signal", "Synthetic Artist", duration=source_duration,
+            ),
+            threshold=80,
+        )
+
+        assert result is not None
+        assert result["match_type"] == "exact"
+
+    def test_materially_longer_candidate_remains_exact(self):
+        sp = self._mock_sp([
+            make_spotify_item(
+                "Synthetic Signal", "Synthetic Artist",
+                "spotify:track:longer", duration_ms=331000,
+            ),
+        ])
+
+        result = match_track(
+            sp,
+            make_track("Synthetic Signal", "Synthetic Artist", duration=300),
+            threshold=80,
+        )
+
+        assert result is not None
+        assert result["match_type"] == "exact"
+
     def test_recovers_existing_repeated_subtitle_candidate_without_new_search(self):
         source_title = "Signal (Sunrise Mix) (  sunrise   mix )"
         track = make_track(source_title, "Synthetic Artist")

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -238,6 +238,23 @@ class TestSaveReport:
         content = (tmp_path / "report.md").read_text()
         assert "Low Confidence" not in content
 
+    def test_shorter_version_is_explained_in_review_section_at_high_score(self, tmp_path):
+        path = str(tmp_path / "report.md")
+        reason = "Spotify version is 31s shorter than source (4:29 vs 5:00)"
+        match = _matched(
+            score=95.0,
+            match_type="shorter_version",
+            score_reasons=(reason,),
+        )
+
+        save_report(_report(playlists=[_playlist(matched=[match])]), path)
+
+        review_section = (tmp_path / "report.md").read_text().split(
+            "## Low Confidence and Version Review Matches", maxsplit=1,
+        )
+        assert len(review_section) == 2
+        assert reason in review_section[1]
+
 
 class TestSaveReviewCsv:
     def test_writes_editable_rows_with_stable_reference_and_spotify_url(self, tmp_path):
@@ -250,3 +267,18 @@ class TestSaveReviewCsv:
         content = (tmp_path / "review.csv").read_text()
         assert "source_track_id,source_track,spotify_url" in content
         assert "source-1,Track A,https://open.spotify.com/track/abc123" in content
+
+    def test_includes_shorter_version_reason_for_human_review(self, tmp_path):
+        path = str(tmp_path / "review.csv")
+        reason = "Spotify version is 31s shorter than source (4:29 vs 5:00)"
+
+        save_review_csv(
+            _report(playlists=[_playlist(matched=[_matched(
+                match_type="shorter_version", score_reasons=(reason,),
+            )])]),
+            path,
+        )
+
+        content = (tmp_path / "review.csv").read_text()
+        assert "score_reasons" in content.splitlines()[0]
+        assert reason in content

--- a/tests/test_transfer.py
+++ b/tests/test_transfer.py
@@ -461,6 +461,33 @@ def test_preview_reuses_and_retains_matching_knowledge_without_playlist_writes()
     assert storage.playlist_writes == 0
 
 
+def test_preview_preserves_shorter_version_reason_for_review_without_publication():
+    reason = "Spotify version is 31s shorter than source (6:29 vs 7:00)"
+    spotify = StatefulSpotify({
+        ("New Artist", "New Track"): {
+            **_match("spotify:track:shorter", "New Track", "New Artist"),
+            "match_type": "shorter_version",
+            "score_reasons": ["source artist similarity", reason],
+        },
+    })
+    storage = InMemoryStorage()
+    original_playlists = dict(spotify.playlists)
+
+    report = Transfer(
+        publishing_guards=TEST_PUBLISHING_GUARDS,
+        source=FixtureBeatportSource(FIXTURE), spotify=spotify,
+        matching_knowledge=storage, publication_storage=storage,
+    ).execute(TransferRequest(source="fixture", preview=True))
+
+    proposal = report.playlists[0].matched[0]
+    review_item = report.playlists[0].review_items[1]
+    assert proposal.match_type == "shorter_version"
+    assert reason in proposal.score_reasons
+    assert reason in review_item.score_reasons
+    assert spotify.playlists == original_playlists
+    assert storage.playlist_writes == 0
+
+
 def test_preview_with_zero_acceptable_matches_succeeds_with_zero_percent():
     spotify = StatefulSpotify()
     storage = InMemoryStorage()
@@ -2076,6 +2103,7 @@ class TestTransferPublicationLifecycle:
             "spotify_track": "",
             "score": "",
             "match_type": "unmatched",
+            "score_reasons": "",
         }
 
     def test_prepared_transfer_is_visible_before_source_intake_and_resumes(self, tmp_path):
@@ -3138,9 +3166,15 @@ class TestProvisionalPlaylistApproval:
                 return super().spotify_track(uri)
 
         cache = MatchCache(str(tmp_path / "matching-knowledge.json"))
+        reason = "Spotify version is 31s shorter than source (5:29 vs 6:00)"
+        approved = _match(
+            "spotify:track:approved", "Known Track", "Known Artist",
+        )
+        approved["match_type"] = "shorter_version"
+        approved["score_reasons"] = [reason]
         cache.record_approval(
             "Known Artist", "Known Track", "approved",
-            _match("spotify:track:approved", "Known Track", "Known Artist"),
+            approved,
         )
         cache.save()
         spotify = UnavailableApprovedSpotify({
@@ -3162,6 +3196,9 @@ class TestProvisionalPlaylistApproval:
         assert cache.lookup("Known Artist", "Known Track", 100).spotify_uri == (
             "spotify:track:approved"
         )
+        approved_review = report.playlists[0].review_items[0]
+        assert approved_review.match_type == "shorter_version"
+        assert approved_review.score_reasons == (reason,)
 
     def test_missing_correction_is_added_once_across_repeated_approval(self, tmp_path):
         transfer, spotify, _, playlist_id = self.publish()


### PR DESCRIPTION
Closes #56

## Summary
- classify accepted Spotify representations over 30 seconds shorter as `shorter_version` while keeping them eligible for Approval
- explain the duration difference through durable matching knowledge, Transfer reports, and review CSVs
- prefer the closest known duration among otherwise equal already-fetched candidates without additional Spotify searches
- preserve exact behavior at 30 seconds, for unknown durations, and for longer Spotify versions

## Validation
- 522 offline tests passed (2 existing ZIP duplicate-entry warnings)
- 18 repository privacy tests passed
- Python compilation passed
- `git diff --check` passed
- standards review passed with 0 findings
- spec review passed with 0 findings after resolving both initial blockers
- no live Spotify or Beatport calls