### PR TITLE
Add agent-native local audio identity

### DIFF
--- a/.claude/docs/architectural_patterns.md
+++ b/.claude/docs/architectural_patterns.md
@@ -8,7 +8,10 @@ Cross-file patterns that appear in 3+ modules. Reference this doc when adding ne
 `FileTransferStorage` use versioned JSON persistence:
 
 1. Class wraps a `Path` to a JSON file
-2. `load()` is a no-op if file is missing or has wrong version — silent degradation
+2. `load()` is a no-op if the file is missing. Configuration may silently
+   ignore an unknown version, but matching knowledge and authoritative state
+   reject unsupported schemas so a later save cannot overwrite newer private
+   data.
 3. `save()` writes a `{"version": N, ...}` envelope via `json.dumps(data, indent=2)`
 4. Version constant at module top (`CONFIG_VERSION`, `CACHE_VERSION`, `STATE_VERSION`)
 
@@ -55,9 +58,9 @@ Files:
 
 Four patterns used consistently:
 
-1. **Safe file loads** — compatible configuration/matching-knowledge loads
-   degrade safely; authoritative Transfer/publication writes are atomic and
-   validated.
+1. **Safe file loads** — missing configuration/matching-knowledge files degrade
+   safely; unsupported matching-knowledge and authoritative state schemas fail
+   closed; Transfer/publication writes are atomic and validated.
 2. **`(bool, str | None)` tuple returns** — Validation functions return success/error tuples (e.g., `validate_rekordbox_xml`).
 3. **`click.ClickException`** — User-facing errors in CLI code use Click's exception for clean terminal output.
 4. **`RateLimitError` for unsafe waits** — Transfer checkpoints and pauses on

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Added
+
+- Opt-in, Rekordbox-only local Chromaprint evidence that can recover an exact,
+  account-scoped Approved Match after XML metadata changes without another
+  Spotify search.
+- Versioned agent-native capability, bounded planning, separate authorization,
+  non-interactive execution, stable resume, and privacy-redacted outcome
+  contracts, exposed through `capabilities --json` and `sync --json`.
+- Durable matching-knowledge schema 2, including private fingerprint
+  observations and associations with backup, restore, and legacy-migration
+  support.
+- Transfer-state schema 3 for durable local-audio opt-in, evidence checkpoints,
+  and stable aggregate outcomes; schemas 1 and 2 remain readable.
+
+### Changed
+
+- Transfer checkpoints completed local observations and aggregate API/local
+  evidence counts so resumed and repeated agent outcomes remain stable.
+- Rekordbox XML intake retains each selected track's private `Location` solely
+  for opted-in local calculation; reports and machine output omit it.
+
 ### Fixed
 
 - Materially shorter Spotify substitutes remain eligible for Approval but are

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   evidence counts so resumed and repeated agent outcomes remain stable.
 - Rekordbox XML intake retains each selected track's private `Location` solely
   for opted-in local calculation; reports and machine output omit it.
+- Batch identity now binds the exact selected source content and effect scope;
+  ambiguous legacy Batches must restart instead of resuming stale source data.
+- The web API accepts the same explicit local-audio opt-in and reports the same
+  aggregate local-evidence counters as other Transfer clients.
+
+### Security
+
+- Unsupported matching-knowledge schemas fail closed without rewriting private
+  state, and changed Preview/publication scope cannot resume an earlier Batch.
 
 ### Fixed
 

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -63,3 +63,11 @@ _Avoid_: Deleted source, stale playlist
 **Preview**:
 A complete matching and reporting attempt for a Transfer that may retain matching knowledge but never modifies Spotify playlists or playlist state.
 _Avoid_: Dry run, test run
+
+**Local Audio Identity**:
+Opt-in, local-only Chromaprint evidence calculated for audio referenced by an explicitly selected Rekordbox Batch. It can recover an existing account-scoped Approved Match by exact equality but can never create Approval or identify an unknown recording from a catalog.
+_Avoid_: Automatic identification, fingerprint approval, library scan
+
+**Agent Client**:
+An AI harness or automation client that uses the same public Transfer policy as CLI and web through capability, bounded plan, explicit authorization, execute or resume, and structured outcome phases. Conversation is never authorization.
+_Avoid_: Autonomous authority, agent workflow engine

--- a/README.md
+++ b/README.md
@@ -258,6 +258,11 @@ djsupport sync -p "Deep House" --json \
   --local-audio-identity
 ```
 
+Run the command first without `--authorize-spotify-write` to receive the
+privacy-safe bounded plan and Batch ID. After reviewing it, repeat the same
+request with write authorization. A changed source selection or execution
+scope produces a different Batch ID and cannot resume the earlier plan.
+
 Whole-library or expensive work additionally requires
 `--confirm-expensive`. JSON mode never prompts or infers authority from the
 conversation. Its versioned response contains only aggregate counts, stable

--- a/README.md
+++ b/README.md
@@ -17,12 +17,17 @@ Transfer curated Rekordbox and Beatport selections to Spotify through reviewable
 - **Explicit Batches** — select one or more Rekordbox playlists, or opt into the whole library with cost preflight
 - **Graceful rate limiting** — aborts with a clear message, saves cache, and exits non-zero instead of hanging; resume later to continue where you left off
 - **Local-data backup and restore** — creates versioned archives without OAuth credentials and validates, previews, and conflict-checks restores before changing data
+- **Opt-in local audio identity** — reuses an exact, previously Approved Match
+  from locally calculated Chromaprint evidence when Rekordbox metadata changes
+- **Agent-native contract** — gives Codex and other harnesses versioned,
+  privacy-redacted capability, plan, authorization, resume, and outcome records
 
 ## Prerequisites
 
 - Python 3.10+
 - A [Spotify Developer](https://developer.spotify.com/dashboard) application (for API credentials)
 - A Rekordbox XML library export
+- Optional: `fpcalc` from Chromaprint for local audio identity
 
 ## Installation
 
@@ -203,6 +208,61 @@ manifests:
 ```bash
 djsupport sync -p "Deep House" --dry-run
 ```
+
+### Recover Approved Matches from local audio
+
+Inspect the optional capability without reading XML, audio, or Spotify:
+
+```bash
+djsupport capabilities
+```
+
+Opt into local audio identity for only the selected Batch:
+
+```bash
+djsupport sync -p "Deep House" --dry-run --local-audio-identity
+```
+
+DJ Support runs the installed `fpcalc` locally and never uploads audio or
+fingerprints. It does not scan directories, modify files or tags, or infer an
+Approval. After the user approves a Provisional Playlist, exact compatible
+evidence can reuse that account-scoped Approved Match without Spotify search.
+Missing or unreadable audio falls back to normal metadata matching. Similar but
+non-identical fingerprints never authorize reuse. `--local-audio-identity` is
+incompatible with `--no-cache` because authority must be durable.
+
+Matching knowledge schema 2 stores observations and Approved Match associations
+only in private application data. Backup, restore, and migration preserve them;
+reports expose aggregate counts but never paths, filenames, or fingerprints.
+
+### Use DJ Support from Codex or another AI harness
+
+Capability inspection is machine-readable and side-effect free:
+
+```bash
+djsupport capabilities --json
+```
+
+Preview one explicitly selected Batch non-interactively:
+
+```bash
+djsupport sync -p "Deep House" --dry-run --json \
+  --authorize-private-source --local-audio-identity
+```
+
+Publishing requires a separate Spotify-write authorization:
+
+```bash
+djsupport sync -p "Deep House" --json \
+  --authorize-private-source --authorize-spotify-write \
+  --local-audio-identity
+```
+
+Whole-library or expensive work additionally requires
+`--confirm-expensive`. JSON mode never prompts or infers authority from the
+conversation. Its versioned response contains only aggregate counts, stable
+identifiers, lifecycle status, and permitted next actions. See
+[ADR-0002](docs/adr/0002-make-transfer-agent-native.md).
 
 ### Tuning match quality
 

--- a/README.md
+++ b/README.md
@@ -269,6 +269,13 @@ conversation. Its versioned response contains only aggregate counts, stable
 identifiers, lifecycle status, and permitted next actions. See
 [ADR-0002](docs/adr/0002-make-transfer-agent-native.md).
 
+The local web API exposes the same Rekordbox-only contract at
+`POST /rekordbox/batches/plan` and `POST /rekordbox/batches/execute`. Requests
+name an explicit XML path and playlist selection plus the separate authority
+flags; responses omit that private material and return the same versioned plan
+or aggregate outcome. The existing `/sync` web route remains Beatport-only and
+does not accept local-audio identity.
+
 ### Tuning match quality
 
 Adjust the minimum match confidence (0–100, default 80):

--- a/agent.md
+++ b/agent.md
@@ -149,6 +149,9 @@ pytest --cov=djsupport     # Run with coverage
   Transfer contract, explicit private-source and Spotify-write authorizations,
   stable identifiers, and privacy-redacted versioned JSON. Never infer authority
   from conversation or add agent-only matching/publication policy.
+- The local web adapter exposes Rekordbox Batch planning and execution under
+  `/rekordbox/batches/plan` and `/rekordbox/batches/execute`; `/sync` remains
+  Beatport-only.
 - Local audio identity is Rekordbox-only, selected-Batch-only, opt-in, exact,
   account-scoped, and subordinate to Approval. Never scan directories, upload
   evidence, emit paths/fingerprints, or make `fpcalc` a required package binary.

--- a/agent.md
+++ b/agent.md
@@ -37,6 +37,8 @@ djsupport/
   transfer.py   # Durable Transfer/Batch orchestration, checkpoints, and publication
   backup.py     # Versioned local-data backup, preview, merge, and atomic restore
   migration.py  # Explicit preview/apply migration of known 0.3.0 local data
+  local_audio.py # Optional local-only Chromaprint system boundary
+  agent.py      # Versioned, harness-neutral Transfer contract rendering
   static/       # Web frontend (index.html with Tailwind CSS)
 tests/          # pytest suite
 docs/           # Plans, reports, and solution docs
@@ -54,6 +56,7 @@ djsupport list <xml>       # List playlists from Rekordbox XML
 djsupport sync <xml> --playlist "My Playlist"  # Transfer one Rekordbox Mirror
 djsupport sync <xml> --whole-library            # Explicit whole-library Batch
 djsupport sync <xml> --dry-run  # Preview without modifying Spotify
+djsupport capabilities --json   # Side-effect-free agent capability contract
 djsupport library set <xml>     # Save default Rekordbox XML path
 djsupport library show          # Show configured XML path
 djsupport beatport <url>       # Create a Beatport Snapshot
@@ -79,6 +82,10 @@ djsupport sync --cache-path my.json      # Matching-knowledge path (compatible f
 djsupport sync --prefix "dj"             # Prefix for Spotify playlist names
 djsupport sync --no-prefix               # Disable playlist name prefix
 djsupport sync --state-path state.json   # Custom playlist state file location
+djsupport sync --local-audio-identity     # Opt into selected local audio reads
+djsupport sync --json --authorize-private-source  # Non-interactive agent Preview
+djsupport sync --json --authorize-private-source --authorize-spotify-write  # Agent publication
+djsupport sync --confirm-expensive        # Explicit agent/CLI expensive-work gate
 
 # Beatport flags
 djsupport beatport <url> --dry-run                  # Preview matches
@@ -138,6 +145,13 @@ pytest --cov=djsupport     # Run with coverage
   generated design exports remain ignored through `design-exports/`
 - `docs/solutions/` holds documented problem solutions with YAML frontmatter (created via `/compound` workflow)
 - Update `agent.md` in the same PR when adding modules, CLI flags, or changing conventions
+- AI harnesses are first-class clients under ADR-0002. They use the shared
+  Transfer contract, explicit private-source and Spotify-write authorizations,
+  stable identifiers, and privacy-redacted versioned JSON. Never infer authority
+  from conversation or add agent-only matching/publication policy.
+- Local audio identity is Rekordbox-only, selected-Batch-only, opt-in, exact,
+  account-scoped, and subordinate to Approval. Never scan directories, upload
+  evidence, emit paths/fingerprints, or make `fpcalc` a required package binary.
 
 ## Additional documentation
 

--- a/djsupport/agent.py
+++ b/djsupport/agent.py
@@ -44,12 +44,18 @@ def authorization_required_document(phase: str, required: str) -> dict:
 
 def error_document(phase: str, code: str) -> dict:
     """Render a privacy-safe machine error without source-derived details."""
+    next_action = {
+        "private_source_unavailable": "inspect_private_source",
+        "durable_knowledge_required": "enable_durable_knowledge",
+        "matching_knowledge_unavailable": "repair_matching_knowledge",
+        "transfer_failed": "inspect_transfer_status",
+    }.get(code, "review_error")
     return {
         "contract_version": AGENT_CONTRACT_VERSION,
         "phase": phase,
         "status": "error",
         "error": {"code": code},
-        "next_actions": ["inspect_private_source"],
+        "next_actions": [next_action],
     }
 
 
@@ -76,10 +82,9 @@ class AgentTransferContract:
     @staticmethod
     def _plan_document(request, authorization, plan) -> dict:
         batch_id = plan.batch_id
-        required = (
-            [] if request.preview or authorization.spotify_write
-            else ["spotify_write"]
-        )
+        required = list(Transfer.required_authorizations(
+            request, authorization, phase="plan",
+        ))
         next_actions = []
         if required:
             next_actions.append("authorize_spotify_write")

--- a/djsupport/agent.py
+++ b/djsupport/agent.py
@@ -1,0 +1,203 @@
+"""Harness-neutral, machine-readable client contract for Transfers."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import asdict, dataclass
+
+from djsupport.transfer import BatchPlanRequest, Transfer
+
+
+AGENT_CONTRACT_VERSION = 1
+
+
+@dataclass(frozen=True)
+class AgentAuthorization:
+    private_source: bool = False
+    spotify_write: bool = False
+
+
+def capability_document(local_audio) -> dict:
+    capability_value = local_audio.capability()
+    capability = {
+        "available": capability_value.available,
+        "algorithm": capability_value.algorithm,
+        "algorithm_version": capability_value.algorithm_version,
+    }
+    if capability_value.reason is not None:
+        capability["reason"] = capability_value.reason
+    return {
+        "contract_version": AGENT_CONTRACT_VERSION,
+        "phase": "capability",
+        "status": "ready",
+        "capabilities": {"local_audio_identity": capability},
+        "next_actions": ["plan"],
+    }
+
+
+class AgentTransferContract:
+    """Render public Transfer behavior for AI and automation clients."""
+
+    def __init__(self, transfer: Transfer) -> None:
+        self._transfer = transfer
+
+    def capabilities(self) -> dict:
+        class CapabilityAdapter:
+            def __init__(self, value):
+                self._value = value
+
+            def capability(self):
+                return self._value
+
+        return capability_document(CapabilityAdapter(
+            self._transfer.local_audio_capability()
+        ))
+
+    def plan_batch(
+        self, request: BatchPlanRequest, authorization: AgentAuthorization,
+    ) -> dict:
+        if not authorization.private_source:
+            return {
+                "contract_version": AGENT_CONTRACT_VERSION,
+                "phase": "plan",
+                "status": "authorization_required",
+                "required_authorizations": ["private_source"],
+                "next_actions": ["authorize_private_source"],
+            }
+        plan = self._transfer.plan_batch(request)
+        identity = asdict(request)
+        identity.pop("confirm_expensive", None)
+        plan_material = json.dumps(
+            identity, sort_keys=True, separators=(",", ":"),
+        )
+        batch_id = hashlib.sha256(plan_material.encode()).hexdigest()
+        required = (
+            [] if request.preview or authorization.spotify_write
+            else ["spotify_write"]
+        )
+        next_actions = []
+        if required:
+            next_actions.append("authorize_spotify_write")
+        next_actions.append("confirm_expensive" if not plan.ready else "execute")
+        return {
+            "contract_version": AGENT_CONTRACT_VERSION,
+            "phase": "plan",
+            "status": "confirmation_required" if not plan.ready else "ready",
+            "batch_id": batch_id,
+            "confirmation_required": plan.confirmation_required,
+            "counts": {
+                "playlists": len(plan.playlists),
+                "tracks": plan.total_tracks,
+                "approved_match_hits": plan.approved_match_hits,
+                "retained_proposal_hits": plan.cache_hits,
+                "expected_spotify_lookups": plan.expected_uncached_lookups,
+                "local_audio_eligible": plan.local_audio_eligible,
+                "local_audio_indexed": plan.local_audio_indexed,
+                "local_audio_pending": plan.local_audio_pending,
+                "local_audio_unavailable": plan.local_audio_unavailable,
+            },
+            "requested_effects": [
+                "private_source",
+                *([] if request.preview else ["spotify_write"]),
+            ],
+            "required_authorizations": required,
+            "next_actions": next_actions,
+        }
+
+    def execute_batch(
+        self, request: BatchPlanRequest, authorization: AgentAuthorization,
+        *, transfer_id: str | None = None,
+    ) -> dict:
+        if not authorization.private_source:
+            return {
+                "contract_version": AGENT_CONTRACT_VERSION,
+                "phase": "execute",
+                "status": "authorization_required",
+                "required_authorizations": ["private_source"],
+                "next_actions": ["authorize_private_source"],
+            }
+        plan_result = self.plan_batch(request, authorization)
+        if not request.preview and not authorization.spotify_write:
+            return {
+                "contract_version": AGENT_CONTRACT_VERSION,
+                "phase": "execute",
+                "status": "authorization_required",
+                "batch_id": plan_result["batch_id"],
+                "required_authorizations": ["spotify_write"],
+                "next_actions": ["authorize_spotify_write"],
+            }
+        plan = self._transfer.plan_batch(request)
+        if not plan.ready:
+            return {
+                "contract_version": AGENT_CONTRACT_VERSION,
+                "phase": "execute",
+                "status": "confirmation_required",
+                "batch_id": plan_result["batch_id"],
+                "required_authorizations": [],
+                "next_actions": ["confirm_expensive"],
+            }
+        batch_id = transfer_id or plan_result["batch_id"]
+        report = self._transfer.execute_batch(plan, transfer_id=batch_id)
+        status = report.status.replace(" ", "_")
+        return {
+            "contract_version": AGENT_CONTRACT_VERSION,
+            "phase": "outcome",
+            "status": status,
+            "batch_id": plan_result["batch_id"],
+            "transfer_id": report.transfer_id,
+            "counts": {
+                "playlists": len(report.playlists),
+                "matched": report.total_matched,
+                "unmatched": report.total_unmatched,
+                "spotify_api_lookups": sum(
+                    playlist.api_lookups for playlist in report.playlists
+                ),
+                "local_audio_eligible": sum(
+                    playlist.local_audio_eligible for playlist in report.playlists
+                ),
+                "local_audio_observed": sum(
+                    playlist.local_audio_observed for playlist in report.playlists
+                ),
+                "local_audio_unavailable": sum(
+                    playlist.local_audio_unavailable for playlist in report.playlists
+                ),
+                "local_audio_reused": sum(
+                    playlist.local_audio_reused for playlist in report.playlists
+                ),
+            },
+            "required_authorizations": [],
+            "next_actions": (
+                ["resume"] if status == "paused" else ["review"]
+            ),
+        }
+
+    def progress(
+        self, transfer_id: str, authorization: AgentAuthorization,
+    ) -> dict:
+        if not authorization.private_source:
+            return {
+                "contract_version": AGENT_CONTRACT_VERSION,
+                "phase": "progress",
+                "status": "authorization_required",
+                "required_authorizations": ["private_source"],
+                "next_actions": ["authorize_private_source"],
+            }
+        progress = self._transfer.batch_progress(transfer_id)
+        status = progress.status.value.replace(" ", "_")
+        return {
+            "contract_version": AGENT_CONTRACT_VERSION,
+            "phase": "progress",
+            "status": status,
+            "transfer_id": transfer_id,
+            "counts": {
+                "playlists": progress.playlists,
+                "completed": progress.completed,
+                "failed": progress.failed,
+                "pending": progress.pending,
+            },
+            "next_actions": (
+                ["resume"] if status in {"paused", "partial_success"}
+                else ["review"]
+            ),
+        }

--- a/djsupport/agent.py
+++ b/djsupport/agent.py
@@ -48,6 +48,7 @@ def error_document(phase: str, code: str) -> dict:
         "private_source_unavailable": "inspect_private_source",
         "durable_knowledge_required": "enable_durable_knowledge",
         "matching_knowledge_unavailable": "repair_matching_knowledge",
+        "spotify_authentication_required": "authenticate_spotify",
         "transfer_failed": "inspect_transfer_status",
     }.get(code, "review_error")
     return {

--- a/djsupport/agent.py
+++ b/djsupport/agent.py
@@ -2,24 +2,20 @@
 
 from __future__ import annotations
 
-import hashlib
-import json
-from dataclasses import asdict, dataclass
-
-from djsupport.transfer import BatchPlanRequest, Transfer
+from djsupport.transfer import (
+    BatchPlanRequest,
+    Transfer,
+    TransferAuthorization,
+)
 
 
 AGENT_CONTRACT_VERSION = 1
 
 
-@dataclass(frozen=True)
-class AgentAuthorization:
-    private_source: bool = False
-    spotify_write: bool = False
+AgentAuthorization = TransferAuthorization
 
 
-def capability_document(local_audio) -> dict:
-    capability_value = local_audio.capability()
+def capability_document(capability_value) -> dict:
     capability = {
         "available": capability_value.available,
         "algorithm": capability_value.algorithm,
@@ -36,6 +32,27 @@ def capability_document(local_audio) -> dict:
     }
 
 
+def authorization_required_document(phase: str, required: str) -> dict:
+    return {
+        "contract_version": AGENT_CONTRACT_VERSION,
+        "phase": phase,
+        "status": "authorization_required",
+        "required_authorizations": [required],
+        "next_actions": [f"authorize_{required}"],
+    }
+
+
+def error_document(phase: str, code: str) -> dict:
+    """Render a privacy-safe machine error without source-derived details."""
+    return {
+        "contract_version": AGENT_CONTRACT_VERSION,
+        "phase": phase,
+        "status": "error",
+        "error": {"code": code},
+        "next_actions": ["inspect_private_source"],
+    }
+
+
 class AgentTransferContract:
     """Render public Transfer behavior for AI and automation clients."""
 
@@ -43,35 +60,22 @@ class AgentTransferContract:
         self._transfer = transfer
 
     def capabilities(self) -> dict:
-        class CapabilityAdapter:
-            def __init__(self, value):
-                self._value = value
-
-            def capability(self):
-                return self._value
-
-        return capability_document(CapabilityAdapter(
-            self._transfer.local_audio_capability()
-        ))
+        return capability_document(self._transfer.local_audio_capability())
 
     def plan_batch(
         self, request: BatchPlanRequest, authorization: AgentAuthorization,
     ) -> dict:
-        if not authorization.private_source:
-            return {
-                "contract_version": AGENT_CONTRACT_VERSION,
-                "phase": "plan",
-                "status": "authorization_required",
-                "required_authorizations": ["private_source"],
-                "next_actions": ["authorize_private_source"],
-            }
-        plan = self._transfer.plan_batch(request)
-        identity = asdict(request)
-        identity.pop("confirm_expensive", None)
-        plan_material = json.dumps(
-            identity, sort_keys=True, separators=(",", ":"),
+        required = self._transfer.authorization_requirement(
+            request, authorization, phase="plan",
         )
-        batch_id = hashlib.sha256(plan_material.encode()).hexdigest()
+        if required:
+            return authorization_required_document("plan", required)
+        plan = self._transfer.plan_batch(request)
+        return self._plan_document(request, authorization, plan)
+
+    @staticmethod
+    def _plan_document(request, authorization, plan) -> dict:
+        batch_id = plan.batch_id
         required = (
             [] if request.preview or authorization.spotify_write
             else ["spotify_write"]
@@ -109,25 +113,21 @@ class AgentTransferContract:
         self, request: BatchPlanRequest, authorization: AgentAuthorization,
         *, transfer_id: str | None = None,
     ) -> dict:
-        if not authorization.private_source:
-            return {
-                "contract_version": AGENT_CONTRACT_VERSION,
-                "phase": "execute",
-                "status": "authorization_required",
-                "required_authorizations": ["private_source"],
-                "next_actions": ["authorize_private_source"],
-            }
-        plan_result = self.plan_batch(request, authorization)
-        if not request.preview and not authorization.spotify_write:
-            return {
-                "contract_version": AGENT_CONTRACT_VERSION,
-                "phase": "execute",
-                "status": "authorization_required",
-                "batch_id": plan_result["batch_id"],
-                "required_authorizations": ["spotify_write"],
-                "next_actions": ["authorize_spotify_write"],
-            }
+        required = self._transfer.authorization_requirement(
+            request, authorization, phase="plan",
+        )
+        if required:
+            return authorization_required_document("execute", required)
         plan = self._transfer.plan_batch(request)
+        plan_result = self._plan_document(request, authorization, plan)
+        required = self._transfer.authorization_requirement(
+            request, authorization, phase="execute",
+        )
+        if required:
+            return {
+                **authorization_required_document("execute", required),
+                "batch_id": plan_result["batch_id"],
+            }
         if not plan.ready:
             return {
                 "contract_version": AGENT_CONTRACT_VERSION,
@@ -175,14 +175,11 @@ class AgentTransferContract:
     def progress(
         self, transfer_id: str, authorization: AgentAuthorization,
     ) -> dict:
-        if not authorization.private_source:
-            return {
-                "contract_version": AGENT_CONTRACT_VERSION,
-                "phase": "progress",
-                "status": "authorization_required",
-                "required_authorizations": ["private_source"],
-                "next_actions": ["authorize_private_source"],
-            }
+        required = self._transfer.private_source_authorization_requirement(
+            authorization,
+        )
+        if required:
+            return authorization_required_document("progress", required)
         progress = self._transfer.batch_progress(transfer_id)
         status = progress.status.value.replace(" ", "_")
         return {

--- a/djsupport/backup.py
+++ b/djsupport/backup.py
@@ -17,9 +17,9 @@ from typing import Callable
 
 BACKUP_VERSION = 1
 SUPPORTED_SCHEMAS = {
-    "matching-knowledge.json": (1,),
-    "transfers.json": (1, 2),
-    "publication-manifests.transfers.json": (1, 2),
+    "matching-knowledge.json": (1, 2),
+    "transfers.json": (1, 2, 3),
+    "publication-manifests.transfers.json": (1, 2, 3),
     "publication-manifests.json": (1, 2, 3, 4, 5),
     "playlist-state.json": (1, 2),
     "legacy-migration.json": (1,),
@@ -255,6 +255,9 @@ class LocalDataBackup:
     def _merge_json(self, path, current, incoming, changes, conflicts, resolutions):
         combined = json.loads(json.dumps(current))
         if path == "matching-knowledge.json":
+            combined["version"] = max(
+                current.get("version", 1), incoming.get("version", 1),
+            )
             combined.setdefault("entries", {})
             for key, value in incoming.get("entries", {}).items():
                 existing = combined["entries"].get(key)
@@ -274,6 +277,51 @@ class LocalDataBackup:
                 for item in incoming.get(field, []):
                     if item not in combined[field]:
                         combined[field].append(item)
+            combined.setdefault("fingerprint_observations", {})
+            for evidence_id, item in incoming.get(
+                "fingerprint_observations", {}
+            ).items():
+                existing = combined["fingerprint_observations"].get(evidence_id)
+                if existing is None:
+                    combined["fingerprint_observations"][evidence_id] = item
+                    changes.append("add local audio observation")
+                elif existing != item:
+                    safe_identity = hashlib.sha256(
+                        evidence_id.encode()
+                    ).hexdigest()[:12]
+                    self._resolve_conflict(
+                        combined["fingerprint_observations"], evidence_id, item,
+                        "identity", path, conflicts, resolutions,
+                        label=f"local-audio:{safe_identity}",
+                    )
+            combined.setdefault("fingerprint_associations", [])
+            for item in incoming.get("fingerprint_associations", []):
+                identity = (
+                    item.get("algorithm"), item.get("algorithm_version"),
+                    item.get("fingerprint"), item.get("account_id"),
+                )
+                existing = next((
+                    value for value in combined["fingerprint_associations"]
+                    if (
+                        value.get("algorithm"),
+                        value.get("algorithm_version"),
+                        value.get("fingerprint"),
+                        value.get("account_id"),
+                    ) == identity
+                ), None)
+                if existing is None:
+                    combined["fingerprint_associations"].append(item)
+                    changes.append("add local audio Approved Match")
+                elif existing != item:
+                    safe_identity = hashlib.sha256(
+                        repr(identity).encode()
+                    ).hexdigest()[:12]
+                    self._resolve_conflict(
+                        combined["fingerprint_associations"],
+                        combined["fingerprint_associations"].index(existing),
+                        item, "approval", path, conflicts, resolutions,
+                        label=f"local-audio:{safe_identity}",
+                    )
         elif path in ("transfers.json", "publication-manifests.transfers.json"):
             for field in ("transfers", "batches"):
                 combined.setdefault(field, {})

--- a/djsupport/cache.py
+++ b/djsupport/cache.py
@@ -1,13 +1,14 @@
 """Persistent match cache with auto-checkpoint and retry logic."""
 
 import json
+from hashlib import sha256
 from dataclasses import asdict, dataclass
 from datetime import datetime, timedelta
 from pathlib import Path
 
 from djsupport.matcher import _normalize
 
-CACHE_VERSION = 1
+CACHE_VERSION = 2
 DEFAULT_CACHE_PATH = ".djsupport_cache.json"
 DEFAULT_RETRY_DAYS = 7
 CHECKPOINT_INTERVAL = 50
@@ -37,6 +38,8 @@ class MatchCache:
         self.entries: dict[str, CacheEntry] = {}
         self.local_regressions: list[dict] = []
         self.approval_conflicts: list[dict] = []
+        self.fingerprint_observations: dict[str, dict] = {}
+        self.fingerprint_associations: list[dict] = []
         self._dirty_count: int = 0
 
     def load(self) -> None:
@@ -47,12 +50,14 @@ class MatchCache:
             data = json.loads(self.path.read_text())
         except (json.JSONDecodeError, OSError):
             return
-        if data.get("version") != CACHE_VERSION:
+        if data.get("version") not in (1, CACHE_VERSION):
             return
         for key, entry in data.get("entries", {}).items():
             self.entries[key] = CacheEntry(**entry)
         self.local_regressions = data.get("local_regressions", [])
         self.approval_conflicts = data.get("approval_conflicts", [])
+        self.fingerprint_observations = data.get("fingerprint_observations", {})
+        self.fingerprint_associations = data.get("fingerprint_associations", [])
 
     def save(self) -> None:
         """Write cache to disk."""
@@ -62,6 +67,8 @@ class MatchCache:
             "entries": {k: asdict(v) for k, v in self.entries.items()},
             "local_regressions": self.local_regressions,
             "approval_conflicts": self.approval_conflicts,
+            "fingerprint_observations": self.fingerprint_observations,
+            "fingerprint_associations": self.fingerprint_associations,
         }
         self.path.write_text(json.dumps(data, indent=2))
         self._dirty_count = 0
@@ -198,6 +205,138 @@ class MatchCache:
         self.entries.pop(self.cache_key(artist, title, source_duration), None)
         if source_duration > 0:
             self.entries.pop(self.cache_key(artist, title), None)
+        self._dirty_count += 1
+
+    def retain_fingerprint_observation(
+        self, *, algorithm: str, algorithm_version: str, fingerprint: str,
+        audio_duration: int, source_track_id: str,
+    ) -> str:
+        """Retain private provisional evidence and return a non-secret handle."""
+        material = "\0".join((
+            algorithm, algorithm_version, fingerprint, str(audio_duration),
+            source_track_id,
+        ))
+        evidence_id = sha256(material.encode()).hexdigest()
+        self.fingerprint_observations[evidence_id] = {
+            "algorithm": algorithm,
+            "algorithm_version": algorithm_version,
+            "fingerprint": fingerprint,
+            "audio_duration": audio_duration,
+            "source_track_id": source_track_id,
+            "observed_at": datetime.now().isoformat(),
+        }
+        self._dirty_count += 1
+        return evidence_id
+
+    def fingerprint_observation(self, evidence_id: str) -> dict | None:
+        return self.fingerprint_observations.get(evidence_id)
+
+    def lookup_fingerprint(
+        self, *, algorithm: str, algorithm_version: str, fingerprint: str,
+        account_id: str,
+    ) -> dict | None:
+        """Return one exact account-scoped Approved Match, never a guess."""
+        candidates = [
+            item for item in self.fingerprint_associations
+            if item["algorithm"] == algorithm
+            and item["algorithm_version"] == algorithm_version
+            and item["fingerprint"] == fingerprint
+            and item["account_id"] == account_id
+            and item.get("authority_status") == "approved"
+        ]
+        uris = {item["spotify_uri"] for item in candidates}
+        if len(uris) != 1:
+            return None
+        item = candidates[0]
+        return {
+            "uri": item["spotify_uri"],
+            "name": item["spotify_name"],
+            "artist": item["spotify_artist"],
+            "score": item["score"],
+            "match_type": "approved_local_audio",
+            "score_reasons": ["Approved Match reused from local audio identity"],
+            "authoritative": True,
+        }
+
+    def approve_fingerprint(
+        self, *, evidence_id: str, account_id: str, source_artist: str,
+        source_title: str, source_duration: int, result: dict,
+    ) -> dict | None:
+        observation = self.fingerprint_observations.get(evidence_id)
+        if observation is None:
+            return None
+        same_identity = [
+            item for item in self.fingerprint_associations
+            if item["algorithm"] == observation["algorithm"]
+            and item["algorithm_version"] == observation["algorithm_version"]
+            and item["fingerprint"] == observation["fingerprint"]
+            and item["account_id"] == account_id
+            and item.get("authority_status") == "approved"
+        ]
+        approved_uris = {item["spotify_uri"] for item in same_identity}
+        if approved_uris and approved_uris != {result["uri"]}:
+            return {
+                "source_artist": source_artist,
+                "source_title": source_title,
+                "source_duration": source_duration,
+                "approved_spotify_uri": sorted(approved_uris)[0],
+                "proposed_spotify_uri": result["uri"],
+            }
+        association = {
+            **observation,
+            "account_id": account_id,
+            "source_artist": source_artist,
+            "source_title": source_title,
+            "source_duration": source_duration,
+            "spotify_uri": result["uri"],
+            "spotify_name": result["name"],
+            "spotify_artist": result["artist"],
+            "score": result["score"],
+            "match_type": result.get("match_type", "exact"),
+            "score_reasons": list(result.get("score_reasons", ())),
+            "authority_status": "approved",
+            "approved_at": datetime.now().isoformat(),
+        }
+        if not any(
+            item["algorithm"] == association["algorithm"]
+            and item["algorithm_version"] == association["algorithm_version"]
+            and item["fingerprint"] == association["fingerprint"]
+            and item["account_id"] == association["account_id"]
+            and item["spotify_uri"] == association["spotify_uri"]
+            for item in self.fingerprint_associations
+        ):
+            self.fingerprint_associations.append(association)
+            self._dirty_count += 1
+        return None
+
+    def revoke_fingerprints(
+        self, *, source_artist: str, source_title: str, source_duration: int,
+        evidence_id: str | None = None, account_id: str,
+    ) -> None:
+        observation = (
+            self.fingerprint_observations.get(evidence_id)
+            if evidence_id is not None else None
+        )
+        self.fingerprint_associations = [
+            item for item in self.fingerprint_associations
+            if not (
+                item.get("account_id") == account_id
+                and (
+                    (
+                        item.get("source_artist") == source_artist
+                        and item.get("source_title") == source_title
+                        and item.get("source_duration") == source_duration
+                    )
+                    or (
+                        observation is not None
+                        and item.get("algorithm") == observation.get("algorithm")
+                        and item.get("algorithm_version")
+                        == observation.get("algorithm_version")
+                        and item.get("fingerprint") == observation.get("fingerprint")
+                    )
+                )
+            )
+        ]
         self._dirty_count += 1
 
     def is_retry_eligible(self, artist: str, title: str,

--- a/djsupport/cache.py
+++ b/djsupport/cache.py
@@ -51,7 +51,10 @@ class MatchCache:
         except (json.JSONDecodeError, OSError):
             return
         if data.get("version") not in (1, CACHE_VERSION):
-            return
+            raise ValueError(
+                "Unsupported matching-knowledge schema; upgrade djsupport "
+                "before using this file"
+            )
         for key, entry in data.get("entries", {}).items():
             self.entries[key] = CacheEntry(**entry)
         self.local_regressions = data.get("local_regressions", [])
@@ -236,13 +239,18 @@ class MatchCache:
         account_id: str,
     ) -> dict | None:
         """Return one exact account-scoped Approved Match, never a guess."""
-        candidates = [
+        matching = [
             item for item in self.fingerprint_associations
             if item["algorithm"] == algorithm
             and item["algorithm_version"] == algorithm_version
             and item["fingerprint"] == fingerprint
             and item["account_id"] == account_id
-            and item.get("authority_status") == "approved"
+        ]
+        if any(item.get("authority_status") == "conflict" for item in matching):
+            return None
+        candidates = [
+            item for item in matching
+            if item.get("authority_status") == "approved"
         ]
         uris = {item["spotify_uri"] for item in candidates}
         if len(uris) != 1:
@@ -274,14 +282,6 @@ class MatchCache:
             and item.get("authority_status") == "approved"
         ]
         approved_uris = {item["spotify_uri"] for item in same_identity}
-        if approved_uris and approved_uris != {result["uri"]}:
-            return {
-                "source_artist": source_artist,
-                "source_title": source_title,
-                "source_duration": source_duration,
-                "approved_spotify_uri": sorted(approved_uris)[0],
-                "proposed_spotify_uri": result["uri"],
-            }
         association = {
             **observation,
             "account_id": account_id,
@@ -297,6 +297,33 @@ class MatchCache:
             "authority_status": "approved",
             "approved_at": datetime.now().isoformat(),
         }
+        if approved_uris and approved_uris != {result["uri"]}:
+            conflict = {
+                "source_artist": source_artist,
+                "source_title": source_title,
+                "source_duration": source_duration,
+                "approved_spotify_uri": sorted(approved_uris)[0],
+                "proposed_spotify_uri": result["uri"],
+            }
+            conflict_association = {
+                **association, "authority_status": "conflict",
+            }
+            if not any(item == conflict_association for item in self.fingerprint_associations):
+                self.fingerprint_associations.append(conflict_association)
+            if conflict not in self.approval_conflicts:
+                self.approval_conflicts.append(conflict)
+            self._dirty_count += 1
+            return conflict
+        self.fingerprint_associations = [
+            item for item in self.fingerprint_associations
+            if not (
+                item["algorithm"] == observation["algorithm"]
+                and item["algorithm_version"] == observation["algorithm_version"]
+                and item["fingerprint"] == observation["fingerprint"]
+                and item["account_id"] == account_id
+                and item.get("authority_status") == "conflict"
+            )
+        ]
         if not any(
             item["algorithm"] == association["algorithm"]
             and item["algorithm_version"] == association["algorithm_version"]

--- a/djsupport/cli.py
+++ b/djsupport/cli.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 from pathlib import Path
 from uuid import uuid4
 
@@ -32,6 +33,27 @@ DEFAULT_PUBLICATION_MANIFEST_PATH = str(default_publication_manifest_path())
 def cli():
     """DJ Support - Transfer DJ selections to Spotify."""
     load_dotenv()
+
+
+@cli.command("capabilities")
+@click.option("--json", "as_json", is_flag=True, help="Emit the agent contract.")
+def capabilities(as_json: bool) -> None:
+    """Inspect optional capabilities without reading a library or Spotify."""
+    from djsupport.agent import capability_document
+    from djsupport.local_audio import ChromaprintLocalAudio
+
+    document = capability_document(ChromaprintLocalAudio())
+    if as_json:
+        click.echo(json.dumps(document, sort_keys=True))
+        return
+    local_audio = document["capabilities"]["local_audio_identity"]
+    if local_audio["available"]:
+        click.echo(
+            "Local audio identity available "
+            f"({local_audio['algorithm']} {local_audio['algorithm_version']})."
+        )
+    else:
+        click.echo("Local audio identity unavailable; install fpcalc to enable it.")
 
 
 def _resolve_xml_path(explicit_xml_path: str | None) -> str:
@@ -234,6 +256,26 @@ def migrate_0_5(legacy_account_id: str, account_id: str) -> None:
 @click.option("--prefix", default="djsupport", show_default=True, help="Prefix for Spotify playlist names.")
 @click.option("--no-prefix", is_flag=True, help="Disable playlist name prefix.")
 @click.option("--state-path", default=DEFAULT_PUBLICATION_MANIFEST_PATH, show_default=True, help="Path to durable publication manifests (compatible flag).")
+@click.option(
+    "--local-audio-identity", is_flag=True,
+    help="Opt into local audio identity for the selected Rekordbox Batch.",
+)
+@click.option(
+    "--json", "agent_json", is_flag=True,
+    help="Emit the versioned non-interactive agent contract.",
+)
+@click.option(
+    "--authorize-private-source", is_flag=True,
+    help="Explicitly authorize reading the selected XML and local audio.",
+)
+@click.option(
+    "--authorize-spotify-write", is_flag=True,
+    help="Explicitly authorize Spotify mutation for this Batch.",
+)
+@click.option(
+    "--confirm-expensive", is_flag=True,
+    help="Explicitly confirm whole-library or expensive work.",
+)
 def sync(
     xml_path: str | None,
     playlist: tuple[str, ...],
@@ -248,11 +290,39 @@ def sync(
     prefix: str,
     no_prefix: bool,
     state_path: str,
+    local_audio_identity: bool,
+    agent_json: bool,
+    authorize_private_source: bool,
+    authorize_spotify_write: bool,
+    confirm_expensive: bool,
 ):
     """Transfer explicitly selected Rekordbox playlists to Spotify.
 
     XML_PATH is the path to your Rekordbox XML library export (optional if configured via `library set`).
     """
+    if agent_json and not authorize_private_source:
+        click.echo(json.dumps({
+            "contract_version": 1,
+            "phase": "plan",
+            "status": "authorization_required",
+            "required_authorizations": ["private_source"],
+            "next_actions": ["authorize_private_source"],
+        }, sort_keys=True))
+        raise click.exceptions.Exit(2)
+    if agent_json and not dry_run and not authorize_spotify_write:
+        click.echo(json.dumps({
+            "contract_version": 1,
+            "phase": "execute",
+            "status": "authorization_required",
+            "required_authorizations": ["spotify_write"],
+            "next_actions": ["authorize_spotify_write"],
+        }, sort_keys=True))
+        raise click.exceptions.Exit(2)
+    if local_audio_identity and no_cache:
+        raise click.UsageError(
+            "Local audio identity requires durable matching knowledge; "
+            "remove --no-cache"
+        )
     xml_path = _resolve_xml_path(xml_path)
     if not playlist and not whole_library:
         raise click.UsageError(
@@ -275,6 +345,7 @@ def sync(
         SpotifyMatcher,
         Transfer,
     )
+    from djsupport.local_audio import ChromaprintLocalAudio
 
     cache = None if no_cache else MatchCache(cache_path)
     if cache is not None:
@@ -293,6 +364,7 @@ def sync(
         transfer_storage=FileTransferStorage(
             str(Path(state_path).with_suffix(".transfers.json"))
         ),
+        local_audio=(ChromaprintLocalAudio() if local_audio_identity else None),
     )
     request = BatchPlanRequest(
         playlist_references=playlist,
@@ -302,7 +374,25 @@ def sync(
         retry=retry,
         retry_days=retry_days,
         playlist_prefix=None if no_prefix else prefix,
+        confirm_expensive=confirm_expensive,
+        local_audio_identity=local_audio_identity,
     )
+    if agent_json:
+        from djsupport.agent import AgentAuthorization, AgentTransferContract
+
+        outcome = AgentTransferContract(transfer).execute_batch(
+            request,
+            AgentAuthorization(
+                private_source=authorize_private_source,
+                spotify_write=authorize_spotify_write,
+            ),
+        )
+        click.echo(json.dumps(outcome, sort_keys=True))
+        if outcome["status"] in {
+            "authorization_required", "confirmation_required",
+        }:
+            raise click.exceptions.Exit(2)
+        return
     plan = transfer.plan_batch(request)
     click.echo(
         f"Transfer plan: {plan.total_tracks} tracks; "
@@ -310,6 +400,14 @@ def sync(
         f"{plan.cache_hits} retained proposal hits; "
         f"{plan.expected_uncached_lookups} expected Spotify lookups."
     )
+    if plan.local_audio_identity:
+        click.echo(
+            "Local audio: "
+            f"{plan.local_audio_eligible} eligible; "
+            f"{plan.local_audio_indexed} indexed; "
+            f"{plan.local_audio_pending} calculations; "
+            f"{plan.local_audio_unavailable} unavailable."
+        )
     if plan.confirmation_required:
         if not click.confirm("This Batch may be expensive. Continue?"):
             raise click.Abort()

--- a/djsupport/cli.py
+++ b/djsupport/cli.py
@@ -42,7 +42,7 @@ def capabilities(as_json: bool) -> None:
     from djsupport.agent import capability_document
     from djsupport.local_audio import ChromaprintLocalAudio
 
-    document = capability_document(ChromaprintLocalAudio())
+    document = capability_document(ChromaprintLocalAudio().capability())
     if as_json:
         click.echo(json.dumps(document, sort_keys=True))
         return
@@ -59,7 +59,10 @@ def capabilities(as_json: bool) -> None:
 def _resolve_xml_path(explicit_xml_path: str | None) -> str:
     """Resolve Rekordbox XML path from explicit arg or saved local config."""
     if explicit_xml_path:
-        return explicit_xml_path
+        explicit = Path(explicit_xml_path).expanduser()
+        if not explicit.exists() or not explicit.is_file():
+            raise click.ClickException("Rekordbox XML path is missing or invalid.")
+        return str(explicit)
 
     cfg = ConfigManager()
     cfg.load()
@@ -237,7 +240,7 @@ def migrate_0_5(legacy_account_id: str, account_id: str) -> None:
 
 
 @cli.command()
-@click.argument("xml_path", required=False, type=click.Path(exists=True, dir_okay=False))
+@click.argument("xml_path", required=False, type=click.Path(dir_okay=False))
 @click.option(
     "--playlist", "-p", multiple=True,
     help="Select a playlist by exact name or path; repeat for a Batch.",
@@ -300,30 +303,6 @@ def sync(
 
     XML_PATH is the path to your Rekordbox XML library export (optional if configured via `library set`).
     """
-    if agent_json and not authorize_private_source:
-        click.echo(json.dumps({
-            "contract_version": 1,
-            "phase": "plan",
-            "status": "authorization_required",
-            "required_authorizations": ["private_source"],
-            "next_actions": ["authorize_private_source"],
-        }, sort_keys=True))
-        raise click.exceptions.Exit(2)
-    if agent_json and not dry_run and not authorize_spotify_write:
-        click.echo(json.dumps({
-            "contract_version": 1,
-            "phase": "execute",
-            "status": "authorization_required",
-            "required_authorizations": ["spotify_write"],
-            "next_actions": ["authorize_spotify_write"],
-        }, sort_keys=True))
-        raise click.exceptions.Exit(2)
-    if local_audio_identity and no_cache:
-        raise click.UsageError(
-            "Local audio identity requires durable matching knowledge; "
-            "remove --no-cache"
-        )
-    xml_path = _resolve_xml_path(xml_path)
     if not playlist and not whole_library:
         raise click.UsageError(
             "Select at least one playlist with --playlist or opt into "
@@ -344,15 +323,84 @@ def sync(
         RekordboxPlaylistSource,
         SpotifyMatcher,
         Transfer,
+        TransferAuthorization,
     )
     from djsupport.local_audio import ChromaprintLocalAudio
 
+    request = BatchPlanRequest(
+        playlist_references=playlist,
+        whole_library=whole_library,
+        threshold=threshold,
+        preview=dry_run,
+        retry=retry,
+        retry_days=retry_days,
+        playlist_prefix=None if no_prefix else prefix,
+        confirm_expensive=confirm_expensive,
+        local_audio_identity=local_audio_identity,
+    )
+    authorization = TransferAuthorization(
+        private_source=authorize_private_source,
+        spotify_write=authorize_spotify_write,
+    )
+    if agent_json:
+        from djsupport.agent import authorization_required_document
+
+        required = Transfer.authorization_requirement(
+            request, authorization, phase="plan",
+        )
+        if required:
+            click.echo(json.dumps(
+                authorization_required_document("plan", required), sort_keys=True,
+            ))
+            raise click.exceptions.Exit(2)
+    if local_audio_identity and no_cache:
+        if agent_json:
+            from djsupport.agent import error_document
+
+            click.echo(json.dumps(
+                error_document("plan", "durable_knowledge_required"), sort_keys=True,
+            ))
+            raise click.exceptions.Exit(2)
+        raise click.UsageError(
+            "Local audio identity requires durable matching knowledge; "
+            "remove --no-cache"
+        )
+    try:
+        xml_path = _resolve_xml_path(xml_path)
+    except (click.ClickException, OSError, ValueError) as exc:
+        if not agent_json:
+            raise
+        from djsupport.agent import error_document
+
+        click.echo(json.dumps(
+            error_document("plan", "private_source_unavailable"), sort_keys=True,
+        ))
+        raise click.exceptions.Exit(2) from exc
+
     cache = None if no_cache else MatchCache(cache_path)
-    if cache is not None:
-        cache.load()
+    try:
+        if cache is not None:
+            cache.load()
+    except (OSError, ValueError) as exc:
+        if not agent_json:
+            raise click.ClickException(str(exc)) from exc
+        from djsupport.agent import error_document
+
+        click.echo(json.dumps(
+            error_document("plan", "matching_knowledge_unavailable"), sort_keys=True,
+        ))
+        raise click.exceptions.Exit(2) from exc
+    execute_authorized = Transfer.authorization_requirement(
+        request, authorization, phase="execute",
+    ) is None
     transfer = Transfer(
-        source=RekordboxPlaylistSource(xml_path),
-        spotify=SpotifyMatcher(get_client()),
+        source=RekordboxPlaylistSource(
+            xml_path, include_locations=local_audio_identity,
+        ),
+        spotify=(
+            SpotifyMatcher(get_client())
+            if execute_authorized else object()
+        ),
         publishing_guards=AccountPublishingGuards(),
         matching_knowledge=(
             EphemeralMatchingKnowledge() if cache is None
@@ -366,31 +414,27 @@ def sync(
         ),
         local_audio=(ChromaprintLocalAudio() if local_audio_identity else None),
     )
-    request = BatchPlanRequest(
-        playlist_references=playlist,
-        whole_library=whole_library,
-        threshold=threshold,
-        preview=dry_run,
-        retry=retry,
-        retry_days=retry_days,
-        playlist_prefix=None if no_prefix else prefix,
-        confirm_expensive=confirm_expensive,
-        local_audio_identity=local_audio_identity,
-    )
     if agent_json:
-        from djsupport.agent import AgentAuthorization, AgentTransferContract
+        from djsupport.agent import AgentTransferContract
 
-        outcome = AgentTransferContract(transfer).execute_batch(
-            request,
-            AgentAuthorization(
-                private_source=authorize_private_source,
-                spotify_write=authorize_spotify_write,
-            ),
-        )
+        contract = AgentTransferContract(transfer)
+        try:
+            outcome = (
+                contract.execute_batch(request, authorization)
+                if execute_authorized
+                else contract.plan_batch(request, authorization)
+            )
+        except Exception:
+            from djsupport.agent import error_document
+
+            outcome = error_document(
+                "execute" if execute_authorized else "plan",
+                "transfer_failed",
+            )
         click.echo(json.dumps(outcome, sort_keys=True))
         if outcome["status"] in {
-            "authorization_required", "confirmation_required",
-        }:
+            "authorization_required", "confirmation_required", "error",
+        } or outcome.get("required_authorizations"):
             raise click.exceptions.Exit(2)
         return
     plan = transfer.plan_batch(request)

--- a/djsupport/cli.py
+++ b/djsupport/cli.py
@@ -240,7 +240,7 @@ def migrate_0_5(legacy_account_id: str, account_id: str) -> None:
 
 
 @cli.command()
-@click.argument("xml_path", required=False, type=click.Path(dir_okay=False))
+@click.argument("xml_path", required=False, type=click.Path())
 @click.option(
     "--playlist", "-p", multiple=True,
     help="Select a playlist by exact name or path; repeat for a Batch.",

--- a/djsupport/local_audio.py
+++ b/djsupport/local_audio.py
@@ -134,4 +134,3 @@ class ChromaprintLocalAudio:
         if not raw_path:
             return None
         return Path(raw_path)
-

--- a/djsupport/local_audio.py
+++ b/djsupport/local_audio.py
@@ -1,0 +1,137 @@
+"""Optional, local-only audio identity boundary for Rekordbox Transfers."""
+
+from __future__ import annotations
+
+import json
+import re
+import shutil
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Callable
+from urllib.parse import unquote, urlparse
+
+from djsupport.rekordbox import Track
+from djsupport.transfer import LocalAudioObservation
+
+
+@dataclass(frozen=True)
+class LocalAudioCapability:
+    available: bool
+    algorithm: str = "chromaprint"
+    algorithm_version: str | None = None
+    reason: str | None = None
+
+
+class ChromaprintLocalAudio:
+    """Calculate Chromaprint evidence without uploading or changing audio."""
+
+    def __init__(
+        self,
+        *,
+        executable: str | None = None,
+        runner: Callable = subprocess.run,
+        timeout: float = 30.0,
+    ) -> None:
+        self._explicit_executable = executable
+        self._runner = runner
+        self._timeout = timeout
+        self._capability: LocalAudioCapability | None = None
+
+    def capability(self) -> LocalAudioCapability:
+        """Inspect the optional binary without reading a library or audio file."""
+        if self._capability is not None:
+            return self._capability
+        executable = self._explicit_executable or shutil.which("fpcalc")
+        if executable is None:
+            self._capability = LocalAudioCapability(
+                available=False, reason="binary_unavailable",
+            )
+            return self._capability
+        try:
+            completed = self._runner(
+                [executable, "-version"], capture_output=True, text=True,
+                timeout=self._timeout, check=False,
+            )
+        except (OSError, subprocess.SubprocessError):
+            self._capability = LocalAudioCapability(
+                available=False, reason="binary_unavailable",
+            )
+            return self._capability
+        if completed.returncode != 0:
+            self._capability = LocalAudioCapability(
+                available=False, reason="binary_unavailable",
+            )
+            return self._capability
+        version_match = re.search(
+            r"(?:fpcalc\s+version\s+)?([0-9]+(?:\.[0-9]+)+)",
+            completed.stdout,
+        )
+        self._capability = LocalAudioCapability(
+            available=True,
+            algorithm_version=(version_match.group(1) if version_match else "unknown"),
+        )
+        return self._capability
+
+    def preflight(self, track: Track) -> str:
+        """Classify a reference without opening or calculating from the audio."""
+        path = self._path(track.location)
+        if path is None:
+            return "unsupported_location" if track.location else "missing_location"
+        return "eligible" if path.is_file() else "missing_file"
+
+    def observe(self, track: Track) -> LocalAudioObservation:
+        path = self._path(track.location)
+        if path is None:
+            return LocalAudioObservation.unavailable(
+                "unsupported_location" if track.location else "missing_location"
+            )
+        if not path.is_file():
+            return LocalAudioObservation.unavailable("missing_file")
+        capability = self.capability()
+        if not capability.available:
+            return LocalAudioObservation.unavailable(
+                capability.reason or "binary_unavailable"
+            )
+        executable = self._explicit_executable or shutil.which("fpcalc")
+        assert executable is not None
+        try:
+            completed = self._runner(
+                [executable, "-json", str(path)], capture_output=True, text=True,
+                timeout=self._timeout, check=False,
+            )
+        except subprocess.TimeoutExpired:
+            return LocalAudioObservation.unavailable("timeout")
+        except (OSError, subprocess.SubprocessError):
+            return LocalAudioObservation.unavailable("calculation_failed")
+        if completed.returncode != 0:
+            return LocalAudioObservation.unavailable("calculation_failed")
+        try:
+            payload = json.loads(completed.stdout)
+            fingerprint = payload["fingerprint"]
+            duration = int(float(payload.get("duration", track.duration)))
+        except (KeyError, TypeError, ValueError, json.JSONDecodeError):
+            return LocalAudioObservation.unavailable("invalid_output")
+        if not isinstance(fingerprint, str) or not fingerprint:
+            return LocalAudioObservation.unavailable("invalid_output")
+        return LocalAudioObservation.available(
+            fingerprint=fingerprint,
+            algorithm="chromaprint",
+            algorithm_version=capability.algorithm_version or "unknown",
+            duration=duration,
+        )
+
+    @staticmethod
+    def _path(location: str) -> Path | None:
+        if not location:
+            return None
+        parsed = urlparse(location)
+        if parsed.scheme and parsed.scheme != "file":
+            return None
+        if parsed.scheme == "file" and parsed.netloc not in ("", "localhost"):
+            return None
+        raw_path = unquote(parsed.path) if parsed.scheme else location
+        if not raw_path:
+            return None
+        return Path(raw_path)
+

--- a/djsupport/migration.py
+++ b/djsupport/migration.py
@@ -24,7 +24,7 @@ LEGACY_STATE_FILES = (
     ".djsupport_beatport_playlists.json",
 )
 MIGRATION_VERSION = 1
-MATCHING_KNOWLEDGE_VERSION = 1
+MATCHING_KNOWLEDGE_VERSION = 2
 SUPPORTED_PUBLICATION_VERSIONS = (1, 2, 3, 4, 5)
 SPOTIFY_TRACK_URI = re.compile(r"^spotify:track:[A-Za-z0-9]{22}$")
 CACHE_FIELDS = {
@@ -325,13 +325,20 @@ class LegacyMigration:
                 "version": MATCHING_KNOWLEDGE_VERSION, "entries": {},
                 "local_regressions": [],
                 "approval_conflicts": [],
+                "fingerprint_observations": {},
+                "fingerprint_associations": [],
             }
         data = json.loads(path.read_text())
         if (
-            data.get("version") != MATCHING_KNOWLEDGE_VERSION
+            data.get("version") not in (1, MATCHING_KNOWLEDGE_VERSION)
             or not isinstance(data.get("entries"), dict)
         ):
             raise ValueError("Current matching knowledge is unsupported or malformed")
+        data["version"] = MATCHING_KNOWLEDGE_VERSION
+        data.setdefault("local_regressions", [])
+        data.setdefault("approval_conflicts", [])
+        data.setdefault("fingerprint_observations", {})
+        data.setdefault("fingerprint_associations", [])
         return data
 
     def _read_migration_records(self) -> dict:

--- a/djsupport/rekordbox.py
+++ b/djsupport/rekordbox.py
@@ -30,7 +30,9 @@ class Playlist:
     track_ids: list[str] = field(default_factory=list)
 
 
-def parse_xml(xml_path: str | Path) -> tuple[dict[str, Track], list[Playlist]]:
+def parse_xml(
+    xml_path: str | Path, *, include_locations: bool = False,
+) -> tuple[dict[str, Track], list[Playlist]]:
     """Parse a Rekordbox XML export file.
 
     Returns:
@@ -56,7 +58,7 @@ def parse_xml(xml_path: str | Path) -> tuple[dict[str, Track], list[Playlist]]:
                 genre=track_el.get("Genre", ""),
                 date_added=track_el.get("DateAdded", ""),
                 duration=int(total_time) if total_time.isdigit() else 0,
-                location=track_el.get("Location", ""),
+                location=(track_el.get("Location", "") if include_locations else ""),
             )
 
     # Parse playlist tree

--- a/djsupport/rekordbox.py
+++ b/djsupport/rekordbox.py
@@ -16,6 +16,7 @@ class Track:
     genre: str
     date_added: str  # e.g. "2024-03-15"
     duration: int = 0  # seconds, from TotalTime attribute
+    location: str = ""  # private Rekordbox audio reference; never report this value
 
     @property
     def display(self) -> str:
@@ -55,6 +56,7 @@ def parse_xml(xml_path: str | Path) -> tuple[dict[str, Track], list[Playlist]]:
                 genre=track_el.get("Genre", ""),
                 date_added=track_el.get("DateAdded", ""),
                 duration=int(total_time) if total_time.isdigit() else 0,
+                location=track_el.get("Location", ""),
             )
 
     # Parse playlist tree

--- a/djsupport/report.py
+++ b/djsupport/report.py
@@ -113,6 +113,10 @@ class PlaylistReport:
     cache_hits: int = 0
     api_lookups: int = 0
     retried: int = 0
+    local_audio_eligible: int = 0
+    local_audio_observed: int = 0
+    local_audio_unavailable: int = 0
+    local_audio_reused: int = 0
 
     @property
     def total(self) -> int:
@@ -188,6 +192,16 @@ def print_report(report: SyncReport) -> None:
 
         if report.cache_enabled:
             click.echo(f"  Cache: {pl.cache_hits} hits | {pl.api_lookups} API | {pl.retried} retries")
+        if (
+            pl.local_audio_eligible or pl.local_audio_observed
+            or pl.local_audio_unavailable or pl.local_audio_reused
+        ):
+            click.echo(
+                f"  Local audio: {pl.local_audio_eligible} eligible"
+                f" | {pl.local_audio_observed} observed"
+                f" | {pl.local_audio_reused} Approved Match reuses"
+                f" | {pl.local_audio_unavailable} unavailable"
+            )
 
     click.echo()
     click.echo("\u2500" * 42)
@@ -382,6 +396,17 @@ def save_report(report: SyncReport, path: str) -> None:
             f"**Cache:** {total_cache} hits"
             f" | {total_api} API calls"
             f" | {total_retries} retries"
+        )
+    local_eligible = sum(p.local_audio_eligible for p in report.playlists)
+    local_observed = sum(p.local_audio_observed for p in report.playlists)
+    local_reused = sum(p.local_audio_reused for p in report.playlists)
+    local_unavailable = sum(p.local_audio_unavailable for p in report.playlists)
+    if local_eligible or local_observed or local_reused or local_unavailable:
+        lines.append(
+            f"**Local audio:** {local_eligible} eligible"
+            f" | {local_observed} observed"
+            f" | {local_reused} Approved Match reuses"
+            f" | {local_unavailable} unavailable"
         )
     lines.append("")
 

--- a/djsupport/transfer.py
+++ b/djsupport/transfer.py
@@ -57,7 +57,7 @@ from djsupport.spotify import (
 
 
 PUBLICATION_MANIFEST_VERSION = 5
-TRANSFER_STATE_VERSION = 2
+TRANSFER_STATE_VERSION = 3
 EXPENSIVE_BATCH_LOOKUP_THRESHOLD = 100
 SPOTIFY_TRACK_URI = re.compile(r"^spotify:track:([A-Za-z0-9]{22})$")
 SPOTIFY_TRACK_URL = re.compile(
@@ -109,6 +109,33 @@ class TransferRequest:
     mirror_disposition: MirrorDisposition | None = None
     mirror_playlist_id: str | None = None
     retain_matching_knowledge: bool = True
+    local_audio_identity: bool = False
+
+
+@dataclass(frozen=True)
+class LocalAudioObservation:
+    """One private local observation; values never enter reports or manifests."""
+
+    status: str
+    fingerprint: str | None = None
+    algorithm: str = "chromaprint"
+    algorithm_version: str = ""
+    duration: int = 0
+    reason: str | None = None
+
+    @classmethod
+    def available(
+        cls, *, fingerprint: str, algorithm: str,
+        algorithm_version: str, duration: int,
+    ) -> LocalAudioObservation:
+        return cls(
+            status="available", fingerprint=fingerprint, algorithm=algorithm,
+            algorithm_version=algorithm_version, duration=duration,
+        )
+
+    @classmethod
+    def unavailable(cls, reason: str) -> LocalAudioObservation:
+        return cls(status="unavailable", reason=reason)
 
 
 @dataclass(frozen=True)
@@ -123,6 +150,7 @@ class BatchPlanRequest:
     retry: bool = False
     retry_days: int = 7
     playlist_prefix: str | None = "djsupport"
+    local_audio_identity: bool = False
 
 
 @dataclass(frozen=True)
@@ -133,6 +161,10 @@ class PlaylistPreflight:
     approved_match_hits: int
     cache_hits: int
     expected_uncached_lookups: int
+    local_audio_eligible: int = 0
+    local_audio_indexed: int = 0
+    local_audio_pending: int = 0
+    local_audio_unavailable: int = 0
 
 
 @dataclass(frozen=True)
@@ -144,6 +176,7 @@ class BatchPlan:
     retry: bool = False
     retry_days: int = 7
     playlist_prefix: str | None = "djsupport"
+    local_audio_identity: bool = False
 
     @property
     def ready(self) -> bool:
@@ -166,6 +199,22 @@ class BatchPlan:
         return sum(
             playlist.expected_uncached_lookups for playlist in self.playlists
         )
+
+    @property
+    def local_audio_eligible(self) -> int:
+        return sum(item.local_audio_eligible for item in self.playlists)
+
+    @property
+    def local_audio_indexed(self) -> int:
+        return sum(item.local_audio_indexed for item in self.playlists)
+
+    @property
+    def local_audio_pending(self) -> int:
+        return sum(item.local_audio_pending for item in self.playlists)
+
+    @property
+    def local_audio_unavailable(self) -> int:
+        return sum(item.local_audio_unavailable for item in self.playlists)
 
 class TransferStatus(str, Enum):
     MATCHING = "matching"
@@ -241,6 +290,7 @@ class BatchState:
     retry: bool = False
     retry_days: int = 7
     playlist_prefix: str | None = "djsupport"
+    local_audio_identity: bool = False
 
     @classmethod
     def from_dict(cls, value: dict) -> BatchState:
@@ -252,6 +302,16 @@ class BatchState:
                 for playlist in value["playlists"]
             ],
         })
+
+
+@dataclass(frozen=True)
+class BatchProgress:
+    transfer_id: str
+    status: BatchStatus
+    playlists: int
+    completed: int
+    failed: int
+    pending: int
 
 
 class ApprovalStatus(str, Enum):
@@ -419,12 +479,21 @@ class TransferState:
     outcome: str | None = None
     mutation_snapshots: list[str] = field(default_factory=list)
     completed_chunks: list[str] = field(default_factory=list)
+    api_lookups: int = 0
+    local_audio_eligible: int = 0
+    local_audio_observed: int = 0
+    local_audio_unavailable: int = 0
+    local_audio_reused: int = 0
+    local_evidence_ids: dict[str, str] = field(default_factory=dict)
 
     @classmethod
     def from_dict(cls, value: dict) -> TransferState:
         return cls(**{
             "alternatives": [], "mutation_snapshots": [],
-            "completed_chunks": [], **value,
+            "completed_chunks": [], "api_lookups": 0,
+            "local_audio_eligible": 0, "local_audio_observed": 0,
+            "local_audio_unavailable": 0, "local_audio_reused": 0,
+            "local_evidence_ids": {}, **value,
             "status": TransferStatus(value["status"]),
         })
 
@@ -456,6 +525,7 @@ class PublicationItem:
     score_reasons: tuple[str, ...] = ()
     source_duration: int = 0
     authoritative: bool = False
+    local_evidence_id: str | None = None
 
 
 @dataclass(frozen=True)
@@ -779,7 +849,7 @@ class FileTransferStorage:
             data = json.loads(self.path.read_text())
         except (json.JSONDecodeError, OSError):
             return
-        if data.get("version") in (1, TRANSFER_STATE_VERSION):
+        if data.get("version") in (1, 2, TRANSFER_STATE_VERSION):
             for transfer_id, state in data.get("transfers", {}).items():
                 try:
                     self.transfers[transfer_id] = TransferState.from_dict(state)
@@ -1239,6 +1309,82 @@ class MatchCacheKnowledge:
             item.source_artist, item.source_title, item.source_duration,
         )
 
+    def revoke_local_audio(
+        self, item: PublicationItem, account_id: str,
+    ) -> None:
+        self._cache.revoke_fingerprints(
+            source_artist=item.source_artist,
+            source_title=item.source_title,
+            source_duration=item.source_duration,
+            evidence_id=item.local_evidence_id,
+            account_id=account_id,
+        )
+
+    def retain_local_audio(
+        self, track: Track, observation: LocalAudioObservation,
+    ) -> str:
+        assert observation.fingerprint is not None
+        return self._cache.retain_fingerprint_observation(
+            algorithm=observation.algorithm,
+            algorithm_version=observation.algorithm_version,
+            fingerprint=observation.fingerprint,
+            audio_duration=observation.duration,
+            source_track_id=track.track_id,
+        )
+
+    def lookup_local_audio(
+        self, observation: LocalAudioObservation, account_id: str,
+    ) -> dict | None:
+        if observation.status != "available" or observation.fingerprint is None:
+            return None
+        return self._cache.lookup_fingerprint(
+            algorithm=observation.algorithm,
+            algorithm_version=observation.algorithm_version,
+            fingerprint=observation.fingerprint,
+            account_id=account_id,
+        )
+
+    def approve_local_audio(
+        self, item: PublicationItem, account_id: str,
+    ) -> ApprovalConflict | None:
+        if item.local_evidence_id is None:
+            return None
+        conflict = self._cache.approve_fingerprint(
+            evidence_id=item.local_evidence_id,
+            account_id=account_id,
+            source_artist=item.source_artist,
+            source_title=item.source_title,
+            source_duration=item.source_duration,
+            result={
+                "uri": item.spotify_uri,
+                "name": item.spotify_name,
+                "artist": item.spotify_artist,
+                "score": item.score,
+                "match_type": item.match_type,
+                "score_reasons": list(item.score_reasons),
+            },
+        )
+        return ApprovalConflict(**conflict) if conflict else None
+
+    def has_local_audio_observation(self, track: Track) -> bool:
+        return any(
+            item.get("source_track_id") == track.track_id
+            for item in self._cache.fingerprint_observations.values()
+        )
+
+    def local_audio_observation(
+        self, evidence_id: str,
+    ) -> LocalAudioObservation | None:
+        item = self._cache.fingerprint_observation(evidence_id)
+        if item is None:
+            return None
+        return LocalAudioObservation.available(
+            fingerprint=item["fingerprint"],
+            algorithm=item["algorithm"],
+            algorithm_version=item["algorithm_version"],
+            duration=item["audio_duration"],
+        )
+
 
 class EphemeralMatchingKnowledge:
     """Non-persistent matching knowledge used for explicit ``--no-cache``."""
@@ -1285,6 +1431,7 @@ class Transfer:
         publication_storage: PublicationStorage | None = None,
         transfer_storage: TransferStorage | None = None,
         retry_policy: RetryPolicy | None = None,
+        local_audio=None,
     ) -> None:
         self._source = source
         self._spotify = spotify
@@ -1293,11 +1440,22 @@ class Transfer:
         self._publication_storage = publication_storage
         self._transfer_storage = transfer_storage
         self._retry_policy = retry_policy or RetryPolicy()
+        self._local_audio = local_audio
         self._pause_requested = False
 
     def pause(self) -> None:
         """Request a pause after the current track reaches a safe checkpoint."""
         self._pause_requested = True
+
+    def local_audio_capability(self):
+        """Inspect optional local identity support without consuming a source."""
+        if self._local_audio is None:
+            from djsupport.local_audio import LocalAudioCapability
+
+            return LocalAudioCapability(
+                available=False, reason="not_configured",
+            )
+        return self._local_audio.capability()
 
     def prepare(self, request: TransferRequest) -> str:
         """Durably reserve a Transfer ID before potentially slow source intake."""
@@ -1354,6 +1512,36 @@ class Transfer:
             ),
         )
 
+    def batch_progress(self, transfer_id: str) -> BatchProgress:
+        """Reload aggregate Batch progress without consuming its source."""
+        if self._transfer_storage is None:
+            raise ValueError("Progress requires durable Transfer storage")
+        batch = self._transfer_storage.load_batch(transfer_id)
+        if batch is None:
+            raise ValueError(f"Unknown Batch: {transfer_id}")
+        if (
+            batch.account_id is not None
+            and batch.account_id != self._spotify.account_id()
+        ):
+            raise ValueError("A Batch cannot be viewed under another Spotify account")
+        return BatchProgress(
+            transfer_id=transfer_id,
+            status=batch.status,
+            playlists=len(batch.playlists),
+            completed=sum(
+                item.outcome == PlaylistOutcome.COMPLETED
+                for item in batch.playlists
+            ),
+            failed=sum(
+                item.outcome == PlaylistOutcome.FAILED
+                for item in batch.playlists
+            ),
+            pending=sum(
+                item.outcome in (PlaylistOutcome.PENDING, PlaylistOutcome.SKIPPED)
+                for item in batch.playlists
+            ),
+        )
+
     @staticmethod
     def _stored_request(request: TransferRequest) -> dict:
         assert request.mode is not None
@@ -1374,10 +1562,18 @@ class Transfer:
             ),
             "mirror_playlist_id": request.mirror_playlist_id,
             "retain_matching_knowledge": request.retain_matching_knowledge,
+            "local_audio_identity": request.local_audio_identity,
         }
 
     def plan_batch(self, request: BatchPlanRequest) -> BatchPlan:
         """Plan an explicitly selected Rekordbox Batch without side effects."""
+        if request.local_audio_identity and not getattr(
+            self._knowledge, "persistent", True,
+        ):
+            raise ValueError(
+                "Local audio identity requires durable matching knowledge; "
+                "remove --no-cache"
+            )
         selections = self._source.consume_batch(
             request.playlist_references, request.whole_library,
         )
@@ -1386,6 +1582,10 @@ class Transfer:
             approved_match_hits = 0
             cache_hits = 0
             expected_uncached_lookups = 0
+            local_audio_eligible = 0
+            local_audio_indexed = 0
+            local_audio_pending = 0
+            local_audio_unavailable = 0
             for track in selection.tracks:
                 known = self._knowledge.lookup(track, request.threshold)
                 if known is not None and known.get("authoritative"):
@@ -1396,6 +1596,25 @@ class Transfer:
                     cache_hits += 1
                 else:
                     expected_uncached_lookups += 1
+                if request.local_audio_identity:
+                    status = (
+                        self._local_audio.preflight(track)
+                        if self._local_audio is not None else "not_configured"
+                    )
+                    if status == "eligible":
+                        local_audio_eligible += 1
+                        indexed = (
+                            self._knowledge.has_local_audio_observation(track)
+                            if hasattr(
+                                self._knowledge, "has_local_audio_observation"
+                            ) else False
+                        )
+                        if indexed:
+                            local_audio_indexed += 1
+                        else:
+                            local_audio_pending += 1
+                    else:
+                        local_audio_unavailable += 1
             playlists.append(PlaylistPreflight(
                 name=selection.name,
                 reference=selection.reference,
@@ -1403,6 +1622,10 @@ class Transfer:
                 approved_match_hits=approved_match_hits,
                 cache_hits=cache_hits,
                 expected_uncached_lookups=expected_uncached_lookups,
+                local_audio_eligible=local_audio_eligible,
+                local_audio_indexed=local_audio_indexed,
+                local_audio_pending=local_audio_pending,
+                local_audio_unavailable=local_audio_unavailable,
             ))
         expected_lookups = sum(
             playlist.expected_uncached_lookups for playlist in playlists
@@ -1421,6 +1644,7 @@ class Transfer:
             retry=request.retry,
             retry_days=request.retry_days,
             playlist_prefix=request.playlist_prefix,
+            local_audio_identity=request.local_audio_identity,
         )
 
     def execute_batch(
@@ -1490,6 +1714,7 @@ class Transfer:
                 retry=plan.retry,
                 retry_days=plan.retry_days,
                 playlist_prefix=plan.playlist_prefix,
+                local_audio_identity=plan.local_audio_identity,
                 playlists=[
                     BatchPlaylistState(
                         planned.name, planned.reference, f"{batch_id}:{index}",
@@ -1518,6 +1743,7 @@ class Transfer:
                     retry_days=batch.retry_days,
                     playlist_prefix=batch.playlist_prefix,
                     transfer_id=item.transfer_id,
+                    local_audio_identity=batch.local_audio_identity,
                 ))
             except Exception as exc:
                 if not self._is_shared_failure(exc) and not self._is_playlist_failure(exc):
@@ -1620,6 +1846,11 @@ class Transfer:
             return report
         report.matched = [MatchedTrack(**matched) for matched in state.matched]
         report.unmatched = list(state.unmatched)
+        report.api_lookups = state.api_lookups
+        report.local_audio_eligible = state.local_audio_eligible
+        report.local_audio_observed = state.local_audio_observed
+        report.local_audio_unavailable = state.local_audio_unavailable
+        report.local_audio_reused = state.local_audio_reused
         report.alternatives = [
             UnmatchedAlternatives(
                 source_track_id=alternative["source_track_id"],
@@ -1801,6 +2032,12 @@ class Transfer:
                         conflict = self._knowledge.approve(item)
                     if conflict is not None:
                         conflicts.append(conflict)
+                    if hasattr(self._knowledge, "approve_local_audio"):
+                        local_conflict = self._knowledge.approve_local_audio(
+                            item, account_id,
+                        )
+                        if local_conflict is not None:
+                            conflicts.append(local_conflict)
                 for item in outcome.rejected:
                     self._knowledge.reject(item)
                 if conflicts:
@@ -1993,6 +2230,13 @@ class Transfer:
         """
         if not request.preview and self._publication_storage is None:
             raise ValueError("Publishing Transfers require publication storage")
+        if request.local_audio_identity and not getattr(
+            self._knowledge, "persistent", True,
+        ):
+            raise ValueError(
+                "Local audio identity requires durable matching knowledge; "
+                "remove --no-cache"
+            )
 
         if request.mode is None:
             # Older internal/test adapters predate source-owned mode policy.
@@ -2192,6 +2436,11 @@ class Transfer:
         )
         playlist.matched = [MatchedTrack(**item) for item in state.matched]
         playlist.unmatched = list(state.unmatched)
+        playlist.api_lookups = state.api_lookups
+        playlist.local_audio_eligible = state.local_audio_eligible
+        playlist.local_audio_observed = state.local_audio_observed
+        playlist.local_audio_unavailable = state.local_audio_unavailable
+        playlist.local_audio_reused = state.local_audio_reused
         playlist.alternatives = [
             UnmatchedAlternatives(
                 source_track_id=item["source_track_id"],
@@ -2256,6 +2505,47 @@ class Transfer:
             for index in range(state.next_track_index, len(selection.tracks)):
                 track = selection.tracks[index]
                 result = self._knowledge.lookup(track, request.threshold)
+                local_evidence_id = None
+                if (
+                    request.local_audio_identity
+                    and self._local_audio is not None
+                    and not (result is not None and result.get("authoritative"))
+                ):
+                    evidence_key = str(index)
+                    local_evidence_id = state.local_evidence_ids.get(evidence_key)
+                    observation = (
+                        self._knowledge.local_audio_observation(local_evidence_id)
+                        if (
+                            local_evidence_id is not None
+                            and hasattr(
+                                self._knowledge, "local_audio_observation"
+                            )
+                        ) else None
+                    )
+                    if observation is None:
+                        observation = self._local_audio.observe(track)
+                    if observation.status == "available":
+                        playlist.local_audio_eligible += 1
+                        playlist.local_audio_observed += 1
+                        if (
+                            local_evidence_id is None
+                            and hasattr(self._knowledge, "retain_local_audio")
+                        ):
+                            local_evidence_id = self._knowledge.retain_local_audio(
+                                track, observation,
+                            )
+                            state.local_evidence_ids[evidence_key] = local_evidence_id
+                            self._knowledge.checkpoint()
+                            self._save_transfer(transfer_id, state)
+                        if hasattr(self._knowledge, "lookup_local_audio"):
+                            local_result = self._knowledge.lookup_local_audio(
+                                observation, self._spotify.account_id(),
+                            )
+                            if local_result is not None:
+                                result = local_result
+                                playlist.local_audio_reused += 1
+                    else:
+                        playlist.local_audio_unavailable += 1
                 if result is not None:
                     playlist.cache_hits += 1
                     if result.get("authoritative") and not self._approved_available(
@@ -2281,6 +2571,7 @@ class Transfer:
                             score_reasons=tuple(result.get("score_reasons", ())),
                             source_duration=track.duration,
                             authoritative=True,
+                            local_evidence_id=local_evidence_id,
                         ))
                         result = None
                 elif self._knowledge.should_retry(
@@ -2307,6 +2598,7 @@ class Transfer:
                             source_artist=track.artist,
                             source_title=track.name,
                             source_duration=track.duration,
+                            local_evidence_id=local_evidence_id,
                         ))
                     candidates = tuple(
                         AlternativeCandidate(
@@ -2355,9 +2647,15 @@ class Transfer:
                             score_reasons=matched_track.score_reasons,
                             source_duration=track.duration,
                             authoritative=bool(result.get("authoritative")),
+                            local_evidence_id=local_evidence_id,
                         ))
 
                 state.next_track_index = index + 1
+                state.api_lookups = playlist.api_lookups
+                state.local_audio_eligible = playlist.local_audio_eligible
+                state.local_audio_observed = playlist.local_audio_observed
+                state.local_audio_unavailable = playlist.local_audio_unavailable
+                state.local_audio_reused = playlist.local_audio_reused
                 state.matched = [asdict(item) for item in playlist.matched]
                 state.unmatched = list(playlist.unmatched)
                 state.alternatives = [asdict(item) for item in playlist.alternatives]
@@ -2495,6 +2793,10 @@ class Transfer:
                         ]
                         for item in revoked_items:
                             self._knowledge.revoke(item)
+                            if hasattr(self._knowledge, "revoke_local_audio"):
+                                self._knowledge.revoke_local_audio(
+                                    item, state.account_id,
+                                )
                         self._knowledge.checkpoint()
                         publication_items = [
                             item for item in publication_items

--- a/djsupport/transfer.py
+++ b/djsupport/transfer.py
@@ -154,6 +154,14 @@ class BatchPlanRequest:
 
 
 @dataclass(frozen=True)
+class TransferAuthorization:
+    """Explicit authority supplied by a client for one Transfer operation."""
+
+    private_source: bool = False
+    spotify_write: bool = False
+
+
+@dataclass(frozen=True)
 class PlaylistPreflight:
     name: str
     reference: str
@@ -165,6 +173,7 @@ class PlaylistPreflight:
     local_audio_indexed: int = 0
     local_audio_pending: int = 0
     local_audio_unavailable: int = 0
+    selection_token: str = ""
 
 
 @dataclass(frozen=True)
@@ -216,6 +225,23 @@ class BatchPlan:
     def local_audio_unavailable(self) -> int:
         return sum(item.local_audio_unavailable for item in self.playlists)
 
+    @property
+    def batch_id(self) -> str:
+        """Return a privacy-safe identity for the exact bounded plan."""
+        material = {
+            "selections": [
+                (item.reference, item.selection_token) for item in self.playlists
+            ],
+            "threshold": self.threshold,
+            "preview": self.preview,
+            "retry": self.retry,
+            "retry_days": self.retry_days,
+            "playlist_prefix": self.playlist_prefix,
+            "local_audio_identity": self.local_audio_identity,
+        }
+        canonical = json.dumps(material, sort_keys=True, separators=(",", ":"))
+        return hashlib.sha256(canonical.encode()).hexdigest()
+
 class TransferStatus(str, Enum):
     MATCHING = "matching"
     PAUSED = "paused"
@@ -235,6 +261,7 @@ class TransferProgress:
     total: int
     error: str | None = None
     retain_matching_knowledge: bool = True
+    local_audio_identity: bool = False
 
 
 class BatchPhase(str, Enum):
@@ -291,6 +318,7 @@ class BatchState:
     retry_days: int = 7
     playlist_prefix: str | None = "djsupport"
     local_audio_identity: bool = False
+    plan_id: str = ""
 
     @classmethod
     def from_dict(cls, value: dict) -> BatchState:
@@ -913,6 +941,30 @@ class MatchingKnowledge(Protocol):
 
     def revoke(self, item: PublicationItem) -> None: ...
 
+    def retain_local_audio(
+        self, track: Track, observation: LocalAudioObservation,
+    ) -> str: ...
+
+    def lookup_local_audio(
+        self, observation: LocalAudioObservation, account_id: str,
+    ) -> dict | None: ...
+
+    def approve_local_audio(
+        self, item: PublicationItem, account_id: str,
+    ) -> ApprovalConflict | None: ...
+
+    def revoke_local_audio(
+        self, item: PublicationItem, account_id: str,
+    ) -> None: ...
+
+    def has_local_audio_observation(
+        self, track: Track, algorithm: str, algorithm_version: str,
+    ) -> bool: ...
+
+    def local_audio_observation(
+        self, evidence_id: str,
+    ) -> LocalAudioObservation | None: ...
+
 
 class BeatportChartSource:
     """Production source adapter for one Beatport chart."""
@@ -976,13 +1028,18 @@ class RekordboxPlaylistSource:
     source_label = "Rekordbox"
     default_mode = TransferMode.MIRROR
 
-    def __init__(self, xml_path: str | Path) -> None:
+    def __init__(
+        self, xml_path: str | Path, *, include_locations: bool = False,
+    ) -> None:
         self._xml_path = Path(xml_path)
+        self._include_locations = include_locations
 
     def consume(self, reference: str) -> SourceSelection:
         from djsupport.rekordbox import parse_xml
 
-        tracks, playlists = parse_xml(self._xml_path)
+        tracks, playlists = parse_xml(
+            self._xml_path, include_locations=self._include_locations,
+        )
         return self._select(tracks, playlists, reference)
 
     @staticmethod
@@ -1025,7 +1082,9 @@ class RekordboxPlaylistSource:
             raise ValueError("A Batch cannot contain a duplicate playlist reference")
         from djsupport.rekordbox import parse_xml
 
-        tracks, playlists = parse_xml(self._xml_path)
+        tracks, playlists = parse_xml(
+            self._xml_path, include_locations=self._include_locations,
+        )
         selected_references = (
             tuple(playlist.path for playlist in playlists)
             if whole_library else references
@@ -1366,9 +1425,13 @@ class MatchCacheKnowledge:
         )
         return ApprovalConflict(**conflict) if conflict else None
 
-    def has_local_audio_observation(self, track: Track) -> bool:
+    def has_local_audio_observation(
+        self, track: Track, algorithm: str, algorithm_version: str,
+    ) -> bool:
         return any(
             item.get("source_track_id") == track.track_id
+            and item.get("algorithm") == algorithm
+            and item.get("algorithm_version") == algorithm_version
             for item in self._cache.fingerprint_observations.values()
         )
 
@@ -1417,6 +1480,36 @@ class EphemeralMatchingKnowledge:
     def revoke(self, item: PublicationItem) -> None:
         pass
 
+    def retain_local_audio(
+        self, track: Track, observation: LocalAudioObservation,
+    ) -> str:
+        raise ValueError("Local audio identity requires durable matching knowledge")
+
+    def lookup_local_audio(
+        self, observation: LocalAudioObservation, account_id: str,
+    ) -> dict | None:
+        return None
+
+    def approve_local_audio(
+        self, item: PublicationItem, account_id: str,
+    ) -> ApprovalConflict | None:
+        return None
+
+    def revoke_local_audio(
+        self, item: PublicationItem, account_id: str,
+    ) -> None:
+        pass
+
+    def has_local_audio_observation(
+        self, track: Track, algorithm: str, algorithm_version: str,
+    ) -> bool:
+        return False
+
+    def local_audio_observation(
+        self, evidence_id: str,
+    ) -> LocalAudioObservation | None:
+        return None
+
 
 class Transfer:
     """Coordinate a Transfer through source, Spotify, and storage seams."""
@@ -1442,6 +1535,34 @@ class Transfer:
         self._retry_policy = retry_policy or RetryPolicy()
         self._local_audio = local_audio
         self._pause_requested = False
+
+    @staticmethod
+    def private_source_authorization_requirement(
+        authorization: TransferAuthorization,
+    ) -> str | None:
+        """Own the policy for access to private source material."""
+        return None if authorization.private_source else "private_source"
+
+    @staticmethod
+    def authorization_requirement(
+        request: BatchPlanRequest,
+        authorization: TransferAuthorization,
+        *,
+        phase: str,
+    ) -> str | None:
+        """Return the next missing authority; adapters only render the result."""
+        private_required = Transfer.private_source_authorization_requirement(
+            authorization,
+        )
+        if private_required:
+            return private_required
+        if (
+            phase == "execute"
+            and not request.preview
+            and not authorization.spotify_write
+        ):
+            return "spotify_write"
+        return None
 
     def pause(self) -> None:
         """Request a pause after the current track reaches a safe checkpoint."""
@@ -1510,6 +1631,7 @@ class Transfer:
             retain_matching_knowledge=state.request.get(
                 "retain_matching_knowledge", True,
             ),
+            local_audio_identity=state.request.get("local_audio_identity", False),
         )
 
     def batch_progress(self, transfer_id: str) -> BatchProgress:
@@ -1565,6 +1687,24 @@ class Transfer:
             "local_audio_identity": request.local_audio_identity,
         }
 
+    @staticmethod
+    def _stored_track(track: Track, *, include_location: bool) -> dict:
+        """Serialize a track without touching its private location by default."""
+        stored = {
+            "track_id": track.track_id,
+            "name": track.name,
+            "artist": track.artist,
+            "album": track.album,
+            "remixer": track.remixer,
+            "label": track.label,
+            "genre": track.genre,
+            "date_added": track.date_added,
+            "duration": track.duration,
+        }
+        if include_location:
+            stored["location"] = track.location
+        return stored
+
     def plan_batch(self, request: BatchPlanRequest) -> BatchPlan:
         """Plan an explicitly selected Rekordbox Batch without side effects."""
         if request.local_audio_identity and not getattr(
@@ -1577,8 +1717,20 @@ class Transfer:
         selections = self._source.consume_batch(
             request.playlist_references, request.whole_library,
         )
+        local_capability = (
+            self.local_audio_capability() if request.local_audio_identity else None
+        )
         playlists = []
         for selection in selections:
+            selection_material = [
+                self._stored_track(
+                    track, include_location=request.local_audio_identity,
+                )
+                for track in selection.tracks
+            ]
+            selection_token = hashlib.sha256(json.dumps(
+                selection_material, sort_keys=True, separators=(",", ":"),
+            ).encode()).hexdigest()
             approved_match_hits = 0
             cache_hits = 0
             expected_uncached_lookups = 0
@@ -1597,17 +1749,15 @@ class Transfer:
                 else:
                     expected_uncached_lookups += 1
                 if request.local_audio_identity:
-                    status = (
-                        self._local_audio.preflight(track)
-                        if self._local_audio is not None else "not_configured"
-                    )
+                    status = "not_configured"
+                    if local_capability is not None and local_capability.available:
+                        status = self._local_audio.preflight(track)
                     if status == "eligible":
                         local_audio_eligible += 1
-                        indexed = (
-                            self._knowledge.has_local_audio_observation(track)
-                            if hasattr(
-                                self._knowledge, "has_local_audio_observation"
-                            ) else False
+                        indexed = self._knowledge.has_local_audio_observation(
+                            track,
+                            local_capability.algorithm,
+                            local_capability.algorithm_version or "unknown",
                         )
                         if indexed:
                             local_audio_indexed += 1
@@ -1626,6 +1776,7 @@ class Transfer:
                 local_audio_indexed=local_audio_indexed,
                 local_audio_pending=local_audio_pending,
                 local_audio_unavailable=local_audio_unavailable,
+                selection_token=selection_token,
             ))
         expected_lookups = sum(
             playlist.expected_uncached_lookups for playlist in playlists
@@ -1715,6 +1866,7 @@ class Transfer:
                 retry_days=plan.retry_days,
                 playlist_prefix=plan.playlist_prefix,
                 local_audio_identity=plan.local_audio_identity,
+                plan_id=plan.batch_id,
                 playlists=[
                     BatchPlaylistState(
                         planned.name, planned.reference, f"{batch_id}:{index}",
@@ -1723,10 +1875,16 @@ class Transfer:
                 ],
             )
             self._transfer_storage.save_batch(batch_id, batch)
+        elif batch.plan_id and batch.plan_id != plan.batch_id:
+            raise ValueError("A resumed Batch must use its original plan")
         elif [item.reference for item in batch.playlists] != [
             item.reference for item in plan.playlists
         ]:
             raise ValueError("A resumed Batch must use its original plan")
+        elif not batch.plan_id:
+            raise ValueError(
+                "A legacy Batch without a bounded plan identity must be restarted"
+            )
         return batch
 
     def _execute_batch(self, batch_id: str, batch: BatchState) -> SyncReport:
@@ -2032,7 +2190,7 @@ class Transfer:
                         conflict = self._knowledge.approve(item)
                     if conflict is not None:
                         conflicts.append(conflict)
-                    if hasattr(self._knowledge, "approve_local_audio"):
+                    if item.local_evidence_id is not None:
                         local_conflict = self._knowledge.approve_local_audio(
                             item, account_id,
                         )
@@ -2368,7 +2526,13 @@ class Transfer:
                 selection={
                     "name": selection.name,
                     "reference": selection.reference,
-                    "tracks": [asdict(track) for track in selection.tracks],
+                    "tracks": [
+                        self._stored_track(
+                            track,
+                            include_location=request.local_audio_identity,
+                        )
+                        for track in selection.tracks
+                    ],
                     "chart_title": selection.chart_title,
                     "curator": selection.curator,
                 },
@@ -2515,35 +2679,26 @@ class Transfer:
                     local_evidence_id = state.local_evidence_ids.get(evidence_key)
                     observation = (
                         self._knowledge.local_audio_observation(local_evidence_id)
-                        if (
-                            local_evidence_id is not None
-                            and hasattr(
-                                self._knowledge, "local_audio_observation"
-                            )
-                        ) else None
+                        if local_evidence_id is not None else None
                     )
                     if observation is None:
                         observation = self._local_audio.observe(track)
                     if observation.status == "available":
                         playlist.local_audio_eligible += 1
                         playlist.local_audio_observed += 1
-                        if (
-                            local_evidence_id is None
-                            and hasattr(self._knowledge, "retain_local_audio")
-                        ):
+                        if local_evidence_id is None:
                             local_evidence_id = self._knowledge.retain_local_audio(
                                 track, observation,
                             )
                             state.local_evidence_ids[evidence_key] = local_evidence_id
                             self._knowledge.checkpoint()
                             self._save_transfer(transfer_id, state)
-                        if hasattr(self._knowledge, "lookup_local_audio"):
-                            local_result = self._knowledge.lookup_local_audio(
-                                observation, self._spotify.account_id(),
-                            )
-                            if local_result is not None:
-                                result = local_result
-                                playlist.local_audio_reused += 1
+                        local_result = self._knowledge.lookup_local_audio(
+                            observation, self._spotify.account_id(),
+                        )
+                        if local_result is not None:
+                            result = local_result
+                            playlist.local_audio_reused += 1
                     else:
                         playlist.local_audio_unavailable += 1
                 if result is not None:
@@ -2793,7 +2948,7 @@ class Transfer:
                         ]
                         for item in revoked_items:
                             self._knowledge.revoke(item)
-                            if hasattr(self._knowledge, "revoke_local_audio"):
+                            if item.local_evidence_id is not None:
                                 self._knowledge.revoke_local_audio(
                                     item, state.account_id,
                                 )

--- a/djsupport/transfer.py
+++ b/djsupport/transfer.py
@@ -1551,18 +1551,33 @@ class Transfer:
         phase: str,
     ) -> str | None:
         """Return the next missing authority; adapters only render the result."""
+        if phase == "plan":
+            return Transfer.private_source_authorization_requirement(authorization)
+        required = Transfer.required_authorizations(
+            request, authorization, phase=phase,
+        )
+        return required[0] if required else None
+
+    @staticmethod
+    def required_authorizations(
+        request: BatchPlanRequest,
+        authorization: TransferAuthorization,
+        *,
+        phase: str,
+    ) -> tuple[str, ...]:
+        """Return all missing authorities for a bounded Transfer phase."""
         private_required = Transfer.private_source_authorization_requirement(
             authorization,
         )
         if private_required:
-            return private_required
+            return (private_required,)
         if (
-            phase == "execute"
+            phase in {"plan", "execute"}
             and not request.preview
             and not authorization.spotify_write
         ):
-            return "spotify_write"
-        return None
+            return ("spotify_write",)
+        return ()
 
     def pause(self) -> None:
         """Request a pause after the current track reaches a safe checkpoint."""

--- a/djsupport/web.py
+++ b/djsupport/web.py
@@ -14,7 +14,12 @@ from urllib.parse import urlparse
 from uuid import uuid4
 
 from fastapi import FastAPI, HTTPException
-from fastapi.responses import HTMLResponse, RedirectResponse, StreamingResponse
+from fastapi.responses import (
+    HTMLResponse,
+    JSONResponse,
+    RedirectResponse,
+    StreamingResponse,
+)
 from fastapi.staticfiles import StaticFiles
 from pydantic import BaseModel, Field
 from spotipy.oauth2 import SpotifyOAuth
@@ -297,7 +302,7 @@ def create_app(
 
     def rekordbox_contract(
         request: RekordboxBatchRequest, *, execute: bool,
-    ) -> dict:
+    ) -> dict | JSONResponse:
         from djsupport.agent import (
             AgentTransferContract,
             authorization_required_document,
@@ -309,7 +314,9 @@ def create_app(
             plan_request, authorization, phase="plan",
         )
         if required:
-            return authorization_required_document("plan", required)
+            return authorization_required_document(
+                "execute" if execute else "plan", required,
+            )
         if request.local_audio_identity and request.no_cache:
             return error_document("plan", "durable_knowledge_required")
         execute_authorized = (
@@ -318,12 +325,20 @@ def create_app(
             ) is None
         )
         if execute and execute_authorized:
-            require_authenticated()
+            try:
+                require_authenticated()
+            except HTTPException as exc:
+                return JSONResponse(
+                    status_code=exc.status_code,
+                    content=error_document(
+                        "execute", "spotify_authentication_required",
+                    ),
+                )
         try:
             contract = AgentTransferContract(make_rekordbox_transfer(
                 request, execute and execute_authorized,
             ))
-            if execute and execute_authorized:
+            if execute:
                 return contract.execute_batch(plan_request, authorization)
             return contract.plan_batch(plan_request, authorization)
         except Exception:

--- a/djsupport/web.py
+++ b/djsupport/web.py
@@ -149,6 +149,13 @@ def create_app(
             ),
         ), progress
 
+    @web_app.get("/capabilities")
+    def capabilities():
+        from djsupport.agent import capability_document
+        from djsupport.local_audio import ChromaprintLocalAudio
+
+        return capability_document(ChromaprintLocalAudio())
+
     @web_app.get("/auth/status")
     def auth_status():
         mgr = oauth_manager()
@@ -298,6 +305,10 @@ def _report_to_dict(report: SyncReport) -> dict[str, Any]:
             "cache_hits": playlist.cache_hits,
             "api_lookups": playlist.api_lookups,
             "retried": playlist.retried,
+            "local_audio_eligible": playlist.local_audio_eligible,
+            "local_audio_observed": playlist.local_audio_observed,
+            "local_audio_unavailable": playlist.local_audio_unavailable,
+            "local_audio_reused": playlist.local_audio_reused,
         })
     return {
         "timestamp": report.timestamp.isoformat(),

--- a/djsupport/web.py
+++ b/djsupport/web.py
@@ -56,6 +56,7 @@ class SyncRequest(BaseModel):
     retry: bool = False
     retry_days: int = 7
     no_cache: bool = False
+    local_audio_identity: bool = False
 
 
 def _auth_manager() -> SpotifyOAuth:
@@ -84,6 +85,7 @@ def _url_error() -> str:
 
 def _default_transfer_factory(url_type: str, request: SyncRequest) -> Transfer:
     from djsupport.cache import MatchCache
+    from djsupport.local_audio import ChromaprintLocalAudio
     from djsupport.spotify import get_client
 
     cache = None if request.no_cache else MatchCache(default_matching_knowledge_path())
@@ -102,6 +104,9 @@ def _default_transfer_factory(url_type: str, request: SyncRequest) -> Transfer:
         ),
         transfer_storage=FileTransferStorage(
             publication_path.with_suffix(".transfers.json")
+        ),
+        local_audio=(
+            ChromaprintLocalAudio() if request.local_audio_identity else None
         ),
     )
 
@@ -146,6 +151,7 @@ def create_app(
             request or SyncRequest(
                 url=progress.source,
                 no_cache=not progress.retain_matching_knowledge,
+                local_audio_identity=progress.local_audio_identity,
             ),
         ), progress
 
@@ -154,7 +160,7 @@ def create_app(
         from djsupport.agent import capability_document
         from djsupport.local_audio import ChromaprintLocalAudio
 
-        return capability_document(ChromaprintLocalAudio())
+        return capability_document(ChromaprintLocalAudio().capability())
 
     @web_app.get("/auth/status")
     def auth_status():
@@ -191,6 +197,11 @@ def create_app(
             url_type = _detect_url_type(request.url)
         except ValueError as exc:
             raise HTTPException(status_code=400, detail=str(exc)) from exc
+        if request.local_audio_identity and request.no_cache:
+            raise HTTPException(
+                status_code=400,
+                detail="Local audio identity requires durable matching knowledge",
+            )
         require_authenticated()
         transfer_id = uuid4().hex
         transfer = make_transfer(url_type, request)
@@ -204,6 +215,7 @@ def create_app(
             playlist_prefix=request.prefix,
             transfer_id=transfer_id,
             retain_matching_knowledge=not request.no_cache,
+            local_audio_identity=request.local_audio_identity,
         )
         transfer.prepare(transfer_request)
         run_background(_run_transfer, (transfer, transfer_request))
@@ -242,6 +254,7 @@ def create_app(
                 source=progress.source,
                 transfer_id=transfer_id,
                 retain_matching_knowledge=progress.retain_matching_knowledge,
+                local_audio_identity=progress.local_audio_identity,
             )
             transfer.prepare(resume_request)
             run_background(
@@ -259,6 +272,7 @@ def create_app(
             raise HTTPException(status_code=202, detail="Transfer still in progress")
         report = transfer.execute(TransferRequest(
             source=progress.source, transfer_id=transfer_id,
+            local_audio_identity=progress.local_audio_identity,
         ))
         return _report_to_dict(report)
 
@@ -321,6 +335,18 @@ def _report_to_dict(report: SyncReport) -> dict[str, Any]:
         "total_matched": report.total_matched,
         "total_unmatched": report.total_unmatched,
         "overall_match_rate": report.overall_match_rate,
+        "local_audio_eligible": sum(
+            playlist.local_audio_eligible for playlist in report.playlists
+        ),
+        "local_audio_observed": sum(
+            playlist.local_audio_observed for playlist in report.playlists
+        ),
+        "local_audio_unavailable": sum(
+            playlist.local_audio_unavailable for playlist in report.playlists
+        ),
+        "local_audio_reused": sum(
+            playlist.local_audio_reused for playlist in report.playlists
+        ),
     }
 
 

--- a/djsupport/web.py
+++ b/djsupport/web.py
@@ -16,21 +16,24 @@ from uuid import uuid4
 from fastapi import FastAPI, HTTPException
 from fastapi.responses import HTMLResponse, RedirectResponse, StreamingResponse
 from fastapi.staticfiles import StaticFiles
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 from spotipy.oauth2 import SpotifyOAuth
 
 from djsupport.report import SyncReport
 from djsupport.spotify import SCOPES
 from djsupport.transfer import (
     AccountPublishingGuards,
+    BatchPlanRequest,
     BeatportChartSource,
     BeatportLabelSource,
     EphemeralMatchingKnowledge,
     FilePublicationStorage,
     FileTransferStorage,
     MatchCacheKnowledge,
+    RekordboxPlaylistSource,
     SpotifyMatcher,
     Transfer,
+    TransferAuthorization,
     TransferMode,
     TransferRequest,
     default_matching_knowledge_path,
@@ -56,7 +59,24 @@ class SyncRequest(BaseModel):
     retry: bool = False
     retry_days: int = 7
     no_cache: bool = False
+
+
+class RekordboxBatchRequest(BaseModel):
+    """Private, explicitly bounded Rekordbox request for the local web API."""
+
+    xml_path: str
+    playlists: list[str] = Field(default_factory=list)
+    whole_library: bool = False
+    threshold: int = 80
+    preview: bool = False
+    retry: bool = False
+    retry_days: int = 7
+    prefix: str | None = "djsupport"
+    no_cache: bool = False
     local_audio_identity: bool = False
+    confirm_expensive: bool = False
+    authorize_private_source: bool = False
+    authorize_spotify_write: bool = False
 
 
 def _auth_manager() -> SpotifyOAuth:
@@ -85,7 +105,6 @@ def _url_error() -> str:
 
 def _default_transfer_factory(url_type: str, request: SyncRequest) -> Transfer:
     from djsupport.cache import MatchCache
-    from djsupport.local_audio import ChromaprintLocalAudio
     from djsupport.spotify import get_client
 
     cache = None if request.no_cache else MatchCache(default_matching_knowledge_path())
@@ -105,6 +124,41 @@ def _default_transfer_factory(url_type: str, request: SyncRequest) -> Transfer:
         transfer_storage=FileTransferStorage(
             publication_path.with_suffix(".transfers.json")
         ),
+    )
+
+
+def _default_rekordbox_transfer_factory(
+    request: RekordboxBatchRequest, execute_authorized: bool,
+) -> Transfer:
+    from djsupport.cache import MatchCache
+    from djsupport.local_audio import ChromaprintLocalAudio
+    from djsupport.spotify import get_client
+
+    cache = None if request.no_cache else MatchCache(
+        default_matching_knowledge_path(),
+    )
+    if cache is not None:
+        cache.load()
+    publication_path = default_publication_manifest_path()
+    return Transfer(
+        source=RekordboxPlaylistSource(
+            request.xml_path,
+            include_locations=request.local_audio_identity,
+        ),
+        spotify=(
+            SpotifyMatcher(get_client()) if execute_authorized else object()
+        ),
+        publishing_guards=AccountPublishingGuards(),
+        matching_knowledge=(
+            EphemeralMatchingKnowledge()
+            if cache is None else MatchCacheKnowledge(cache)
+        ),
+        publication_storage=(
+            None if request.preview else FilePublicationStorage(publication_path)
+        ),
+        transfer_storage=FileTransferStorage(
+            publication_path.with_suffix(".transfers.json")
+        ),
         local_audio=(
             ChromaprintLocalAudio() if request.local_audio_identity else None
         ),
@@ -118,6 +172,9 @@ def _thread_runner(target: Callable, args: tuple) -> None:
 def create_app(
     *,
     transfer_factory: Callable[[str, SyncRequest], Transfer] | None = None,
+    rekordbox_transfer_factory: Callable[
+        [RekordboxBatchRequest, bool], Transfer
+    ] | None = None,
     auth_manager: Callable[[], SpotifyOAuth] | None = None,
     background_runner: Callable[[Callable, tuple], None] | None = None,
 ) -> FastAPI:
@@ -125,6 +182,9 @@ def create_app(
     web_app = FastAPI(title="djsupport", lifespan=lifespan)
     web_app.mount("/static", StaticFiles(directory=str(STATIC_DIR)), name="static")
     make_transfer = transfer_factory or _default_transfer_factory
+    make_rekordbox_transfer = (
+        rekordbox_transfer_factory or _default_rekordbox_transfer_factory
+    )
     run_background = background_runner or _thread_runner
 
     def oauth_manager():
@@ -151,7 +211,6 @@ def create_app(
             request or SyncRequest(
                 url=progress.source,
                 no_cache=not progress.retain_matching_knowledge,
-                local_audio_identity=progress.local_audio_identity,
             ),
         ), progress
 
@@ -197,11 +256,6 @@ def create_app(
             url_type = _detect_url_type(request.url)
         except ValueError as exc:
             raise HTTPException(status_code=400, detail=str(exc)) from exc
-        if request.local_audio_identity and request.no_cache:
-            raise HTTPException(
-                status_code=400,
-                detail="Local audio identity requires durable matching knowledge",
-            )
         require_authenticated()
         transfer_id = uuid4().hex
         transfer = make_transfer(url_type, request)
@@ -215,7 +269,6 @@ def create_app(
             playlist_prefix=request.prefix,
             transfer_id=transfer_id,
             retain_matching_knowledge=not request.no_cache,
-            local_audio_identity=request.local_audio_identity,
         )
         transfer.prepare(transfer_request)
         run_background(_run_transfer, (transfer, transfer_request))
@@ -223,6 +276,69 @@ def create_app(
             "transfer_id": transfer_id,
             "url_type": url_type,
         }
+
+    def rekordbox_request(
+        request: RekordboxBatchRequest,
+    ) -> tuple[BatchPlanRequest, TransferAuthorization]:
+        return BatchPlanRequest(
+            playlist_references=tuple(request.playlists),
+            whole_library=request.whole_library,
+            threshold=request.threshold,
+            preview=request.preview,
+            retry=request.retry,
+            retry_days=request.retry_days,
+            playlist_prefix=request.prefix,
+            local_audio_identity=request.local_audio_identity,
+            confirm_expensive=request.confirm_expensive,
+        ), TransferAuthorization(
+            private_source=request.authorize_private_source,
+            spotify_write=request.authorize_spotify_write,
+        )
+
+    def rekordbox_contract(
+        request: RekordboxBatchRequest, *, execute: bool,
+    ) -> dict:
+        from djsupport.agent import (
+            AgentTransferContract,
+            authorization_required_document,
+            error_document,
+        )
+
+        plan_request, authorization = rekordbox_request(request)
+        required = Transfer.authorization_requirement(
+            plan_request, authorization, phase="plan",
+        )
+        if required:
+            return authorization_required_document("plan", required)
+        if request.local_audio_identity and request.no_cache:
+            return error_document("plan", "durable_knowledge_required")
+        execute_authorized = (
+            Transfer.authorization_requirement(
+                plan_request, authorization, phase="execute",
+            ) is None
+        )
+        if execute and execute_authorized:
+            require_authenticated()
+        try:
+            contract = AgentTransferContract(make_rekordbox_transfer(
+                request, execute and execute_authorized,
+            ))
+            if execute and execute_authorized:
+                return contract.execute_batch(plan_request, authorization)
+            return contract.plan_batch(plan_request, authorization)
+        except Exception:
+            return error_document(
+                "execute" if execute and execute_authorized else "plan",
+                "transfer_failed",
+            )
+
+    @web_app.post("/rekordbox/batches/plan")
+    def plan_rekordbox_batch(request: RekordboxBatchRequest):
+        return rekordbox_contract(request, execute=False)
+
+    @web_app.post("/rekordbox/batches/execute")
+    def execute_rekordbox_batch(request: RekordboxBatchRequest):
+        return rekordbox_contract(request, execute=True)
 
     @web_app.get("/sync/{transfer_id}/progress")
     async def sync_progress(transfer_id: str):
@@ -254,7 +370,6 @@ def create_app(
                 source=progress.source,
                 transfer_id=transfer_id,
                 retain_matching_knowledge=progress.retain_matching_knowledge,
-                local_audio_identity=progress.local_audio_identity,
             )
             transfer.prepare(resume_request)
             run_background(
@@ -272,7 +387,6 @@ def create_app(
             raise HTTPException(status_code=202, detail="Transfer still in progress")
         report = transfer.execute(TransferRequest(
             source=progress.source, transfer_id=transfer_id,
-            local_audio_identity=progress.local_audio_identity,
         ))
         return _report_to_dict(report)
 

--- a/docs/adr/0002-make-transfer-agent-native.md
+++ b/docs/adr/0002-make-transfer-agent-native.md
@@ -30,6 +30,13 @@ and permitted next actions. They do not expose source paths, playlist or track
 contents, raw XML metadata, fingerprints, subprocess output, credentials, or
 Spotify account identifiers.
 
+Transfer derives the Batch identifier from the exact selected source content
+and requested effect scope, then hashes that private material before returning
+the identifier. Confirmation does not alter identity. A changed source,
+Preview/publication mode, matching policy, or local-audio opt-in cannot resume
+an earlier Batch. Legacy checkpoints without this bounded identity remain
+readable for inspection but must be restarted rather than resumed ambiguously.
+
 Opt-in local audio identity is the first end-to-end proof of this decision. An
 agent can detect Chromaprint support, plan one selected Rekordbox Batch, obtain
 separate authority, and run or resume the Transfer through the same policy used

--- a/docs/adr/0002-make-transfer-agent-native.md
+++ b/docs/adr/0002-make-transfer-agent-native.md
@@ -1,0 +1,42 @@
+# Make Transfer agent-native without creating agent authority
+
+AI coding harnesses such as Codex are a primary operating surface for DJ
+Support. They need a stable way to inspect the installation, plan bounded work,
+execute or resume it, and explain the result. Treating a harness as an
+incidental shell wrapper would encourage prompt scraping, hidden interactive
+questions, duplicated policy, and accidental expansion of private-file or
+Spotify authority.
+
+DJ Support therefore treats AI harnesses as first-class clients of the public
+Transfer contract. Every agent flow follows five explicit phases: capability
+inspection, bounded Batch planning, authorization, execute or resume, and a
+structured outcome. Transfer remains the only policy authority. CLI, web, and
+future harness adapters may render its behavior but may not create separate
+matching, Approval, persistence, or publication rules.
+
+Capability inspection is side-effect free and does not read a Rekordbox XML
+file, audio, matching knowledge, or Spotify account. Planning requires explicit
+private-source authorization and cannot broaden an explicitly selected Batch.
+Spotify mutation requires a separate explicit authorization. Conversation,
+ambient browser state, previous sessions, or an agent's judgment are never
+authority. Missing authorization produces a versioned
+`authorization_required` outcome before the gated effect; once all required
+inputs are present, execution is non-interactive.
+
+Machine-readable capability, plan, progress, and outcome records are versioned,
+idempotent, and privacy-redacted by construction. They may expose aggregate
+counts, lifecycle states, stable Transfer or Batch identifiers, reason codes,
+and permitted next actions. They do not expose source paths, playlist or track
+contents, raw XML metadata, fingerprints, subprocess output, credentials, or
+Spotify account identifiers.
+
+Opt-in local audio identity is the first end-to-end proof of this decision. An
+agent can detect Chromaprint support, plan one selected Rekordbox Batch, obtain
+separate authority, and run or resume the Transfer through the same policy used
+by human-facing clients. The fingerprint remains private evidence and cannot
+create Approval. An exact account-scoped fingerprint may reuse an already
+Approved Match; similar evidence remains non-authoritative.
+
+This decision does not require a proprietary harness, an MCP server, a hosted
+agent service, conversational authorization inference, or an agent-specific
+policy engine. Those may be evaluated later as adapters over the same contract.

--- a/docs/backup-and-restore.md
+++ b/docs/backup-and-restore.md
@@ -5,6 +5,13 @@ It includes matching knowledge, Transfer and publication state, migration
 records, and privacy-screened reports. Credentials and unrelated files are not
 included.
 
+Matching-knowledge schema 2 includes private local-audio observations and
+account-scoped Approved Match associations. Transfer-state schema 3 includes
+the opt-in and completed evidence checkpoint handles. Both are backed up and
+restored as private application data. Conflicting local-audio authority requires
+an explicit restore choice identified by a privacy-safe hashed label; reports
+and archive manifests do not print fingerprints or source paths.
+
 Restore is preview-first:
 
 ```bash

--- a/docs/upgrading.md
+++ b/docs/upgrading.md
@@ -6,8 +6,11 @@ The first write after installing the local-audio identity release upgrades
 matching knowledge to schema 2 and Transfer state to schema 3. Matching schema
 1 and Transfer schemas 1–2 remain readable. Create a local-data backup first if
 you want a recovery point. The upgrade retains Approved Matches, Corrections,
-publication history, and resumable work; new fingerprint evidence remains in
-private application data and is never added to Git or generated reports.
+publication history, and current resumable work; a legacy Batch without a
+content-bound plan identity must be restarted so changed private source content
+cannot resume stale work. New fingerprint evidence remains in private
+application data and is never added to Git or generated reports. Unsupported
+matching-knowledge schemas are rejected without rewriting the private file.
 
 ## From 0.3.0
 

--- a/docs/upgrading.md
+++ b/docs/upgrading.md
@@ -1,5 +1,14 @@
 # Upgrading DJ Support
 
+## Matching knowledge and Transfer state
+
+The first write after installing the local-audio identity release upgrades
+matching knowledge to schema 2 and Transfer state to schema 3. Matching schema
+1 and Transfer schemas 1–2 remain readable. Create a local-data backup first if
+you want a recovery point. The upgrade retains Approved Matches, Corrections,
+publication history, and resumable work; new fingerprint evidence remains in
+private application data and is never added to Git or generated reports.
+
 ## From 0.3.0
 
 DJ Support does not migrate working-directory data automatically. Keep the old

--- a/tests/test_agent_cli.py
+++ b/tests/test_agent_cli.py
@@ -53,6 +53,49 @@ def test_sync_json_requires_explicit_private_source_authorization(monkeypatch):
     }
 
 
+def test_authorized_publish_returns_bounded_plan_before_spotify_write_authority(
+    monkeypatch, tmp_path,
+):
+    monkeypatch.setattr(
+        "djsupport.cli.get_client",
+        lambda: (_ for _ in ()).throw(AssertionError("Spotify must stay untouched")),
+    )
+
+    result = CliRunner().invoke(cli, [
+        "sync", "tests/fixtures/library.xml",
+        "--playlist", "My Playlists/Peak Time",
+        "--json", "--authorize-private-source",
+        "--cache-path", str(tmp_path / "knowledge.json"),
+        "--state-path", str(tmp_path / "publications.json"),
+    ])
+
+    assert result.exit_code == 2
+    plan = json.loads(result.output)
+    assert plan["phase"] == "plan"
+    assert plan["status"] == "ready"
+    assert plan["required_authorizations"] == ["spotify_write"]
+    assert len(plan["batch_id"]) == 64
+
+
+def test_json_source_error_is_structured_and_does_not_echo_private_path(tmp_path):
+    private_path = tmp_path / "private-library-name.xml"
+
+    result = CliRunner().invoke(cli, [
+        "sync", str(private_path), "--playlist", "Selected",
+        "--dry-run", "--json", "--authorize-private-source",
+    ])
+
+    assert result.exit_code == 2
+    assert json.loads(result.output) == {
+        "contract_version": 1,
+        "phase": "plan",
+        "status": "error",
+        "error": {"code": "private_source_unavailable"},
+        "next_actions": ["inspect_private_source"],
+    }
+    assert "private-library-name" not in result.output
+
+
 def test_authorized_sync_json_returns_only_structured_outcome(
     monkeypatch, tmp_path,
 ):

--- a/tests/test_agent_cli.py
+++ b/tests/test_agent_cli.py
@@ -96,6 +96,22 @@ def test_json_source_error_is_structured_and_does_not_echo_private_path(tmp_path
     assert "private-library-name" not in result.output
 
 
+def test_json_directory_source_error_cannot_bypass_the_redacted_contract(tmp_path):
+    private_directory = tmp_path / "private-library-directory"
+    private_directory.mkdir()
+
+    result = CliRunner().invoke(cli, [
+        "sync", str(private_directory), "--playlist", "Selected",
+        "--dry-run", "--json", "--authorize-private-source",
+    ])
+
+    assert result.exit_code == 2
+    assert json.loads(result.output)["error"]["code"] == (
+        "private_source_unavailable"
+    )
+    assert "private-library-directory" not in result.output
+
+
 def test_authorized_sync_json_returns_only_structured_outcome(
     monkeypatch, tmp_path,
 ):

--- a/tests/test_agent_cli.py
+++ b/tests/test_agent_cli.py
@@ -1,0 +1,105 @@
+"""Thin CLI mapping for the harness-neutral agent contract."""
+
+import json
+
+from click.testing import CliRunner
+
+from djsupport.cli import cli
+
+
+def test_capabilities_json_does_not_require_xml_or_spotify(monkeypatch):
+    monkeypatch.setattr("djsupport.local_audio.shutil.which", lambda name: None)
+
+    result = CliRunner().invoke(cli, ["capabilities", "--json"])
+
+    assert result.exit_code == 0
+    assert json.loads(result.output) == {
+        "contract_version": 1,
+        "phase": "capability",
+        "status": "ready",
+        "capabilities": {
+            "local_audio_identity": {
+                "available": False,
+                "algorithm": "chromaprint",
+                "algorithm_version": None,
+                "reason": "binary_unavailable",
+            },
+        },
+        "next_actions": ["plan"],
+    }
+
+
+def test_sync_json_requires_explicit_private_source_authorization(monkeypatch):
+    monkeypatch.setattr(
+        "djsupport.cli.get_client",
+        lambda: (_ for _ in ()).throw(AssertionError("Spotify must stay untouched")),
+    )
+
+    result = CliRunner().invoke(cli, [
+        "sync",
+        "tests/fixtures/library.xml",
+        "--playlist", "My Playlists/Peak Time",
+        "--dry-run",
+        "--json",
+    ])
+
+    assert result.exit_code == 2
+    assert json.loads(result.output) == {
+        "contract_version": 1,
+        "phase": "plan",
+        "status": "authorization_required",
+        "required_authorizations": ["private_source"],
+        "next_actions": ["authorize_private_source"],
+    }
+
+
+def test_authorized_sync_json_returns_only_structured_outcome(
+    monkeypatch, tmp_path,
+):
+    class Spotify:
+        def account_id(self):
+            return "spotify-account-one"
+
+        def match(self, track, threshold):
+            return {
+                "uri": f"spotify:track:{track.track_id}",
+                "name": "Synthetic Result",
+                "artist": "Synthetic Artist",
+                "score": 95.0,
+                "match_type": "exact",
+            }
+
+    spotify = Spotify()
+    monkeypatch.setattr("djsupport.cli.get_client", lambda: object())
+    monkeypatch.setattr(
+        "djsupport.transfer.SpotifyMatcher", lambda client: spotify,
+    )
+
+    result = CliRunner().invoke(cli, [
+        "sync",
+        "tests/fixtures/library.xml",
+        "--playlist", "My Playlists/Peak Time",
+        "--dry-run",
+        "--json",
+        "--authorize-private-source",
+        "--cache-path", str(tmp_path / "knowledge.json"),
+        "--state-path", str(tmp_path / "publications.json"),
+    ])
+
+    assert result.exit_code == 0, result.output
+    outcome = json.loads(result.output)
+    assert outcome["contract_version"] == 1
+    assert outcome["phase"] == "outcome"
+    assert outcome["status"] == "completed"
+    assert outcome["counts"] == {
+        "playlists": 1,
+        "matched": 2,
+        "unmatched": 0,
+        "spotify_api_lookups": 2,
+        "local_audio_eligible": 0,
+        "local_audio_observed": 0,
+        "local_audio_unavailable": 0,
+        "local_audio_reused": 0,
+    }
+    assert "My Playlists" not in result.output
+    assert "Solomun" not in result.output

--- a/tests/test_agent_contract.py
+++ b/tests/test_agent_contract.py
@@ -2,12 +2,15 @@
 
 import json
 
+import pytest
+
 from djsupport.agent import AgentAuthorization, AgentTransferContract
 from djsupport.local_audio import LocalAudioCapability
 from djsupport.rekordbox import Track
 from djsupport.transfer import (
     AccountPublishingGuards,
     BatchPlanRequest,
+    FilePublicationStorage,
     FileTransferStorage,
     SourceSelection,
     Transfer,
@@ -78,10 +81,14 @@ def test_capability_inspection_is_versioned_and_side_effect_free(tmp_path):
 
 
 class BoundedSource(UntouchedSource):
+    def __init__(self):
+        super().__init__()
+        self.title = "Invented Signal"
+
     def selection(self, reference):
         return SourceSelection("Private Playlist", reference, [Track(
             track_id="synthetic-1",
-            name="Invented Signal",
+            name=self.title,
             artist="Invented Artist",
             album="",
             remixer="",
@@ -196,6 +203,24 @@ def test_expensive_confirmation_does_not_change_batch_identity(tmp_path):
     assert before["batch_id"] == confirmed["batch_id"]
 
 
+def test_source_content_change_creates_a_new_bounded_batch_identity(tmp_path):
+    source = BoundedSource()
+    contract = AgentTransferContract(Transfer(
+        source=source,
+        spotify=UntouchedSpotify(),
+        matching_knowledge=EmptyKnowledge(),
+        publishing_guards=AccountPublishingGuards(tmp_path / "locks"),
+    ))
+    request = BatchPlanRequest(playlist_references=("Private/Selection",))
+    authorization = AgentAuthorization(private_source=True)
+
+    before = contract.plan_batch(request, authorization)
+    source.title = "Changed Source Content"
+    after = contract.plan_batch(request, authorization)
+
+    assert before["batch_id"] != after["batch_id"]
+
+
 def test_private_read_authorization_does_not_authorize_spotify_mutation(tmp_path):
     source = BoundedSource()
     spotify = UntouchedSpotify()
@@ -288,3 +313,25 @@ def test_authorized_preview_executes_non_interactively_and_is_idempotent(tmp_pat
     rendered = json.dumps(first)
     assert "Private" not in rendered
     assert "Invented" not in rendered
+
+
+def test_resume_rejects_a_request_that_changes_the_original_effect_scope(tmp_path):
+    storage = FileTransferStorage(tmp_path / "transfers.json")
+    transfer = Transfer(
+        source=BoundedSource(),
+        spotify=PreviewSpotify(),
+        matching_knowledge=EmptyKnowledge(),
+        publishing_guards=AccountPublishingGuards(tmp_path / "locks"),
+        publication_storage=FilePublicationStorage(tmp_path / "publications.json"),
+        transfer_storage=storage,
+    )
+    preview = transfer.plan_batch(BatchPlanRequest(
+        playlist_references=("Private/Selection",), preview=True,
+    ))
+    completed = transfer.execute_batch(preview, transfer_id=preview.batch_id)
+    publishing = transfer.plan_batch(BatchPlanRequest(
+        playlist_references=("Private/Selection",), preview=False,
+    ))
+
+    with pytest.raises(ValueError, match="original plan"):
+        transfer.execute_batch(publishing, transfer_id=completed.transfer_id)

--- a/tests/test_agent_contract.py
+++ b/tests/test_agent_contract.py
@@ -4,7 +4,11 @@ import json
 
 import pytest
 
-from djsupport.agent import AgentAuthorization, AgentTransferContract
+from djsupport.agent import (
+    AgentAuthorization,
+    AgentTransferContract,
+    error_document,
+)
 from djsupport.local_audio import LocalAudioCapability
 from djsupport.rekordbox import Track
 from djsupport.transfer import (
@@ -26,6 +30,18 @@ class UntouchedSource:
     def consume(self, reference):
         self.calls += 1
         raise AssertionError("capability inspection must not read the source")
+
+
+def test_machine_error_next_actions_are_specific_to_the_failure():
+    assert error_document(
+        "plan", "durable_knowledge_required",
+    )["next_actions"] == ["enable_durable_knowledge"]
+    assert error_document(
+        "plan", "matching_knowledge_unavailable",
+    )["next_actions"] == ["repair_matching_knowledge"]
+    assert error_document(
+        "execute", "transfer_failed",
+    )["next_actions"] == ["inspect_transfer_status"]
 
 
 class UntouchedSpotify:

--- a/tests/test_agent_contract.py
+++ b/tests/test_agent_contract.py
@@ -42,6 +42,9 @@ def test_machine_error_next_actions_are_specific_to_the_failure():
     assert error_document(
         "execute", "transfer_failed",
     )["next_actions"] == ["inspect_transfer_status"]
+    assert error_document(
+        "execute", "spotify_authentication_required",
+    )["next_actions"] == ["authenticate_spotify"]
 
 
 class UntouchedSpotify:

--- a/tests/test_agent_contract.py
+++ b/tests/test_agent_contract.py
@@ -1,0 +1,290 @@
+"""Versioned, harness-neutral contract tests for AI agent clients."""
+
+import json
+
+from djsupport.agent import AgentAuthorization, AgentTransferContract
+from djsupport.local_audio import LocalAudioCapability
+from djsupport.rekordbox import Track
+from djsupport.transfer import (
+    AccountPublishingGuards,
+    BatchPlanRequest,
+    FileTransferStorage,
+    SourceSelection,
+    Transfer,
+)
+
+
+class UntouchedSource:
+    source_label = "Rekordbox"
+
+    def __init__(self) -> None:
+        self.calls = 0
+
+    def consume(self, reference):
+        self.calls += 1
+        raise AssertionError("capability inspection must not read the source")
+
+
+class UntouchedSpotify:
+    def __init__(self) -> None:
+        self.calls = 0
+
+    def account_id(self):
+        self.calls += 1
+        raise AssertionError("capability inspection must not contact Spotify")
+
+
+class UntouchedKnowledge:
+    persistent = True
+
+
+class AvailableLocalAudio:
+    def capability(self):
+        return LocalAudioCapability(
+            available=True,
+            algorithm="chromaprint",
+            algorithm_version="1.6.1",
+        )
+
+
+def test_capability_inspection_is_versioned_and_side_effect_free(tmp_path):
+    source = UntouchedSource()
+    spotify = UntouchedSpotify()
+    contract = AgentTransferContract(Transfer(
+        source=source,
+        spotify=spotify,
+        matching_knowledge=UntouchedKnowledge(),
+        publishing_guards=AccountPublishingGuards(tmp_path / "locks"),
+        local_audio=AvailableLocalAudio(),
+    ))
+
+    result = contract.capabilities()
+
+    assert result == {
+        "contract_version": 1,
+        "phase": "capability",
+        "status": "ready",
+        "capabilities": {
+            "local_audio_identity": {
+                "available": True,
+                "algorithm": "chromaprint",
+                "algorithm_version": "1.6.1",
+            },
+        },
+        "next_actions": ["plan"],
+    }
+    assert source.calls == 0
+    assert spotify.calls == 0
+
+
+class BoundedSource(UntouchedSource):
+    def selection(self, reference):
+        return SourceSelection("Private Playlist", reference, [Track(
+            track_id="synthetic-1",
+            name="Invented Signal",
+            artist="Invented Artist",
+            album="",
+            remixer="",
+            label="",
+            genre="",
+            date_added="",
+            duration=180,
+        )])
+
+    def consume(self, reference):
+        self.calls += 1
+        return self.selection(reference)
+
+    def consume_batch(self, references, whole_library):
+        self.calls += 1
+        return (self.selection(references[0]),)
+
+
+class EmptyKnowledge(UntouchedKnowledge):
+    def __init__(self):
+        self.retained = []
+
+    def lookup(self, track, threshold):
+        return None
+
+    def should_retry(self, track, threshold, retry_days, force):
+        return True
+
+    def retain(self, track, threshold, result):
+        self.retained.append(result)
+
+    def checkpoint(self):
+        pass
+
+
+def test_batch_plan_requires_explicit_private_source_authorization(tmp_path):
+    source = BoundedSource()
+    contract = AgentTransferContract(Transfer(
+        source=source,
+        spotify=UntouchedSpotify(),
+        matching_knowledge=EmptyKnowledge(),
+        publishing_guards=AccountPublishingGuards(tmp_path / "locks"),
+    ))
+    request = BatchPlanRequest(playlist_references=("Private/Selection",))
+
+    blocked = contract.plan_batch(request, AgentAuthorization())
+
+    assert blocked == {
+        "contract_version": 1,
+        "phase": "plan",
+        "status": "authorization_required",
+        "required_authorizations": ["private_source"],
+        "next_actions": ["authorize_private_source"],
+    }
+    assert source.calls == 0
+
+
+def test_authorized_plan_is_stable_bounded_and_privacy_redacted(tmp_path):
+    source = BoundedSource()
+    contract = AgentTransferContract(Transfer(
+        source=source,
+        spotify=UntouchedSpotify(),
+        matching_knowledge=EmptyKnowledge(),
+        publishing_guards=AccountPublishingGuards(tmp_path / "locks"),
+    ))
+    request = BatchPlanRequest(playlist_references=("Private/Selection",))
+    authorization = AgentAuthorization(private_source=True)
+
+    first = contract.plan_batch(request, authorization)
+    second = contract.plan_batch(request, authorization)
+
+    assert first == second
+    assert first["contract_version"] == 1
+    assert first["phase"] == "plan"
+    assert first["status"] == "ready"
+    assert len(first["batch_id"]) == 64
+    assert first["counts"] == {
+        "playlists": 1,
+        "tracks": 1,
+        "approved_match_hits": 0,
+        "retained_proposal_hits": 0,
+        "expected_spotify_lookups": 1,
+        "local_audio_eligible": 0,
+        "local_audio_indexed": 0,
+        "local_audio_pending": 0,
+        "local_audio_unavailable": 0,
+    }
+    assert first["required_authorizations"] == ["spotify_write"]
+    assert first["next_actions"] == ["authorize_spotify_write", "execute"]
+    rendered = json.dumps(first)
+    assert "Private" not in rendered
+    assert "Invented" not in rendered
+
+
+def test_expensive_confirmation_does_not_change_batch_identity(tmp_path):
+    contract = AgentTransferContract(Transfer(
+        source=BoundedSource(),
+        spotify=UntouchedSpotify(),
+        matching_knowledge=EmptyKnowledge(),
+        publishing_guards=AccountPublishingGuards(tmp_path / "locks"),
+    ))
+    authorization = AgentAuthorization(private_source=True)
+
+    before = contract.plan_batch(BatchPlanRequest(
+        playlist_references=("Private/Selection",),
+    ), authorization)
+    confirmed = contract.plan_batch(BatchPlanRequest(
+        playlist_references=("Private/Selection",),
+        confirm_expensive=True,
+    ), authorization)
+
+    assert before["batch_id"] == confirmed["batch_id"]
+
+
+def test_private_read_authorization_does_not_authorize_spotify_mutation(tmp_path):
+    source = BoundedSource()
+    spotify = UntouchedSpotify()
+    contract = AgentTransferContract(Transfer(
+        source=source,
+        spotify=spotify,
+        matching_knowledge=EmptyKnowledge(),
+        publishing_guards=AccountPublishingGuards(tmp_path / "locks"),
+    ))
+    request = BatchPlanRequest(playlist_references=("Private/Selection",))
+
+    blocked = contract.execute_batch(
+        request, AgentAuthorization(private_source=True),
+    )
+
+    assert blocked["contract_version"] == 1
+    assert blocked["phase"] == "execute"
+    assert blocked["status"] == "authorization_required"
+    assert blocked["required_authorizations"] == ["spotify_write"]
+    assert blocked["next_actions"] == ["authorize_spotify_write"]
+    assert spotify.calls == 0
+
+
+class PreviewSpotify:
+    def __init__(self):
+        self.searches = 0
+
+    def account_id(self):
+        return "spotify-account-one"
+
+    def match(self, track, threshold):
+        self.searches += 1
+        return {
+            "uri": "spotify:track:synthetic",
+            "name": "Invented Signal",
+            "artist": "Invented Artist",
+            "score": 96.0,
+            "match_type": "exact",
+        }
+
+
+def test_authorized_preview_executes_non_interactively_and_is_idempotent(tmp_path):
+    spotify = PreviewSpotify()
+    contract = AgentTransferContract(Transfer(
+        source=BoundedSource(),
+        spotify=spotify,
+        matching_knowledge=EmptyKnowledge(),
+        publishing_guards=AccountPublishingGuards(tmp_path / "locks"),
+        transfer_storage=FileTransferStorage(tmp_path / "transfers.json"),
+    ))
+    request = BatchPlanRequest(
+        playlist_references=("Private/Selection",), preview=True,
+    )
+    authorization = AgentAuthorization(private_source=True)
+
+    first = contract.execute_batch(request, authorization)
+    repeated = contract.execute_batch(request, authorization)
+    progress = contract.progress(first["transfer_id"], authorization)
+
+    assert first == repeated
+    assert first["contract_version"] == 1
+    assert first["phase"] == "outcome"
+    assert first["status"] == "completed"
+    assert first["transfer_id"] == first["batch_id"]
+    assert first["counts"] == {
+        "playlists": 1,
+        "matched": 1,
+        "unmatched": 0,
+        "spotify_api_lookups": 1,
+        "local_audio_eligible": 0,
+        "local_audio_observed": 0,
+        "local_audio_unavailable": 0,
+        "local_audio_reused": 0,
+    }
+    assert first["next_actions"] == ["review"]
+    assert spotify.searches == 1
+    assert progress == {
+        "contract_version": 1,
+        "phase": "progress",
+        "status": "completed",
+        "transfer_id": first["transfer_id"],
+        "counts": {
+            "playlists": 1,
+            "completed": 1,
+            "failed": 0,
+            "pending": 0,
+        },
+        "next_actions": ["review"],
+    }
+    rendered = json.dumps(first)
+    assert "Private" not in rendered
+    assert "Invented" not in rendered

--- a/tests/test_backup.py
+++ b/tests/test_backup.py
@@ -193,6 +193,43 @@ class TestRestore:
             "incoming": {"spotify_uri": "new"},
         }
 
+    def test_merges_private_local_audio_identity_knowledge(self, tmp_path):
+        source = tmp_path / "source"
+        target = tmp_path / "target"
+        incoming_observation = {
+            "algorithm": "chromaprint",
+            "algorithm_version": "1.6.1",
+            "fingerprint": "invented-incoming-evidence",
+        }
+        incoming_association = {
+            **incoming_observation,
+            "account_id": "spotify-account-one",
+            "spotify_uri": "spotify:track:incoming",
+            "authority_status": "approved",
+        }
+        _write_json(source / "matching-knowledge.json", {
+            "version": 2,
+            "entries": {},
+            "fingerprint_observations": {"incoming-id": incoming_observation},
+            "fingerprint_associations": [incoming_association],
+        })
+        _write_json(target / "matching-knowledge.json", {
+            "version": 2,
+            "entries": {},
+            "fingerprint_observations": {},
+            "fingerprint_associations": [],
+        })
+        archive = LocalDataBackup(source).create(tmp_path / "backups")
+
+        result = LocalDataBackup(target).restore(archive)
+
+        assert result.restored is True
+        stored = json.loads((target / "matching-knowledge.json").read_text())
+        assert stored["fingerprint_observations"] == {
+            "incoming-id": incoming_observation,
+        }
+        assert stored["fingerprint_associations"] == [incoming_association]
+
     @pytest.mark.parametrize("kind", ["approval", "playlist-state"])
     def test_conflicts_require_resolution_and_leave_current_data_intact(self, tmp_path, kind):
         source = tmp_path / "source"

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -42,12 +42,15 @@ class TestMatchCacheLoad:
         c.load()
         assert len(c.entries) == 0
 
-    def test_load_wrong_version_is_noop(self, tmp_path):
+    def test_load_wrong_version_is_rejected_before_private_data_can_be_overwritten(
+        self, tmp_path,
+    ):
         p = tmp_path / "cache.json"
         p.write_text(json.dumps({"version": 999, "entries": {}}))
         c = MatchCache(path=str(p))
-        c.load()
-        assert len(c.entries) == 0
+        with pytest.raises(ValueError, match="Unsupported matching-knowledge schema"):
+            c.load()
+        assert json.loads(p.read_text())["version"] == 999
 
     def test_roundtrip_save_and_load(self, tmp_path):
         path = str(tmp_path / "cache.json")

--- a/tests/test_local_audio_adapter.py
+++ b/tests/test_local_audio_adapter.py
@@ -1,0 +1,76 @@
+"""Contract tests for the optional local Chromaprint boundary."""
+
+import json
+from types import SimpleNamespace
+
+from djsupport.local_audio import ChromaprintLocalAudio
+from djsupport.rekordbox import Track
+
+
+def _track(location: str) -> Track:
+    return Track(
+        track_id="synthetic-1",
+        name="Invented Signal",
+        artist="Invented Artist",
+        album="",
+        remixer="",
+        label="",
+        genre="",
+        date_added="",
+        duration=181,
+        location=location,
+    )
+
+
+def test_capability_and_observation_use_only_the_selected_audio_reference(tmp_path):
+    audio = tmp_path / "selected.wav"
+    audio.write_bytes(b"synthetic-not-real-audio")
+    commands = []
+
+    def run(command, **kwargs):
+        commands.append(command)
+        if "-version" in command:
+            return SimpleNamespace(
+                returncode=0, stdout="fpcalc version 1.6.1\n", stderr="",
+            )
+        return SimpleNamespace(
+            returncode=0,
+            stdout=json.dumps({
+                "duration": 181.25,
+                "fingerprint": "invented-fingerprint-value",
+            }),
+            stderr="",
+        )
+
+    adapter = ChromaprintLocalAudio(executable="fpcalc", runner=run)
+
+    capability = adapter.capability()
+    observation = adapter.observe(_track(audio.as_uri()))
+
+    assert capability.available is True
+    assert capability.algorithm == "chromaprint"
+    assert capability.algorithm_version == "1.6.1"
+    assert observation.status == "available"
+    assert observation.fingerprint == "invented-fingerprint-value"
+    assert observation.duration == 181
+    assert commands == [
+        ["fpcalc", "-version"],
+        ["fpcalc", "-json", str(audio)],
+    ]
+
+
+def test_unavailable_observation_never_exposes_the_private_location(tmp_path):
+    private_location = (tmp_path / "private-name.wav").as_uri()
+    adapter = ChromaprintLocalAudio(
+        executable="fpcalc",
+        runner=lambda *args, **kwargs: SimpleNamespace(
+            returncode=1, stdout="", stderr="private-name.wav failed",
+        ),
+    )
+
+    observation = adapter.observe(_track(private_location))
+
+    assert observation.status == "unavailable"
+    assert observation.reason == "missing_file"
+    assert "private-name" not in repr(observation)
+

--- a/tests/test_local_audio_adapter.py
+++ b/tests/test_local_audio_adapter.py
@@ -73,4 +73,3 @@ def test_unavailable_observation_never_exposes_the_private_location(tmp_path):
     assert observation.status == "unavailable"
     assert observation.reason == "missing_file"
     assert "private-name" not in repr(observation)
-

--- a/tests/test_local_audio_identity.py
+++ b/tests/test_local_audio_identity.py
@@ -1,0 +1,415 @@
+"""Behavior tests for opt-in local audio identity at the Transfer seam."""
+
+import json
+from pathlib import Path
+
+import pytest
+import requests
+
+from djsupport.cache import MatchCache
+from djsupport.rekordbox import Track
+from djsupport.report import save_report
+from djsupport.transfer import (
+    AccountPublishingGuards,
+    BatchPlanRequest,
+    EphemeralMatchingKnowledge,
+    FilePublicationStorage,
+    FileTransferStorage,
+    DriftResolution,
+    LocalAudioObservation,
+    MatchCacheKnowledge,
+    SourceSelection,
+    Transfer,
+    TransferMode,
+    TransferRequest,
+)
+
+
+def _track(*, track_id: str, artist: str, title: str) -> Track:
+    return Track(
+        track_id=track_id,
+        artist=artist,
+        name=title,
+        album="",
+        remixer="",
+        label="",
+        genre="",
+        date_added="",
+        duration=360,
+        location="file:///synthetic/selected-track.wav",
+    )
+
+
+class SelectedSource:
+    source_label = "Rekordbox"
+    default_mode = TransferMode.MIRROR
+
+    def __init__(self, track: Track) -> None:
+        self.track = track
+
+    def consume(self, reference: str) -> SourceSelection:
+        return SourceSelection("Selected", reference, [self.track])
+
+    def consume_batch(self, references, whole_library):
+        return tuple(self.consume(reference) for reference in references)
+
+
+class FixedLocalAudio:
+    def __init__(self) -> None:
+        self.observed = []
+
+    def observe(self, track: Track) -> LocalAudioObservation:
+        self.observed.append(track.track_id)
+        return LocalAudioObservation.available(
+            fingerprint="synthetic-fingerprint-001",
+            algorithm="chromaprint",
+            algorithm_version="1.6.0",
+            duration=360,
+        )
+
+
+class SpotifyBoundary:
+    def __init__(self, account_id="spotify-account-one") -> None:
+        self._account_id = account_id
+        self.searches = []
+        self.playlists = {}
+
+    def account_id(self):
+        return self._account_id
+
+    def match(self, track, threshold):
+        self.searches.append((track.artist, track.name, threshold))
+        return {
+            "uri": "spotify:track:approved",
+            "name": "Known Recording",
+            "artist": "Known Artist",
+            "score": 97.0,
+            "match_type": "exact",
+        }
+
+    def publish_provisional_snapshot(
+        self, name, track_uris, description, publication_key,
+    ):
+        playlist_id = "provisional-one"
+        self.playlists[playlist_id] = list(track_uris)
+        return playlist_id
+
+    def delete_provisional_snapshot(self, playlist_id):
+        self.playlists.pop(playlist_id, None)
+
+    def provisional_playlist_track_uris(self, playlist_id):
+        return list(self.playlists[playlist_id])
+
+    def spotify_track(self, uri):
+        return {"uri": uri, "is_playable": True}
+
+
+def test_approved_local_identity_recovers_damaged_metadata_without_spotify(tmp_path):
+    spotify = SpotifyBoundary()
+    cache_path = tmp_path / "matching-knowledge.json"
+    cache = MatchCache(cache_path)
+    publications = FilePublicationStorage(tmp_path / "publications.json")
+    local_audio = FixedLocalAudio()
+    first = Transfer(
+        source=SelectedSource(_track(
+            track_id="rb-original", artist="Known Artist", title="Known Recording",
+        )),
+        spotify=spotify,
+        matching_knowledge=MatchCacheKnowledge(cache),
+        publishing_guards=AccountPublishingGuards(tmp_path / "locks"),
+        publication_storage=publications,
+        local_audio=local_audio,
+    )
+
+    published = first.execute(TransferRequest(
+        source="Selected", local_audio_identity=True,
+    ))
+    first.approve(published.playlists[0].spotify_playlist_id)
+
+    restored_cache = MatchCache(cache_path)
+    restored_cache.load()
+    later = Transfer(
+        source=SelectedSource(_track(
+            track_id="rb-later", artist="", title="Damaged Metadata",
+        )),
+        spotify=spotify,
+        matching_knowledge=MatchCacheKnowledge(restored_cache),
+        publishing_guards=AccountPublishingGuards(tmp_path / "locks"),
+        local_audio=local_audio,
+    ).execute(TransferRequest(
+        source="Selected", preview=True, local_audio_identity=True,
+    ))
+
+    assert spotify.searches == [("Known Artist", "Known Recording", 80)]
+    assert later.total_matched == 1
+    assert later.playlists[0].matched[0].spotify_uri == "spotify:track:approved"
+    assert later.playlists[0].matched[0].match_type == "approved_local_audio"
+
+
+def test_local_identity_requires_durable_matching_knowledge_before_audio_access(
+    tmp_path,
+):
+    local_audio = FixedLocalAudio()
+    transfer = Transfer(
+        source=SelectedSource(_track(
+            track_id="rb-original", artist="Known Artist", title="Known Recording",
+        )),
+        spotify=SpotifyBoundary(),
+        matching_knowledge=EphemeralMatchingKnowledge(),
+        publishing_guards=AccountPublishingGuards(tmp_path / "locks"),
+        local_audio=local_audio,
+    )
+
+    try:
+        transfer.execute(TransferRequest(
+            source="Selected", preview=True, local_audio_identity=True,
+        ))
+    except ValueError as exc:
+        assert str(exc) == (
+            "Local audio identity requires durable matching knowledge; "
+            "remove --no-cache"
+        )
+    else:
+        raise AssertionError("local identity should reject ephemeral knowledge")
+
+    assert local_audio.observed == []
+
+
+def test_batch_preflight_counts_local_work_without_calculating_fingerprints(tmp_path):
+    local_audio = FixedLocalAudio()
+    local_audio.preflight = lambda track: "eligible"
+    cache = MatchCache(tmp_path / "matching-knowledge.json")
+    transfer = Transfer(
+        source=SelectedSource(_track(
+            track_id="rb-original", artist="Known Artist", title="Known Recording",
+        )),
+        spotify=SpotifyBoundary(),
+        matching_knowledge=MatchCacheKnowledge(cache),
+        publishing_guards=AccountPublishingGuards(tmp_path / "locks"),
+        local_audio=local_audio,
+    )
+
+    plan = transfer.plan_batch(BatchPlanRequest(
+        playlist_references=("Selected",),
+        preview=True,
+        local_audio_identity=True,
+    ))
+
+    assert plan.local_audio_eligible == 1
+    assert plan.local_audio_indexed == 0
+    assert plan.local_audio_pending == 1
+    assert plan.local_audio_unavailable == 0
+    assert local_audio.observed == []
+
+
+def test_completed_local_observation_is_not_recalculated_after_spotify_timeout(
+    tmp_path,
+):
+    class RecoveringSpotify(SpotifyBoundary):
+        def __init__(self):
+            super().__init__()
+            self.fail = True
+
+        def match(self, track, threshold):
+            if self.fail:
+                raise requests.Timeout("synthetic timeout")
+            return super().match(track, threshold)
+
+    spotify = RecoveringSpotify()
+    local_audio = FixedLocalAudio()
+    cache = MatchCache(tmp_path / "matching-knowledge.json")
+    state_path = tmp_path / "transfers.json"
+    source = SelectedSource(_track(
+        track_id="rb-original", artist="Known Artist", title="Known Recording",
+    ))
+    request = TransferRequest(
+        source="Selected",
+        preview=True,
+        transfer_id="stable-transfer",
+        local_audio_identity=True,
+    )
+
+    first = Transfer(
+        source=source,
+        spotify=spotify,
+        matching_knowledge=MatchCacheKnowledge(cache),
+        publishing_guards=AccountPublishingGuards(tmp_path / "locks"),
+        transfer_storage=FileTransferStorage(state_path),
+        local_audio=local_audio,
+    )
+    with pytest.raises(requests.Timeout):
+        first.execute(request)
+    spotify.fail = False
+
+    restored_cache = MatchCache(tmp_path / "matching-knowledge.json")
+    restored_cache.load()
+    resumed = Transfer(
+        source=source,
+        spotify=spotify,
+        matching_knowledge=MatchCacheKnowledge(restored_cache),
+        publishing_guards=AccountPublishingGuards(tmp_path / "locks"),
+        transfer_storage=FileTransferStorage(state_path),
+        local_audio=local_audio,
+    ).execute(request)
+
+    assert resumed.total_matched == 1
+    assert local_audio.observed == ["rb-original"]
+    assert json.loads(state_path.read_text())["version"] == 3
+
+
+def test_explicit_drift_revocation_removes_local_identity_authority(tmp_path):
+    spotify = SpotifyBoundary()
+    cache = MatchCache(tmp_path / "matching-knowledge.json")
+    knowledge = MatchCacheKnowledge(cache)
+    publications = FilePublicationStorage(tmp_path / "publications.json")
+    local_audio = FixedLocalAudio()
+    first = Transfer(
+        source=SelectedSource(_track(
+            track_id="rb-original", artist="Known Artist", title="Known Recording",
+        )),
+        spotify=spotify,
+        matching_knowledge=knowledge,
+        publishing_guards=AccountPublishingGuards(tmp_path / "locks"),
+        publication_storage=publications,
+        local_audio=local_audio,
+    )
+    published = first.execute(TransferRequest(
+        source="Selected", local_audio_identity=True,
+    ))
+    playlist_id = published.playlists[0].spotify_playlist_id
+    first.approve(playlist_id)
+    spotify.playlists[playlist_id] = []
+
+    damaged_source = SelectedSource(_track(
+        track_id="rb-later", artist="", title="Damaged Metadata",
+    ))
+    Transfer(
+        source=damaged_source,
+        spotify=spotify,
+        matching_knowledge=knowledge,
+        publishing_guards=AccountPublishingGuards(tmp_path / "locks"),
+        publication_storage=publications,
+        local_audio=local_audio,
+    ).execute(TransferRequest(
+        source="Selected",
+        local_audio_identity=True,
+        drift_resolution=DriftResolution.REVOKE,
+    ))
+
+    after_revoke = Transfer(
+        source=damaged_source,
+        spotify=spotify,
+        matching_knowledge=knowledge,
+        publishing_guards=AccountPublishingGuards(tmp_path / "locks"),
+        local_audio=local_audio,
+    ).execute(TransferRequest(
+        source="Selected", preview=True, local_audio_identity=True,
+    ))
+
+    assert after_revoke.playlists[0].local_audio_reused == 0
+    assert spotify.searches == [
+        ("Known Artist", "Known Recording", 80),
+        ("", "Damaged Metadata", 80),
+    ]
+
+
+def test_unavailable_local_audio_falls_back_without_exposing_private_details(
+    tmp_path,
+):
+    class UnavailableLocalAudio:
+        def observe(self, track):
+            return LocalAudioObservation.unavailable("missing_file")
+
+    spotify = SpotifyBoundary()
+    report = Transfer(
+        source=SelectedSource(_track(
+            track_id="rb-original", artist="Known Artist", title="Known Recording",
+        )),
+        spotify=spotify,
+        matching_knowledge=MatchCacheKnowledge(
+            MatchCache(tmp_path / "matching-knowledge.json")
+        ),
+        publishing_guards=AccountPublishingGuards(tmp_path / "locks"),
+        local_audio=UnavailableLocalAudio(),
+    ).execute(TransferRequest(
+        source="Selected", preview=True, local_audio_identity=True,
+    ))
+
+    playlist = report.playlists[0]
+    assert report.total_matched == 1
+    assert playlist.local_audio_eligible == 0
+    assert playlist.local_audio_observed == 0
+    assert playlist.local_audio_unavailable == 1
+    assert playlist.local_audio_reused == 0
+    report_path = tmp_path / "report.md"
+    save_report(report, report_path)
+    rendered = report_path.read_text()
+    assert (
+        "**Local audio:** 0 eligible | 0 observed | 0 Approved Match reuses "
+        "| 1 unavailable"
+    ) in rendered
+    assert "selected-track.wav" not in rendered
+
+
+def test_revocation_is_scoped_to_the_approving_spotify_account(tmp_path):
+    cache = MatchCache(tmp_path / "matching-knowledge.json")
+    knowledge = MatchCacheKnowledge(cache)
+    publications = FilePublicationStorage(tmp_path / "publications.json")
+    local_audio = FixedLocalAudio()
+
+    def approve_for(account_id, artist, title):
+        spotify = SpotifyBoundary(account_id)
+        transfer = Transfer(
+            source=SelectedSource(_track(
+                track_id=f"rb-{account_id}", artist=artist, title=title,
+            )),
+            spotify=spotify,
+            matching_knowledge=knowledge,
+            publishing_guards=AccountPublishingGuards(tmp_path / "locks"),
+            publication_storage=publications,
+            local_audio=local_audio,
+        )
+        published = transfer.execute(TransferRequest(
+            source=f"Selected-{account_id}", local_audio_identity=True,
+        ))
+        playlist_id = published.playlists[0].spotify_playlist_id
+        transfer.approve(playlist_id)
+        return spotify, playlist_id
+
+    spotify_a, playlist_a = approve_for(
+        "spotify-account-a", "Account A Artist", "Account A Recording",
+    )
+    spotify_b, _ = approve_for(
+        "spotify-account-b", "Account B Artist", "Account B Recording",
+    )
+    spotify_a.playlists[playlist_a] = []
+    damaged = SelectedSource(_track(
+        track_id="rb-damaged", artist="", title="Damaged Metadata",
+    ))
+    Transfer(
+        source=damaged,
+        spotify=spotify_a,
+        matching_knowledge=knowledge,
+        publishing_guards=AccountPublishingGuards(tmp_path / "locks"),
+        publication_storage=publications,
+        local_audio=local_audio,
+    ).execute(TransferRequest(
+        source="Selected-spotify-account-a",
+        local_audio_identity=True,
+        drift_resolution=DriftResolution.REVOKE,
+    ))
+
+    account_b_result = Transfer(
+        source=damaged,
+        spotify=spotify_b,
+        matching_knowledge=knowledge,
+        publishing_guards=AccountPublishingGuards(tmp_path / "locks"),
+        local_audio=local_audio,
+    ).execute(TransferRequest(
+        source="Selected-spotify-account-b",
+        preview=True,
+        local_audio_identity=True,
+    ))
+
+    assert account_b_result.playlists[0].local_audio_reused == 1
+    assert spotify_b.searches == [("Account B Artist", "Account B Recording", 80)]

--- a/tests/test_local_audio_identity.py
+++ b/tests/test_local_audio_identity.py
@@ -7,6 +7,7 @@ import pytest
 import requests
 
 from djsupport.cache import MatchCache
+from djsupport.local_audio import LocalAudioCapability
 from djsupport.rekordbox import Track
 from djsupport.report import save_report
 from djsupport.transfer import (
@@ -67,6 +68,13 @@ class FixedLocalAudio:
             duration=360,
         )
 
+    def capability(self) -> LocalAudioCapability:
+        return LocalAudioCapability(
+            available=True,
+            algorithm="chromaprint",
+            algorithm_version="1.6.0",
+        )
+
 
 class SpotifyBoundary:
     def __init__(self, account_id="spotify-account-one") -> None:
@@ -102,6 +110,27 @@ class SpotifyBoundary:
 
     def spotify_track(self, uri):
         return {"uri": uri, "is_playable": True}
+
+
+def test_ordinary_transfer_does_not_persist_private_audio_location(tmp_path):
+    state_path = tmp_path / "transfers.json"
+    Transfer(
+        source=SelectedSource(_track(
+            track_id="rb-original", artist="Known Artist", title="Known Recording",
+        )),
+        spotify=SpotifyBoundary(),
+        matching_knowledge=MatchCacheKnowledge(MatchCache(
+            tmp_path / "matching-knowledge.json",
+        )),
+        publishing_guards=AccountPublishingGuards(tmp_path / "locks"),
+        transfer_storage=FileTransferStorage(state_path),
+    ).execute(TransferRequest(
+        source="Selected", preview=True, transfer_id="ordinary-transfer",
+    ))
+
+    rendered = state_path.read_text()
+    assert "selected-track.wav" not in rendered
+    assert '"location"' not in rendered
 
 
 def test_approved_local_identity_recovers_damaged_metadata_without_spotify(tmp_path):
@@ -200,6 +229,40 @@ def test_batch_preflight_counts_local_work_without_calculating_fingerprints(tmp_
     assert plan.local_audio_pending == 1
     assert plan.local_audio_unavailable == 0
     assert local_audio.observed == []
+
+
+def test_batch_preflight_only_counts_compatible_fingerprint_evidence_as_indexed(
+    tmp_path,
+):
+    track = _track(
+        track_id="rb-original", artist="Known Artist", title="Known Recording",
+    )
+    local_audio = FixedLocalAudio()
+    local_audio.preflight = lambda candidate: "eligible"
+    cache = MatchCache(tmp_path / "matching-knowledge.json")
+    cache.retain_fingerprint_observation(
+        algorithm="chromaprint",
+        algorithm_version="1.5.0",
+        fingerprint="older-version-evidence",
+        audio_duration=track.duration,
+        source_track_id=track.track_id,
+    )
+    transfer = Transfer(
+        source=SelectedSource(track),
+        spotify=SpotifyBoundary(),
+        matching_knowledge=MatchCacheKnowledge(cache),
+        publishing_guards=AccountPublishingGuards(tmp_path / "locks"),
+        local_audio=local_audio,
+    )
+
+    plan = transfer.plan_batch(BatchPlanRequest(
+        playlist_references=("Selected",),
+        preview=True,
+        local_audio_identity=True,
+    ))
+
+    assert plan.local_audio_indexed == 0
+    assert plan.local_audio_pending == 1
 
 
 def test_completed_local_observation_is_not_recalculated_after_spotify_timeout(
@@ -413,3 +476,74 @@ def test_revocation_is_scoped_to_the_approving_spotify_account(tmp_path):
 
     assert account_b_result.playlists[0].local_audio_reused == 1
     assert spotify_b.searches == [("Account B Artist", "Account B Recording", 80)]
+
+
+def test_conflicting_fingerprint_approvals_suspend_automatic_reuse(tmp_path):
+    class ConflictingSpotify(SpotifyBoundary):
+        def __init__(self):
+            super().__init__()
+            self.next_playlist = 0
+
+        def match(self, track, threshold):
+            self.searches.append((track.artist, track.name, threshold))
+            suffix = "a" if track.artist == "Artist A" else "b"
+            return {
+                "uri": f"spotify:track:{suffix}",
+                "name": f"Recording {suffix.upper()}",
+                "artist": track.artist,
+                "score": 97.0,
+                "match_type": "exact",
+            }
+
+        def publish_provisional_snapshot(
+            self, name, track_uris, description, publication_key,
+        ):
+            self.next_playlist += 1
+            playlist_id = f"provisional-{self.next_playlist}"
+            self.playlists[playlist_id] = list(track_uris)
+            return playlist_id
+
+    spotify = ConflictingSpotify()
+    cache = MatchCache(tmp_path / "matching-knowledge.json")
+    knowledge = MatchCacheKnowledge(cache)
+    publications = FilePublicationStorage(tmp_path / "publications.json")
+    local_audio = FixedLocalAudio()
+
+    def publish(reference, artist):
+        transfer = Transfer(
+            source=SelectedSource(_track(
+                track_id=f"rb-{artist}", artist=artist, title="Recording",
+            )),
+            spotify=spotify,
+            matching_knowledge=knowledge,
+            publishing_guards=AccountPublishingGuards(tmp_path / "locks"),
+            publication_storage=publications,
+            local_audio=local_audio,
+        )
+        report = transfer.execute(TransferRequest(
+            source=reference, local_audio_identity=True,
+        ))
+        return transfer, report.playlists[0].spotify_playlist_id
+
+    first, playlist_a = publish("Selection A", "Artist A")
+    second, playlist_b = publish("Selection B", "Artist B")
+    first.approve(playlist_a)
+
+    conflict = second.approve(playlist_b)
+
+    assert conflict.status.value == "needs review"
+    assert len(conflict.conflicts) == 1
+    searches_before = len(spotify.searches)
+    after_conflict = Transfer(
+        source=SelectedSource(_track(
+            track_id="rb-damaged", artist="", title="Damaged Metadata",
+        )),
+        spotify=spotify,
+        matching_knowledge=knowledge,
+        publishing_guards=AccountPublishingGuards(tmp_path / "locks"),
+        local_audio=local_audio,
+    ).execute(TransferRequest(
+        source="Damaged", preview=True, local_audio_identity=True,
+    ))
+    assert after_conflict.playlists[0].local_audio_reused == 0
+    assert len(spotify.searches) == searches_before + 1

--- a/tests/test_migration.py
+++ b/tests/test_migration.py
@@ -144,6 +144,41 @@ class TestLegacyMigration:
         assert result.report.conflicts == 1
         assert any((app_data / "backups").glob("djsupport-backup-*.zip"))
 
+    def test_apply_preserves_version_two_local_audio_identity_knowledge(
+        self, tmp_path,
+    ):
+        legacy = tmp_path / "legacy"
+        legacy.mkdir()
+        _write_json(legacy / ".djsupport_cache.json", {
+            "version": 1,
+            "entries": {"new||track": _cache_entry("A")},
+        })
+        app_data = tmp_path / "app-data"
+        association = {
+            "algorithm": "chromaprint",
+            "algorithm_version": "1.6.1",
+            "fingerprint": "invented-private-evidence",
+            "account_id": "spotify-account-one",
+            "spotify_uri": "spotify:track:" + "B" * 22,
+            "authority_status": "approved",
+        }
+        _write_json(app_data / "matching-knowledge.json", {
+            "version": 2,
+            "entries": {},
+            "local_regressions": [],
+            "approval_conflicts": [],
+            "fingerprint_observations": {},
+            "fingerprint_associations": [association],
+        })
+
+        result = LegacyMigration(app_data).apply(legacy)
+
+        assert result.applied is True
+        stored = json.loads((app_data / "matching-knowledge.json").read_text())
+        assert stored["version"] == 2
+        assert stored["fingerprint_associations"] == [association]
+        assert "new||track" in stored["entries"]
+
 
     def test_ambiguous_cross_cache_entry_is_reported_and_not_imported(self, tmp_path):
         legacy = tmp_path / "legacy"

--- a/tests/test_rekordbox.py
+++ b/tests/test_rekordbox.py
@@ -9,6 +9,23 @@ from djsupport.rekordbox import Track, Playlist, parse_xml
 
 
 class TestParseXml:
+    def test_location_is_only_read_after_explicit_opt_in(self, tmp_path):
+        xml = tmp_path / "location.xml"
+        xml.write_text(textwrap.dedent("""\
+            <DJ_PLAYLISTS>
+              <COLLECTION Entries="1">
+                <TRACK TrackID="1" Name="Track" Artist="Artist"
+                       Location="file://localhost/private/audio.wav"/>
+              </COLLECTION>
+            </DJ_PLAYLISTS>
+        """))
+
+        ordinary, _ = parse_xml(xml)
+        opted_in, _ = parse_xml(xml, include_locations=True)
+
+        assert ordinary["1"].location == ""
+        assert opted_in["1"].location == "file://localhost/private/audio.wav"
+
     def test_parses_correct_number_of_tracks(self, library_xml):
         tracks, _ = parse_xml(library_xml)
         assert len(tracks) == 3

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -145,6 +145,89 @@ def test_rekordbox_web_execute_returns_aggregate_local_audio_outcome():
     assert "synthetic-library" not in response.text
 
 
+def test_rekordbox_web_execute_preserves_execute_phase_authorization_contract():
+    web = create_app(
+        rekordbox_transfer_factory=lambda request, authorized: (
+            _ for _ in ()
+        ).throw(AssertionError("private source must stay untouched")),
+    )
+
+    response = TestClient(web).post("/rekordbox/batches/execute", json={
+        "xml_path": "/private/synthetic-library.xml",
+        "playlists": ["Private/Selection"],
+    })
+
+    assert response.json() == {
+        "contract_version": 1,
+        "phase": "execute",
+        "status": "authorization_required",
+        "required_authorizations": ["private_source"],
+        "next_actions": ["authorize_private_source"],
+    }
+
+
+def test_rekordbox_web_execute_plans_before_requesting_spotify_write():
+    plan = BatchPlan((PlaylistPreflight(
+        name="Private Selection",
+        reference="Private/Selection",
+        total_tracks=1,
+        approved_match_hits=0,
+        cache_hits=0,
+        expected_uncached_lookups=1,
+        selection_token="private-content-token",
+    ),))
+    transfer = _agent_web_transfer(plan)
+    web = create_app(
+        rekordbox_transfer_factory=lambda request, authorized: transfer,
+    )
+
+    response = TestClient(web).post("/rekordbox/batches/execute", json={
+        "xml_path": "/private/synthetic-library.xml",
+        "playlists": ["Private/Selection"],
+        "authorize_private_source": True,
+    })
+
+    assert response.json()["phase"] == "execute"
+    assert response.json()["status"] == "authorization_required"
+    assert response.json()["required_authorizations"] == ["spotify_write"]
+    assert response.json()["batch_id"] == plan.batch_id
+
+
+def test_rekordbox_web_execute_renders_spotify_login_as_versioned_error():
+    plan = BatchPlan((PlaylistPreflight(
+        name="Private Selection",
+        reference="Private/Selection",
+        total_tracks=1,
+        approved_match_hits=0,
+        cache_hits=0,
+        expected_uncached_lookups=1,
+        selection_token="private-content-token",
+    ),), preview=True)
+    transfer = _agent_web_transfer(plan)
+    mgr = MagicMock()
+    mgr.get_cached_token.return_value = None
+    web = create_app(
+        rekordbox_transfer_factory=lambda request, authorized: transfer,
+        auth_manager=lambda: mgr,
+    )
+
+    response = TestClient(web).post("/rekordbox/batches/execute", json={
+        "xml_path": "/private/synthetic-library.xml",
+        "playlists": ["Private/Selection"],
+        "preview": True,
+        "authorize_private_source": True,
+    })
+
+    assert response.status_code == 401
+    assert response.json() == {
+        "contract_version": 1,
+        "phase": "execute",
+        "status": "error",
+        "error": {"code": "spotify_authentication_required"},
+        "next_actions": ["authenticate_spotify"],
+    }
+
+
 def test_capabilities_are_available_without_spotify_or_private_source(monkeypatch):
     monkeypatch.setattr("djsupport.local_audio.shutil.which", lambda name: None)
 

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -12,8 +12,10 @@ from djsupport.report import PlaylistReport, SyncReport
 from djsupport.rekordbox import Track
 from djsupport.transfer import (
     AccountPublishingGuards,
+    BatchPlan,
     FilePublicationStorage,
     FileTransferStorage,
+    PlaylistPreflight,
     SourceSelection,
     Transfer,
     TransferProgress,
@@ -41,6 +43,106 @@ def test_web_outcome_exposes_aggregate_local_audio_counts():
     assert rendered["local_audio_observed"] == 2
     assert rendered["local_audio_unavailable"] == 1
     assert rendered["local_audio_reused"] == 1
+
+
+def _agent_web_transfer(plan, report=None):
+    transfer = MagicMock()
+    transfer.authorization_requirement.side_effect = (
+        lambda request, authorization, phase: Transfer.authorization_requirement(
+            request, authorization, phase=phase,
+        )
+    )
+    transfer.plan_batch.return_value = plan
+    if report is not None:
+        transfer.execute_batch.return_value = report
+    return transfer
+
+
+def test_rekordbox_web_plan_exposes_explicit_local_audio_opt_in_without_spotify():
+    plan = BatchPlan((PlaylistPreflight(
+        name="Private Selection",
+        reference="Private/Selection",
+        total_tracks=2,
+        approved_match_hits=0,
+        cache_hits=0,
+        expected_uncached_lookups=2,
+        local_audio_eligible=2,
+        local_audio_pending=2,
+        selection_token="private-content-token",
+    ),), local_audio_identity=True)
+    factory_calls = []
+
+    def factory(request, execute_authorized):
+        factory_calls.append((request, execute_authorized))
+        return _agent_web_transfer(plan)
+
+    web = create_app(
+        rekordbox_transfer_factory=factory,
+        auth_manager=lambda: (_ for _ in ()).throw(
+            AssertionError("Spotify must stay untouched during planning")
+        ),
+    )
+    response = TestClient(web).post("/rekordbox/batches/plan", json={
+        "xml_path": "/private/synthetic-library.xml",
+        "playlists": ["Private/Selection"],
+        "local_audio_identity": True,
+        "authorize_private_source": True,
+    })
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["phase"] == "plan"
+    assert body["counts"]["local_audio_eligible"] == 2
+    assert body["counts"]["local_audio_pending"] == 2
+    assert factory_calls[0][0].local_audio_identity is True
+    assert factory_calls[0][1] is False
+    assert "synthetic-library" not in response.text
+
+
+def test_rekordbox_web_execute_returns_aggregate_local_audio_outcome():
+    plan = BatchPlan((PlaylistPreflight(
+        name="Private Selection",
+        reference="Private/Selection",
+        total_tracks=1,
+        approved_match_hits=0,
+        cache_hits=0,
+        expected_uncached_lookups=1,
+        local_audio_eligible=1,
+        local_audio_pending=1,
+        selection_token="private-content-token",
+    ),), local_audio_identity=True)
+    playlist = PlaylistReport(
+        name="Private Selection", path="Private/Selection", action="preview",
+    )
+    playlist.local_audio_eligible = 1
+    playlist.local_audio_observed = 1
+    playlist.local_audio_reused = 1
+    report = SyncReport(
+        timestamp=datetime(2026, 8, 3), threshold=80, dry_run=True,
+        playlists=[playlist], transfer_id=plan.batch_id, status="completed",
+    )
+    transfer = _agent_web_transfer(plan, report)
+    mgr = MagicMock()
+    mgr.get_cached_token.return_value = {"access_token": "tok"}
+    mgr.is_token_expired.return_value = False
+    web = create_app(
+        rekordbox_transfer_factory=lambda request, authorized: transfer,
+        auth_manager=lambda: mgr,
+    )
+
+    response = TestClient(web).post("/rekordbox/batches/execute", json={
+        "xml_path": "/private/synthetic-library.xml",
+        "playlists": ["Private/Selection"],
+        "preview": True,
+        "local_audio_identity": True,
+        "authorize_private_source": True,
+    })
+
+    assert response.status_code == 200
+    assert response.json()["phase"] == "outcome"
+    assert response.json()["counts"]["local_audio_observed"] == 1
+    assert response.json()["counts"]["local_audio_reused"] == 1
+    assert "synthetic-library" not in response.text
 
 
 def test_capabilities_are_available_without_spotify_or_private_source(monkeypatch):
@@ -241,27 +343,14 @@ class TestSyncEndpoints:
             background_runner=lambda target, args: target(*args),
         )
         res = TestClient(label_app).post(
-            "/sync", json={
-                "url": "https://www.beatport.com/label/test/1",
-                "local_audio_identity": True,
-            },
+            "/sync", json={"url": "https://www.beatport.com/label/test/1"},
         )
         assert res.status_code == 200
         assert res.json()["url_type"] == "label"
         request = transfer.execute.call_args.args[0]
         assert request.source == "https://www.beatport.com/label/test/1"
         assert request.mode.value == "snapshot"
-        assert request.local_audio_identity is True
-
-    def test_local_audio_identity_requires_durable_web_knowledge(self):
-        res = client.post("/sync", json={
-            "url": "https://www.beatport.com/chart/test/123",
-            "local_audio_identity": True,
-            "no_cache": True,
-        })
-
-        assert res.status_code == 400
-        assert "durable matching knowledge" in res.json()["detail"]
+        assert request.local_audio_identity is False
 
     def test_failed_outcome_reloads_after_restart(self, tmp_path):
         class FailingSource:

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -24,6 +24,22 @@ from djsupport.web import app, create_app
 client = TestClient(app)
 
 
+def test_capabilities_are_available_without_spotify_or_private_source(monkeypatch):
+    monkeypatch.setattr("djsupport.local_audio.shutil.which", lambda name: None)
+
+    response = TestClient(create_app()).get("/capabilities")
+
+    assert response.status_code == 200
+    assert response.json()["contract_version"] == 1
+    assert response.json()["phase"] == "capability"
+    assert response.json()["capabilities"]["local_audio_identity"] == {
+        "available": False,
+        "algorithm": "chromaprint",
+        "algorithm_version": None,
+        "reason": "binary_unavailable",
+    }
+
+
 class TestAuthEndpoints:
     @patch("djsupport.web._auth_manager")
     def test_auth_status_authenticated(self, mock_mgr_fn):

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -18,10 +18,29 @@ from djsupport.transfer import (
     Transfer,
     TransferProgress,
 )
-from djsupport.web import app, create_app
+from djsupport.web import _report_to_dict, app, create_app
 
 
 client = TestClient(app)
+
+
+def test_web_outcome_exposes_aggregate_local_audio_counts():
+    playlist = PlaylistReport(name="Synthetic", path="private", action="preview")
+    playlist.local_audio_eligible = 3
+    playlist.local_audio_observed = 2
+    playlist.local_audio_unavailable = 1
+    playlist.local_audio_reused = 1
+    report = SyncReport(
+        timestamp=datetime(2026, 8, 3), threshold=80, dry_run=True,
+        playlists=[playlist],
+    )
+
+    rendered = _report_to_dict(report)
+
+    assert rendered["local_audio_eligible"] == 3
+    assert rendered["local_audio_observed"] == 2
+    assert rendered["local_audio_unavailable"] == 1
+    assert rendered["local_audio_reused"] == 1
 
 
 def test_capabilities_are_available_without_spotify_or_private_source(monkeypatch):
@@ -222,13 +241,27 @@ class TestSyncEndpoints:
             background_runner=lambda target, args: target(*args),
         )
         res = TestClient(label_app).post(
-            "/sync", json={"url": "https://www.beatport.com/label/test/1"},
+            "/sync", json={
+                "url": "https://www.beatport.com/label/test/1",
+                "local_audio_identity": True,
+            },
         )
         assert res.status_code == 200
         assert res.json()["url_type"] == "label"
         request = transfer.execute.call_args.args[0]
         assert request.source == "https://www.beatport.com/label/test/1"
         assert request.mode.value == "snapshot"
+        assert request.local_audio_identity is True
+
+    def test_local_audio_identity_requires_durable_web_knowledge(self):
+        res = client.post("/sync", json={
+            "url": "https://www.beatport.com/chart/test/123",
+            "local_audio_identity": True,
+            "no_cache": True,
+        })
+
+        assert res.status_code == 400
+        assert "durable matching knowledge" in res.json()["detail"]
 
     def test_failed_outcome_reloads_after_restart(self, tmp_path):
         class FailingSource:


### PR DESCRIPTION
Closes #96

## Summary
- add opt-in, Rekordbox-only Chromaprint evidence for exact account-scoped Approved Match recovery
- make AI harnesses first-class Transfer clients through versioned capability, bounded plan, authorization, progress, and outcome contracts
- bind durable Batch identity to selected source content and effect scope, with fail-closed resume and private schema handling
- add dedicated Rekordbox web plan/execute endpoints while leaving Beatport behavior unchanged
- preserve backup, migration, Preview, privacy, and Approval authority boundaries

## Validation
- 559 offline tests passed
- 18 repository privacy checks passed
- Python compilation passed
- full diff/whitespace validation passed
- standards review passed with no blockers
- specification review passed with no blockers