### PR TITLE
Add Rekordbox Qualification Workspace with local audition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Added
 
+- Rekordbox-only, attention-led Qualification Workspace with durable,
+  non-authoritative drafts; explicit draft application remains separate from
+  playlist-scoped Approval.
+- Exact selected-source local audition through short-lived opaque handles,
+  loopback-only no-store media streaming, and bounded byte ranges, independent
+  of Chromaprint identity and durable matching knowledge.
+- Rich retained source/Spotify release, version, duration, evidence, and
+  authority facts, including zero-search Approved Match reuse by exact local
+  audio identity.
 - Opt-in, Rekordbox-only local Chromaprint evidence that can recover an exact,
   account-scoped Approved Match after XML metadata changes without another
   Spotify search.
@@ -18,8 +27,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - Durable matching-knowledge schema 2, including private fingerprint
   observations and associations with backup, restore, and legacy-migration
   support.
-- Transfer-state schema 3 for durable local-audio opt-in, evidence checkpoints,
-  and stable aggregate outcomes; schemas 1 and 2 remain readable.
+- Transfer-state schema 4 for durable local-audio opt-in, evidence checkpoints,
+  stable aggregate outcomes, and Qualification Drafts; schemas 1–3 remain
+  readable.
 
 ### Changed
 

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -88,6 +88,18 @@ _Avoid_: Dry run, test run
 Opt-in, local-only Chromaprint evidence calculated for audio referenced by an explicitly selected Rekordbox Batch. It can recover an existing account-scoped Approved Match by exact equality but can never create Approval or identify an unknown recording from a catalog.
 _Avoid_: Automatic identification, fingerprint approval, library scan
 
+**Qualification Workspace**:
+The Rekordbox-only, attention-led comparison surface for one selected playlist. It presents retained source and Spotify proposal facts, optionally auditions the exact authorized local source, and collects one explicit Qualification Draft outcome at a time. Browser-origin selections remain reviewed in Spotify.
+_Avoid_: Approval screen, generic review UI, match confirmation
+
+**Qualification Draft**:
+Private, versioned, resumable working state bound to one Rekordbox playlist Transfer, publication manifest, Spotify account, and playlist head. Its keep, Correction, deferred, exclusion, and rejection choices carry no matching or playlist authority; applying it and approving the resulting playlist remain separate explicit operations.
+_Avoid_: Approval, matching knowledge, draft playlist
+
+**Local Audition**:
+Opt-in playback of one exact local source occurrence from an explicitly authorized Rekordbox Batch through a short-lived, process-local handle. It does not calculate a fingerprint, require retained matching knowledge, expose a path, or authorize Spotify writes.
+_Avoid_: Local audio identity, directory playback, file server
+
 **Agent Client**:
 An AI harness or automation client that uses the same public Transfer policy as CLI and web through capability, bounded plan, explicit authorization, execute or resume, and structured outcome phases. Conversation is never authorization.
 _Avoid_: Autonomous authority, agent workflow engine

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,6 +40,7 @@ djsupport/
   backup.py      Versioned local-data backup and restore
   migration.py   Explicit legacy-data migration
   local_audio.py Optional local-only Chromaprint boundary
+  local_audition.py Process-local, path-redacted selected-media boundary
 tests/           Offline behavior, adapter, migration, privacy, and package tests
 docs/adr/        Architecture decisions
 docs/plans/      Product roadmap and retained implementation history
@@ -65,6 +66,12 @@ publication rules.
 - Local audio identity is Rekordbox-only, selected-Batch-only, opt-in, exact,
   account-scoped, and subordinate to Approval. Never scan directories, upload
   evidence, emit paths or fingerprints, or require `fpcalc` as a package binary.
+- Qualification is Rekordbox-only and Transfer-owned. Draft decisions carry no
+  authority; draft application and playlist Approval are separate explicit
+  operations. Web, CLI, and agent code only render and collect Transfer facts.
+- Local audition is a separate opt-in capability from local audio identity. It
+  accepts only the exact selected occurrence, uses process-local opaque handles,
+  emits no paths or filenames, and never calculates a fingerprint.
 - Update `CONTRIBUTING.md` when the project map, development commands, or these
   conventions change.
 

--- a/README.md
+++ b/README.md
@@ -6,11 +6,11 @@ publication, and later playlist changes.
 
 ## Supported workflows
 
-| Source | Default result | Best for |
-| --- | --- | --- |
-| Rekordbox playlist | **Mirror** | Keeping a Spotify playlist aligned with an explicitly selected Rekordbox playlist |
-| Beatport chart | **Snapshot** | Capturing a chart once; opt into a Mirror only when it should be maintained |
-| Beatport label | **Snapshot** | Capturing a label selection once; opt into a Mirror only when it should be maintained |
+| Source | Default result | Review surface | Best for |
+| --- | --- | --- | --- |
+| Rekordbox playlist | **Mirror** | Qualification Workspace, then separate Approval | Keeping a Spotify playlist aligned with an explicitly selected Rekordbox playlist |
+| Beatport chart | **Snapshot** | Spotify, then Approval | Capturing a chart once; opt into a Mirror only when it should be maintained |
+| Beatport label | **Snapshot** | Spotify, then Approval | Capturing a label selection once; opt into a Mirror only when it should be maintained |
 
 Every Transfer can be Previewed before Spotify is changed. Published matches
 are reviewable in Spotify, and explicit Approval turns accepted matches into
@@ -103,6 +103,41 @@ expensive:
 djsupport sync --whole-library
 ```
 
+## Qualify a Rekordbox playlist
+
+Rekordbox Mirrors can use the local Qualification Workspace because Spotify
+cannot reveal what the selected source file sounded like. Opt into audition
+when creating the bounded Batch; this is independent of fingerprint identity
+and remains compatible with `--no-cache`:
+
+```bash
+djsupport sync -p "Deep House" --local-audio-audition
+djsupport web
+```
+
+Obtain or resume the playlist-scoped Qualification Draft through the same
+Transfer lifecycle:
+
+```bash
+djsupport qualification <batch-or-transfer-id> \
+  --playlist "Deep House" --local-audio-audition \
+  --authorize-private-source
+```
+
+The workspace defaults to proposals needing attention, shows retained source
+release/version/duration beside Spotify release/duration and match evidence,
+and offers only **Correct**, **Wrong — find another**, **Cannot verify**, or
+**Not my source**. Local playback opens only the exact selected occurrence
+after private-source authorization; the browser receives an opaque temporary
+URL, never its path or filename.
+
+Every outcome remains a non-authoritative, revisable draft. Applying a complete
+draft is a separate operation requiring `--authorize-spotify-write`; it updates
+only the linked Provisional Playlist. Playlist-scoped Approval is still the
+only operation that records Approved Matches, Corrections, or Rejected Matches.
+Beatport and other browser-origin selections continue to be reviewed directly
+in Spotify.
+
 ## Beatport charts and labels
 
 Preview and publish a one-time chart Snapshot:
@@ -186,6 +221,13 @@ upload audio or fingerprints, modify files, or identify unknown recordings.
 Exact compatible evidence can only reuse a match that the same Spotify account
 already approved. Missing or unreadable audio falls back to metadata matching.
 
+On a new installation, identity cannot improve the first Spotify discovery:
+there is no fingerprint-backed Approved Match to reuse yet. During an
+authorized Transfer it runs only after retained matching-knowledge lookup and
+before Spotify search. Its benefit begins after explicit Approval binds that
+observation to retained Approved Match facts. Audition never requires or
+automatically triggers this calculation.
+
 ## AI-agent use
 
 Codex and other harnesses are first-class clients of the same Transfer policy.
@@ -208,6 +250,10 @@ Spotify publication requires separate authorization:
 djsupport sync -p "Deep House" --json \
   --authorize-private-source --authorize-spotify-write
 ```
+
+After a Rekordbox outcome returns `qualify`, obtain a privacy-redacted draft
+document and opaque loopback review URL with `djsupport qualification --json`.
+Draft application and the later playlist Approval remain distinct actions.
 
 JSON mode is non-interactive and never treats conversation as authorization. A
 changed source selection or effect scope produces a different Batch identity.

--- a/README.md
+++ b/README.md
@@ -111,7 +111,8 @@ when creating the bounded Batch; this is independent of fingerprint identity
 and remains compatible with `--no-cache`:
 
 ```bash
-djsupport sync -p "Deep House" --local-audio-audition
+djsupport sync -p "Deep House" --local-audio-audition \
+  --authorize-private-source
 djsupport web
 ```
 
@@ -120,7 +121,7 @@ Transfer lifecycle:
 
 ```bash
 djsupport qualification <batch-or-transfer-id> \
-  --playlist "Deep House" --local-audio-audition \
+  --playlist "Deep House" \
   --authorize-private-source
 ```
 

--- a/djsupport/agent.py
+++ b/djsupport/agent.py
@@ -4,18 +4,20 @@ from __future__ import annotations
 
 from djsupport.transfer import (
     BatchPlanRequest,
+    QualificationRequest,
+    QualificationStatus,
     Transfer,
     TransferAuthorization,
 )
 
 
-AGENT_CONTRACT_VERSION = 1
+AGENT_CONTRACT_VERSION = 2
 
 
 AgentAuthorization = TransferAuthorization
 
 
-def capability_document(capability_value) -> dict:
+def capability_document(capability_value, audition_value=None) -> dict:
     capability = {
         "available": capability_value.available,
         "algorithm": capability_value.algorithm,
@@ -23,11 +25,33 @@ def capability_document(capability_value) -> dict:
     }
     if capability_value.reason is not None:
         capability["reason"] = capability_value.reason
+    capability.update({
+        "default_enabled": False,
+        "authority": "approved_match_reuse_only",
+        "first_run_discovery": "none_until_explicit_approval",
+        "execution_order": "after_retained_knowledge_before_spotify_search",
+    })
+    audition = {
+        "available": bool(
+            audition_value is not None and audition_value.available
+        ),
+        "default_enabled": False,
+        "authority": "none",
+        "requires_local_audio_identity": False,
+        "requires_durable_matching_knowledge": False,
+    }
+    if audition_value is not None and audition_value.reason is not None:
+        audition["reason"] = audition_value.reason
+    elif audition_value is None:
+        audition["reason"] = "not_configured"
     return {
         "contract_version": AGENT_CONTRACT_VERSION,
         "phase": "capability",
         "status": "ready",
-        "capabilities": {"local_audio_identity": capability},
+        "capabilities": {
+            "local_audio_identity": capability,
+            "local_audio_audition": audition,
+        },
         "next_actions": ["plan"],
     }
 
@@ -67,7 +91,10 @@ class AgentTransferContract:
         self._transfer = transfer
 
     def capabilities(self) -> dict:
-        return capability_document(self._transfer.local_audio_capability())
+        return capability_document(
+            self._transfer.local_audio_capability(),
+            self._transfer.local_audition_capability(),
+        )
 
     def plan_batch(
         self, request: BatchPlanRequest, authorization: AgentAuthorization,
@@ -109,8 +136,26 @@ class AgentTransferContract:
             },
             "requested_effects": [
                 "private_source",
+                *(
+                    ["local_audio_identity"]
+                    if request.local_audio_identity else []
+                ),
+                *(
+                    ["local_audio_audition"]
+                    if request.local_audio_audition else []
+                ),
                 *([] if request.preview else ["spotify_write"]),
             ],
+            "local_audio": {
+                "identity_requested": request.local_audio_identity,
+                "audition_requested": request.local_audio_audition,
+                "identity_default_enabled": False,
+                "identity_first_run_discovery": "none_until_explicit_approval",
+                "identity_execution_order": (
+                    "after_retained_knowledge_before_spotify_search"
+                ),
+                "audition_requires_identity": False,
+            },
             "required_authorizations": required,
             "next_actions": next_actions,
         }
@@ -174,8 +219,88 @@ class AgentTransferContract:
             },
             "required_authorizations": [],
             "next_actions": (
-                ["resume"] if status == "paused" else ["review"]
+                ["resume"] if status == "paused" else ["qualify"]
             ),
+        }
+
+    def qualification_draft(
+        self,
+        request: QualificationRequest,
+        authorization: AgentAuthorization,
+        *,
+        review_origin: str = "http://127.0.0.1:8000",
+    ) -> dict:
+        """Obtain a draft while keeping source and playlist facts local."""
+        required = self._transfer.private_source_authorization_requirement(
+            authorization,
+        )
+        if required:
+            return authorization_required_document("qualification", required)
+        view = self._transfer.obtain_qualification(request, authorization)
+        return self._qualification_document(view, review_origin)
+
+    def qualification_progress(
+        self,
+        draft_id: str,
+        authorization: AgentAuthorization,
+        *,
+        review_origin: str = "http://127.0.0.1:8000",
+    ) -> dict:
+        required = self._transfer.private_source_authorization_requirement(
+            authorization,
+        )
+        if required:
+            return authorization_required_document("qualification", required)
+        view = self._transfer.qualification(draft_id)
+        return self._qualification_document(view, review_origin)
+
+    @staticmethod
+    def _qualification_document(view, review_origin: str) -> dict:
+        status = view.status.value
+        next_actions = (
+            ["approve"] if status == QualificationStatus.APPLIED.value
+            else ["apply"] if view.complete
+            else ["review"]
+        )
+        return {
+            "contract_version": AGENT_CONTRACT_VERSION,
+            "phase": "qualification",
+            "status": status,
+            "draft_id": view.draft_id,
+            "transfer_id": view.transfer_id,
+            "counts": {
+                "items": len(view.items),
+                "pending": view.pending,
+                "deferred": view.deferred,
+            },
+            "authority": "none",
+            "review_url": (
+                f"{review_origin.rstrip('/')}/qualification/{view.draft_id}"
+            ),
+            "next_actions": next_actions,
+        }
+
+    def apply_qualification(
+        self, draft_id: str, authorization: AgentAuthorization,
+    ) -> dict:
+        required = self._transfer.private_source_authorization_requirement(
+            authorization,
+        )
+        if required:
+            return authorization_required_document("qualification_apply", required)
+        if not authorization.spotify_write:
+            return authorization_required_document(
+                "qualification_apply", "spotify_write",
+            )
+        outcome = self._transfer.apply_qualification(draft_id, authorization)
+        return {
+            "contract_version": AGENT_CONTRACT_VERSION,
+            "phase": "qualification_apply",
+            "status": outcome.status.value,
+            "draft_id": outcome.draft_id,
+            "counts": {"applied_items": outcome.applied_items},
+            "authority": "none",
+            "next_actions": list(outcome.next_actions),
         }
 
     def progress(
@@ -201,6 +326,6 @@ class AgentTransferContract:
             },
             "next_actions": (
                 ["resume"] if status in {"paused", "partial_success"}
-                else ["review"]
+                else ["qualify"]
             ),
         }

--- a/djsupport/agent.py
+++ b/djsupport/agent.py
@@ -2,10 +2,16 @@
 
 from __future__ import annotations
 
+import ipaddress
+from urllib.parse import urlsplit
+
 from djsupport.transfer import (
     BatchPlanRequest,
+    QualificationDecision,
     QualificationRequest,
     QualificationStatus,
+    SpotifyPlaylistChanged,
+    SpotifyPlaylistReviewRequired,
     Transfer,
     TransferAuthorization,
 )
@@ -15,6 +21,36 @@ AGENT_CONTRACT_VERSION = 2
 
 
 AgentAuthorization = TransferAuthorization
+
+
+def _loopback_review_origin(value: str) -> str:
+    """Accept only an origin that keeps the private review URL local."""
+    parsed = urlsplit(value)
+    try:
+        port = parsed.port
+    except ValueError as exc:
+        raise ValueError("Qualification review origin must be loopback") from exc
+    del port
+    if (
+        parsed.scheme not in {"http", "https"}
+        or parsed.username is not None
+        or parsed.password is not None
+        or parsed.hostname is None
+        or parsed.path not in {"", "/"}
+        or parsed.query
+        or parsed.fragment
+    ):
+        raise ValueError("Qualification review origin must be loopback")
+    hostname = parsed.hostname.casefold()
+    if hostname != "localhost":
+        try:
+            if not ipaddress.ip_address(hostname).is_loopback:
+                raise ValueError
+        except ValueError as exc:
+            raise ValueError(
+                "Qualification review origin must be loopback"
+            ) from exc
+    return f"{parsed.scheme}://{parsed.netloc}"
 
 
 def capability_document(capability_value, audition_value=None) -> dict:
@@ -82,6 +118,26 @@ def error_document(phase: str, code: str) -> dict:
         "error": {"code": code},
         "next_actions": [next_action],
     }
+
+
+def qualification_review_required_document(
+    phase: str,
+    code: str,
+    *,
+    draft_id: str | None = None,
+    next_actions: list[str] | None = None,
+) -> dict:
+    """Render an expected, privacy-safe Qualification stop condition."""
+    document = {
+        "contract_version": AGENT_CONTRACT_VERSION,
+        "phase": phase,
+        "status": "review_required",
+        "review": {"code": code},
+        "next_actions": next_actions or ["review"],
+    }
+    if draft_id is not None:
+        document["draft_id"] = draft_id
+    return document
 
 
 class AgentTransferContract:
@@ -189,7 +245,18 @@ class AgentTransferContract:
                 "next_actions": ["confirm_expensive"],
             }
         batch_id = transfer_id or plan_result["batch_id"]
-        report = self._transfer.execute_batch(plan, transfer_id=batch_id)
+        try:
+            report = self._transfer.execute_batch(plan, transfer_id=batch_id)
+        except SpotifyPlaylistReviewRequired:
+            return {
+                "contract_version": AGENT_CONTRACT_VERSION,
+                "phase": "execute",
+                "status": "review_required",
+                "batch_id": plan_result["batch_id"],
+                "review": {"code": "source_selection_changed"},
+                "required_authorizations": [],
+                "next_actions": ["replan"],
+            }
         status = report.status.replace(" ", "_")
         return {
             "contract_version": AGENT_CONTRACT_VERSION,
@@ -236,7 +303,19 @@ class AgentTransferContract:
         )
         if required:
             return authorization_required_document("qualification", required)
-        view = self._transfer.obtain_qualification(request, authorization)
+        review_origin = _loopback_review_origin(review_origin)
+        try:
+            view = self._transfer.obtain_qualification(request, authorization)
+        except SpotifyPlaylistChanged:
+            return qualification_review_required_document(
+                "qualification", "spotify_playlist_changed",
+            )
+        except SpotifyPlaylistReviewRequired as exc:
+            return qualification_review_required_document(
+                "qualification", "qualification_review_required",
+                draft_id=exc.draft_id,
+                next_actions=["review", "discard"],
+            )
         return self._qualification_document(view, review_origin)
 
     def qualification_progress(
@@ -251,17 +330,72 @@ class AgentTransferContract:
         )
         if required:
             return authorization_required_document("qualification", required)
-        view = self._transfer.qualification(draft_id)
+        review_origin = _loopback_review_origin(review_origin)
+        try:
+            view = self._transfer.qualification(draft_id, authorization)
+        except SpotifyPlaylistChanged:
+            return qualification_review_required_document(
+                "qualification", "spotify_playlist_changed",
+                draft_id=draft_id,
+                next_actions=["review", "discard"],
+            )
+        except SpotifyPlaylistReviewRequired:
+            return qualification_review_required_document(
+                "qualification", "qualification_review_required",
+                draft_id=draft_id,
+                next_actions=["review", "discard"],
+            )
+        return self._qualification_document(view, review_origin)
+
+    def record_qualification(
+        self,
+        draft_id: str,
+        item_id: str,
+        decision: QualificationDecision,
+        authorization: AgentAuthorization,
+        *,
+        spotify_reference: str | None = None,
+        reason: str | None = None,
+        exclude: bool = False,
+        review_origin: str = "http://127.0.0.1:8000",
+    ) -> dict:
+        """Stage one opaque draft outcome through the public Transfer seam."""
+        required = self._transfer.private_source_authorization_requirement(
+            authorization,
+        )
+        if required:
+            return authorization_required_document(
+                "qualification_decision", required,
+            )
+        review_origin = _loopback_review_origin(review_origin)
+        try:
+            view = self._transfer.record_qualification(
+                draft_id,
+                item_id,
+                decision,
+                authorization,
+                spotify_reference=spotify_reference,
+                reason=reason,
+                exclude=exclude,
+            )
+        except SpotifyPlaylistChanged:
+            return qualification_review_required_document(
+                "qualification_decision", "spotify_playlist_changed",
+                draft_id=draft_id,
+                next_actions=["review", "discard"],
+            )
+        except SpotifyPlaylistReviewRequired:
+            return qualification_review_required_document(
+                "qualification_decision", "qualification_review_required",
+                draft_id=draft_id,
+                next_actions=["review", "discard"],
+            )
         return self._qualification_document(view, review_origin)
 
     @staticmethod
     def _qualification_document(view, review_origin: str) -> dict:
+        review_origin = _loopback_review_origin(review_origin)
         status = view.status.value
-        next_actions = (
-            ["approve"] if status == QualificationStatus.APPLIED.value
-            else ["apply"] if view.complete
-            else ["review"]
-        )
         return {
             "contract_version": AGENT_CONTRACT_VERSION,
             "phase": "qualification",
@@ -274,11 +408,55 @@ class AgentTransferContract:
                 "deferred": view.deferred,
             },
             "authority": "none",
+            "current_item": (
+                {
+                    "item_id": view.current_item.item_id,
+                    "permitted_actions": [
+                        action.value
+                        for action in view.current_item.permitted_actions
+                    ],
+                }
+                if view.current_item is not None else None
+            ),
             "review_url": (
                 f"{review_origin.rstrip('/')}/qualification/{view.draft_id}"
             ),
-            "next_actions": next_actions,
+            "next_actions": list(view.next_actions),
         }
+
+    def link_qualification(
+        self,
+        draft_id: str,
+        publishing_transfer_id: str,
+        authorization: AgentAuthorization,
+        *,
+        review_origin: str = "http://127.0.0.1:8000",
+    ) -> dict:
+        required = self._transfer.private_source_authorization_requirement(
+            authorization,
+        )
+        if required:
+            return authorization_required_document(
+                "qualification_link", required,
+            )
+        review_origin = _loopback_review_origin(review_origin)
+        try:
+            view = self._transfer.link_qualification(
+                draft_id, publishing_transfer_id, authorization,
+            )
+        except SpotifyPlaylistChanged:
+            return qualification_review_required_document(
+                "qualification_link", "spotify_playlist_changed",
+                draft_id=draft_id,
+                next_actions=["review", "discard"],
+            )
+        except SpotifyPlaylistReviewRequired:
+            return qualification_review_required_document(
+                "qualification_link", "qualification_review_required",
+                draft_id=draft_id,
+                next_actions=["review", "discard"],
+            )
+        return self._qualification_document(view, review_origin)
 
     def apply_qualification(
         self, draft_id: str, authorization: AgentAuthorization,
@@ -292,7 +470,20 @@ class AgentTransferContract:
             return authorization_required_document(
                 "qualification_apply", "spotify_write",
             )
-        outcome = self._transfer.apply_qualification(draft_id, authorization)
+        try:
+            outcome = self._transfer.apply_qualification(draft_id, authorization)
+        except SpotifyPlaylistChanged:
+            return qualification_review_required_document(
+                "qualification_apply", "spotify_playlist_changed",
+                draft_id=draft_id,
+                next_actions=["review", "discard"],
+            )
+        except SpotifyPlaylistReviewRequired:
+            return qualification_review_required_document(
+                "qualification_apply", "qualification_review_required",
+                draft_id=draft_id,
+                next_actions=["review", "discard"],
+            )
         return {
             "contract_version": AGENT_CONTRACT_VERSION,
             "phase": "qualification_apply",
@@ -301,6 +492,97 @@ class AgentTransferContract:
             "counts": {"applied_items": outcome.applied_items},
             "authority": "none",
             "next_actions": list(outcome.next_actions),
+        }
+
+    def discard_qualification(
+        self, draft_id: str, authorization: AgentAuthorization,
+    ) -> dict:
+        required = self._transfer.private_source_authorization_requirement(
+            authorization,
+        )
+        if required:
+            return authorization_required_document(
+                "qualification_discard", required,
+            )
+        view = self._transfer.discard_qualification(draft_id, authorization)
+        return {
+            "contract_version": AGENT_CONTRACT_VERSION,
+            "phase": "qualification_discard",
+            "status": view.status.value,
+            "draft_id": view.draft_id,
+            "authority": "none",
+            "next_actions": list(view.next_actions),
+        }
+
+    def supersede_qualification(
+        self,
+        draft_id: str,
+        authorization: AgentAuthorization,
+        *,
+        review_origin: str = "http://127.0.0.1:8000",
+    ) -> dict:
+        required = self._transfer.private_source_authorization_requirement(
+            authorization,
+        )
+        if required:
+            return authorization_required_document(
+                "qualification_supersede", required,
+            )
+        review_origin = _loopback_review_origin(review_origin)
+        try:
+            view = self._transfer.supersede_qualification(
+                draft_id, authorization,
+            )
+        except SpotifyPlaylistReviewRequired:
+            return qualification_review_required_document(
+                "qualification_supersede", "qualification_review_required",
+                draft_id=draft_id,
+                next_actions=["review"],
+            )
+        return self._qualification_document(view, review_origin)
+
+    def approve_qualification(
+        self, draft_id: str, authorization: AgentAuthorization,
+    ) -> dict:
+        required = self._transfer.private_source_authorization_requirement(
+            authorization,
+        )
+        if required:
+            return authorization_required_document(
+                "qualification_approval", required,
+            )
+        try:
+            outcome = self._transfer.approve_qualification(
+                draft_id, authorization,
+            )
+        except SpotifyPlaylistChanged:
+            return qualification_review_required_document(
+                "qualification_approval", "spotify_playlist_changed",
+                draft_id=draft_id,
+            )
+        except SpotifyPlaylistReviewRequired:
+            return qualification_review_required_document(
+                "qualification_approval", "qualification_review_required",
+                draft_id=draft_id,
+            )
+        return {
+            "contract_version": AGENT_CONTRACT_VERSION,
+            "phase": "qualification_approval",
+            "status": outcome.status.value.replace(" ", "_"),
+            "draft_id": draft_id,
+            "counts": {
+                "approved": len(outcome.approved),
+                "rejected": len(outcome.rejected),
+                "collisions": len(outcome.collisions),
+                "corrections": len(outcome.corrections),
+            },
+            "authority": (
+                "playlist_approval"
+                if outcome.status.value == "approved" else "none"
+            ),
+            "next_actions": (
+                ["review"] if outcome.status.value == "needs review" else []
+            ),
         }
 
     def progress(

--- a/djsupport/backup.py
+++ b/djsupport/backup.py
@@ -18,8 +18,8 @@ from typing import Callable
 BACKUP_VERSION = 1
 SUPPORTED_SCHEMAS = {
     "matching-knowledge.json": (1, 2),
-    "transfers.json": (1, 2, 3),
-    "publication-manifests.transfers.json": (1, 2, 3),
+    "transfers.json": (1, 2, 3, 4),
+    "publication-manifests.transfers.json": (1, 2, 3, 4),
     "publication-manifests.json": (1, 2, 3, 4, 5),
     "playlist-state.json": (1, 2),
     "legacy-migration.json": (1,),
@@ -323,12 +323,21 @@ class LocalDataBackup:
                         label=f"local-audio:{safe_identity}",
                     )
         elif path in ("transfers.json", "publication-manifests.transfers.json"):
-            for field in ("transfers", "batches"):
+            combined["version"] = max(
+                current.get("version", 1), incoming.get("version", 1),
+            )
+            for field in ("transfers", "batches", "qualifications"):
                 combined.setdefault(field, {})
                 for key, value in incoming.get(field, {}).items():
                     if key not in combined[field]:
                         combined[field][key] = value
                         changes.append(f"add {field[:-1]}: {key}")
+                    elif field == "qualifications" and combined[field][key] != value:
+                        self._resolve_conflict(
+                            combined[field], key, value,
+                            "qualification-draft", path,
+                            conflicts, resolutions,
+                        )
         elif path == "playlist-state.json":
             combined.setdefault("entries", {})
             for key, value in incoming.get("entries", {}).items():

--- a/djsupport/backup.py
+++ b/djsupport/backup.py
@@ -17,10 +17,10 @@ from typing import Callable
 
 BACKUP_VERSION = 1
 SUPPORTED_SCHEMAS = {
-    "matching-knowledge.json": (1, 2),
+    "matching-knowledge.json": (1, 2, 3),
     "transfers.json": (1, 2, 3, 4),
     "publication-manifests.transfers.json": (1, 2, 3, 4),
-    "publication-manifests.json": (1, 2, 3, 4, 5),
+    "publication-manifests.json": (1, 2, 3, 4, 5, 6),
     "playlist-state.json": (1, 2),
     "legacy-migration.json": (1,),
     "foundation-migration.json": (1,),
@@ -350,6 +350,9 @@ class LocalDataBackup:
                         conflicts, resolutions,
                     )
         elif path == "publication-manifests.json":
+            combined["version"] = max(
+                current.get("version", 1), incoming.get("version", 1),
+            )
             for field in ("manifests", "mirrors"):
                 combined.setdefault(field, [])
                 for item in incoming.get(field, []):

--- a/djsupport/cache.py
+++ b/djsupport/cache.py
@@ -27,6 +27,8 @@ class CacheEntry:
     approval_status: str | None = None
     source_duration: int = 0
     score_reasons: tuple[str, ...] = ()
+    spotify_release: str = ""
+    spotify_duration: int = 0
 
     def __post_init__(self) -> None:
         self.score_reasons = tuple(self.score_reasons)
@@ -128,6 +130,8 @@ class MatchCache:
                 score=result["score"],
                 match_type=result.get("match_type"),
                 score_reasons=tuple(result.get("score_reasons", ())),
+                spotify_release=result.get("album", ""),
+                spotify_duration=int(result.get("duration_ms", 0)) // 1000,
                 matched=True,
                 timestamp=datetime.now().isoformat(),
                 threshold=threshold,
@@ -184,6 +188,13 @@ class MatchCache:
                 threshold=0,
                 match_type=result.get("match_type"),
                 score_reasons=tuple(result.get("score_reasons", ())),
+                spotify_release=result.get("spotify_release", result.get("album", "")),
+                spotify_duration=int(
+                    result.get(
+                        "spotify_duration",
+                        int(result.get("duration_ms", 0)) // 1000,
+                    )
+                ),
                 source_duration=source_duration,
             )
             self.entries[key] = entry
@@ -262,7 +273,12 @@ class MatchCache:
             "artist": item["spotify_artist"],
             "score": item["score"],
             "match_type": "approved_local_audio",
-            "score_reasons": ["Approved Match reused from local audio identity"],
+            "score_reasons": [
+                "Approved Match reused from local audio identity",
+                *item.get("score_reasons", ()),
+            ],
+            "album": item.get("spotify_release", ""),
+            "duration_ms": int(item.get("spotify_duration", 0)) * 1000,
             "authoritative": True,
         }
 
@@ -294,6 +310,8 @@ class MatchCache:
             "score": result["score"],
             "match_type": result.get("match_type", "exact"),
             "score_reasons": list(result.get("score_reasons", ())),
+            "spotify_release": result.get("spotify_release", ""),
+            "spotify_duration": int(result.get("spotify_duration", 0)),
             "authority_status": "approved",
             "approved_at": datetime.now().isoformat(),
         }

--- a/djsupport/cache.py
+++ b/djsupport/cache.py
@@ -8,7 +8,7 @@ from pathlib import Path
 
 from djsupport.matcher import _normalize
 
-CACHE_VERSION = 2
+CACHE_VERSION = 3
 DEFAULT_CACHE_PATH = ".djsupport_cache.json"
 DEFAULT_RETRY_DAYS = 7
 CHECKPOINT_INTERVAL = 50
@@ -29,6 +29,10 @@ class CacheEntry:
     score_reasons: tuple[str, ...] = ()
     spotify_release: str = ""
     spotify_duration: int = 0
+    availability_status: str = "unknown"
+    availability_reason: str | None = "not_checked"
+    availability_checked_at: str | None = None
+    availability_source: str | None = None
 
     def __post_init__(self) -> None:
         self.score_reasons = tuple(self.score_reasons)
@@ -43,6 +47,7 @@ class MatchCache:
         self.fingerprint_observations: dict[str, dict] = {}
         self.fingerprint_associations: list[dict] = []
         self._dirty_count: int = 0
+        self._durable_seen = False
 
     def load(self) -> None:
         """Load cache from disk. No-op if file doesn't exist."""
@@ -52,17 +57,47 @@ class MatchCache:
             data = json.loads(self.path.read_text())
         except (json.JSONDecodeError, OSError):
             return
-        if data.get("version") not in (1, CACHE_VERSION):
+        self._replace_from_data(data)
+        self._durable_seen = True
+
+    def reload_strict(self) -> None:
+        """Replace in-memory facts from durable state or fail closed."""
+        if not self.path.exists():
+            if self._durable_seen:
+                raise ValueError(
+                    "Matching knowledge is unavailable; restore it before use"
+                )
+            return
+        try:
+            data = json.loads(self.path.read_text())
+            self._replace_from_data(data)
+            self._durable_seen = True
+        except (
+            AttributeError, json.JSONDecodeError, OSError, KeyError, TypeError,
+        ) as exc:
+            raise ValueError(
+                "Matching knowledge is malformed; restore it before use"
+            ) from exc
+
+    def _replace_from_data(self, data: dict) -> None:
+        if data.get("version") not in (1, 2, CACHE_VERSION):
             raise ValueError(
                 "Unsupported matching-knowledge schema; upgrade djsupport "
                 "before using this file"
             )
-        for key, entry in data.get("entries", {}).items():
-            self.entries[key] = CacheEntry(**entry)
-        self.local_regressions = data.get("local_regressions", [])
-        self.approval_conflicts = data.get("approval_conflicts", [])
-        self.fingerprint_observations = data.get("fingerprint_observations", {})
-        self.fingerprint_associations = data.get("fingerprint_associations", [])
+        entries = {
+            key: CacheEntry(**entry)
+            for key, entry in data.get("entries", {}).items()
+        }
+        self.entries = entries
+        self.local_regressions = list(data.get("local_regressions", []))
+        self.approval_conflicts = list(data.get("approval_conflicts", []))
+        self.fingerprint_observations = dict(
+            data.get("fingerprint_observations", {})
+        )
+        self.fingerprint_associations = list(
+            data.get("fingerprint_associations", [])
+        )
 
     def save(self) -> None:
         """Write cache to disk."""
@@ -77,6 +112,7 @@ class MatchCache:
         }
         self.path.write_text(json.dumps(data, indent=2))
         self._dirty_count = 0
+        self._durable_seen = True
 
     def cache_key(self, artist: str, title: str, source_duration: int = 0) -> str:
         identity = f"{_normalize(artist)}||{_normalize(title)}"
@@ -132,6 +168,16 @@ class MatchCache:
                 score_reasons=tuple(result.get("score_reasons", ())),
                 spotify_release=result.get("album", ""),
                 spotify_duration=int(result.get("duration_ms", 0)) // 1000,
+                availability_status=result.get(
+                    "availability_status", "unknown",
+                ),
+                availability_reason=result.get(
+                    "availability_reason", "not_checked",
+                ),
+                availability_checked_at=result.get(
+                    "availability_checked_at"
+                ),
+                availability_source=result.get("availability_source"),
                 matched=True,
                 timestamp=datetime.now().isoformat(),
                 threshold=threshold,
@@ -196,6 +242,16 @@ class MatchCache:
                     )
                 ),
                 source_duration=source_duration,
+                availability_status=result.get(
+                    "availability_status", "unknown",
+                ),
+                availability_reason=result.get(
+                    "availability_reason", "not_checked",
+                ),
+                availability_checked_at=result.get(
+                    "availability_checked_at"
+                ),
+                availability_source=result.get("availability_source"),
             )
             self.entries[key] = entry
         entry.approval_status = status
@@ -279,6 +335,16 @@ class MatchCache:
             ],
             "album": item.get("spotify_release", ""),
             "duration_ms": int(item.get("spotify_duration", 0)) * 1000,
+            "availability_status": item.get(
+                "availability_status", "unknown",
+            ),
+            "availability_reason": item.get(
+                "availability_reason", "not_checked",
+            ),
+            "availability_checked_at": item.get(
+                "availability_checked_at"
+            ),
+            "availability_source": item.get("availability_source"),
             "authoritative": True,
         }
 
@@ -312,6 +378,16 @@ class MatchCache:
             "score_reasons": list(result.get("score_reasons", ())),
             "spotify_release": result.get("spotify_release", ""),
             "spotify_duration": int(result.get("spotify_duration", 0)),
+            "availability_status": result.get(
+                "availability_status", "unknown",
+            ),
+            "availability_reason": result.get(
+                "availability_reason", "not_checked",
+            ),
+            "availability_checked_at": result.get(
+                "availability_checked_at"
+            ),
+            "availability_source": result.get("availability_source"),
             "authority_status": "approved",
             "approved_at": datetime.now().isoformat(),
         }
@@ -342,17 +418,50 @@ class MatchCache:
                 and item.get("authority_status") == "conflict"
             )
         ]
-        if not any(
-            item["algorithm"] == association["algorithm"]
+        existing_index = next((
+            index
+            for index, item in enumerate(self.fingerprint_associations)
+            if item["algorithm"] == association["algorithm"]
             and item["algorithm_version"] == association["algorithm_version"]
             and item["fingerprint"] == association["fingerprint"]
             and item["account_id"] == association["account_id"]
             and item["spotify_uri"] == association["spotify_uri"]
-            for item in self.fingerprint_associations
-        ):
+        ), None)
+        if existing_index is None:
             self.fingerprint_associations.append(association)
             self._dirty_count += 1
+        elif self.fingerprint_associations[existing_index] != association:
+            self.fingerprint_associations[existing_index] = association
+            self._dirty_count += 1
         return None
+
+    def fingerprint_approval_conflict(
+        self, *, evidence_id: str, account_id: str, spotify_uri: str,
+        source_artist: str, source_title: str, source_duration: int,
+    ) -> dict | None:
+        """Inspect exact-identity authority without mutating retained facts."""
+        observation = self.fingerprint_observations.get(evidence_id)
+        if observation is None:
+            return None
+        approved_uris = {
+            item["spotify_uri"]
+            for item in self.fingerprint_associations
+            if item.get("algorithm") == observation.get("algorithm")
+            and item.get("algorithm_version")
+            == observation.get("algorithm_version")
+            and item.get("fingerprint") == observation.get("fingerprint")
+            and item.get("account_id") == account_id
+            and item.get("authority_status") == "approved"
+        }
+        if not approved_uris or approved_uris == {spotify_uri}:
+            return None
+        return {
+            "source_artist": source_artist,
+            "source_title": source_title,
+            "source_duration": source_duration,
+            "approved_spotify_uri": sorted(approved_uris)[0],
+            "proposed_spotify_uri": spotify_uri,
+        }
 
     def revoke_fingerprints(
         self, *, source_artist: str, source_title: str, source_duration: int,

--- a/djsupport/cli.py
+++ b/djsupport/cli.py
@@ -41,8 +41,11 @@ def capabilities(as_json: bool) -> None:
     """Inspect optional capabilities without reading a library or Spotify."""
     from djsupport.agent import capability_document
     from djsupport.local_audio import ChromaprintLocalAudio
+    from djsupport.local_audition import LocalSourceAudition
 
-    document = capability_document(ChromaprintLocalAudio().capability())
+    document = capability_document(
+        ChromaprintLocalAudio().capability(), LocalSourceAudition().capability(),
+    )
     if as_json:
         click.echo(json.dumps(document, sort_keys=True))
         return
@@ -54,6 +57,7 @@ def capabilities(as_json: bool) -> None:
         )
     else:
         click.echo("Local audio identity unavailable; install fpcalc to enable it.")
+    click.echo("Local audition available for explicitly authorized Rekordbox audio.")
 
 
 def _resolve_xml_path(explicit_xml_path: str | None) -> str:
@@ -264,6 +268,10 @@ def migrate_0_5(legacy_account_id: str, account_id: str) -> None:
     help="Opt into local audio identity for the selected Rekordbox Batch.",
 )
 @click.option(
+    "--local-audio-audition", is_flag=True,
+    help="Opt into private local audition for the selected Rekordbox Batch.",
+)
+@click.option(
     "--json", "agent_json", is_flag=True,
     help="Emit the versioned non-interactive agent contract.",
 )
@@ -294,6 +302,7 @@ def sync(
     no_prefix: bool,
     state_path: str,
     local_audio_identity: bool,
+    local_audio_audition: bool,
     agent_json: bool,
     authorize_private_source: bool,
     authorize_spotify_write: bool,
@@ -326,6 +335,7 @@ def sync(
         TransferAuthorization,
     )
     from djsupport.local_audio import ChromaprintLocalAudio
+    from djsupport.local_audition import LocalSourceAudition
 
     request = BatchPlanRequest(
         playlist_references=playlist,
@@ -337,6 +347,7 @@ def sync(
         playlist_prefix=None if no_prefix else prefix,
         confirm_expensive=confirm_expensive,
         local_audio_identity=local_audio_identity,
+        local_audio_audition=local_audio_audition,
     )
     authorization = TransferAuthorization(
         private_source=authorize_private_source,
@@ -395,7 +406,8 @@ def sync(
     ) is None
     transfer = Transfer(
         source=RekordboxPlaylistSource(
-            xml_path, include_locations=local_audio_identity,
+            xml_path,
+            include_locations=(local_audio_identity or local_audio_audition),
         ),
         spotify=(
             SpotifyMatcher(get_client())
@@ -413,6 +425,7 @@ def sync(
             str(Path(state_path).with_suffix(".transfers.json"))
         ),
         local_audio=(ChromaprintLocalAudio() if local_audio_identity else None),
+        local_audition=(LocalSourceAudition() if local_audio_audition else None),
     )
     if agent_json:
         from djsupport.agent import AgentTransferContract
@@ -471,6 +484,168 @@ def sync(
         save_review_csv(report, review_path)
         click.echo(f"\nDetailed report saved to {report_path}")
         click.echo(f"Editable review CSV saved to {review_path}")
+
+
+@cli.command("qualification")
+@click.argument("transfer_id")
+@click.argument("xml_path", required=False, type=click.Path())
+@click.option("--playlist", required=True, help="Exact selected Rekordbox playlist reference.")
+@click.option("--include-all", is_flag=True, help="Include authoritative proposals for spot-checking.")
+@click.option("--item-id", default=None, help="Opaque queue item to revise.")
+@click.option(
+    "--decision",
+    type=click.Choice([
+        "keep_proposal", "correction", "deferred", "reject_proposal",
+    ]),
+    default=None,
+    help="Stage one non-authoritative draft outcome.",
+)
+@click.option("--spotify-reference", default=None, help="Explicit Spotify URL/URI for a Correction.")
+@click.option("--reason", default=None, help="Optional private reason for a deferred item.")
+@click.option("--exclude", is_flag=True, help="Explicitly exclude one deferred item from apply.")
+@click.option("--apply", "apply_draft", is_flag=True, help="Apply a complete draft to its Provisional Playlist.")
+@click.option("--no-cache", is_flag=True, help="Bypass retained matching knowledge.")
+@click.option("--cache-path", default=DEFAULT_MATCHING_KNOWLEDGE_PATH, show_default=True)
+@click.option("--state-path", default=DEFAULT_PUBLICATION_MANIFEST_PATH, show_default=True)
+@click.option("--local-audio-audition", is_flag=True, help="Enable authorized audition facts for this session.")
+@click.option("--authorize-private-source", is_flag=True, help="Authorize this bounded Rekordbox selection.")
+@click.option("--authorize-spotify-write", is_flag=True, help="Authorize explicit draft application.")
+@click.option("--review-origin", default="http://127.0.0.1:8000", show_default=True)
+@click.option("--json", "agent_json", is_flag=True, help="Emit the privacy-redacted agent contract.")
+def qualification_command(
+    transfer_id: str,
+    xml_path: str | None,
+    playlist: str,
+    include_all: bool,
+    item_id: str | None,
+    decision: str | None,
+    spotify_reference: str | None,
+    reason: str | None,
+    exclude: bool,
+    apply_draft: bool,
+    no_cache: bool,
+    cache_path: str,
+    state_path: str,
+    local_audio_audition: bool,
+    authorize_private_source: bool,
+    authorize_spotify_write: bool,
+    review_origin: str,
+    agent_json: bool,
+) -> None:
+    """Obtain, revise, or apply one Rekordbox Qualification Draft."""
+    from djsupport.agent import (
+        AgentTransferContract,
+        authorization_required_document,
+        error_document,
+    )
+    from djsupport.cache import MatchCache
+    from djsupport.local_audition import LocalSourceAudition
+    from djsupport.transfer import (
+        EphemeralMatchingKnowledge,
+        FilePublicationStorage,
+        FileTransferStorage,
+        MatchCacheKnowledge,
+        QualificationDecision,
+        QualificationRequest,
+        RekordboxPlaylistSource,
+        SpotifyMatcher,
+        Transfer,
+        TransferAuthorization,
+    )
+
+    if not authorize_private_source:
+        if agent_json:
+            click.echo(json.dumps(
+                authorization_required_document(
+                    "qualification", "private_source",
+                ),
+                sort_keys=True,
+            ))
+            raise click.exceptions.Exit(2)
+        raise click.UsageError(
+            "Qualification requires --authorize-private-source."
+        )
+    if (item_id is None) != (decision is None):
+        raise click.UsageError("Use --item-id and --decision together.")
+    xml_path = _resolve_xml_path(xml_path)
+    cache = None if no_cache else MatchCache(cache_path)
+    if cache is not None:
+        cache.load()
+    transfer = Transfer(
+        source=RekordboxPlaylistSource(
+            xml_path, include_locations=local_audio_audition,
+        ),
+        spotify=SpotifyMatcher(get_client()),
+        publishing_guards=AccountPublishingGuards(),
+        matching_knowledge=(
+            EphemeralMatchingKnowledge()
+            if cache is None else MatchCacheKnowledge(cache)
+        ),
+        publication_storage=FilePublicationStorage(state_path),
+        transfer_storage=FileTransferStorage(
+            str(Path(state_path).with_suffix(".transfers.json"))
+        ),
+        local_audition=(
+            LocalSourceAudition() if local_audio_audition else None
+        ),
+    )
+    authorization = TransferAuthorization(
+        private_source=True,
+        spotify_write=authorize_spotify_write,
+    )
+    contract = AgentTransferContract(transfer)
+    request = QualificationRequest(
+        transfer_id=transfer_id,
+        playlist_reference=playlist,
+        include_all=include_all,
+    )
+    try:
+        document = contract.qualification_draft(
+            request, authorization, review_origin=review_origin,
+        )
+        draft_id = document.get("draft_id")
+        if draft_id and item_id and decision:
+            transfer.record_qualification(
+                draft_id,
+                item_id,
+                QualificationDecision(decision),
+                spotify_reference=spotify_reference,
+                reason=reason,
+                exclude=exclude,
+            )
+            document = contract.qualification_progress(
+                draft_id, authorization, review_origin=review_origin,
+            )
+        if draft_id and apply_draft:
+            document = contract.apply_qualification(draft_id, authorization)
+    except (OSError, PermissionError, ValueError) as exc:
+        if agent_json:
+            click.echo(json.dumps(
+                error_document("qualification", "qualification_unavailable"),
+                sort_keys=True,
+            ))
+            raise click.exceptions.Exit(2) from exc
+        raise click.ClickException("Qualification operation is unavailable.") from exc
+    if agent_json:
+        click.echo(json.dumps(document, sort_keys=True))
+        if document["status"] in {"authorization_required", "error"}:
+            raise click.exceptions.Exit(2)
+        return
+    view = transfer.qualification(document["draft_id"])
+    click.echo(
+        f"Qualification Draft {view.draft_id}: {view.status.value}; "
+        f"{len(view.items)} items, {view.pending} pending, "
+        f"{view.deferred} deferred."
+    )
+    current = view.current_item
+    if current is not None:
+        click.echo(
+            f"Current: {current.source_artist} — {current.source_title}; "
+            f"proposal {current.spotify_artist} — {current.spotify_name}; "
+            f"{current.match_type}; score {current.score:.0f}."
+        )
+    click.echo(f"Review locally: {review_origin.rstrip('/')}/qualification/{view.draft_id}")
+    click.echo("Draft outcomes carry no authority; Approval remains separate.")
 
 
 @cli.command("list")

--- a/djsupport/cli.py
+++ b/djsupport/cli.py
@@ -364,6 +364,10 @@ def sync(
                 authorization_required_document("plan", required), sort_keys=True,
             ))
             raise click.exceptions.Exit(2)
+    elif local_audio_audition and not authorization.private_source:
+        raise click.UsageError(
+            "Local audition requires --authorize-private-source."
+        )
     if local_audio_identity and no_cache:
         if agent_json:
             from djsupport.agent import error_document
@@ -447,6 +451,7 @@ def sync(
         click.echo(json.dumps(outcome, sort_keys=True))
         if outcome["status"] in {
             "authorization_required", "confirmation_required", "error",
+            "review_required",
         } or outcome.get("required_authorizations"):
             raise click.exceptions.Exit(2)
         return
@@ -487,9 +492,11 @@ def sync(
 
 
 @cli.command("qualification")
-@click.argument("transfer_id")
-@click.argument("xml_path", required=False, type=click.Path())
-@click.option("--playlist", required=True, help="Exact selected Rekordbox playlist reference.")
+@click.argument("transfer_id", required=False)
+@click.argument("xml_path_argument", required=False, type=click.Path())
+@click.option("--xml-path", default=None, type=click.Path(), help="Explicit Rekordbox XML path for a draft-scoped operation.")
+@click.option("--draft-id", default=None, help="Opaque Qualification Draft to resume.")
+@click.option("--playlist", default=None, help="Exact selected Rekordbox playlist reference when obtaining a draft.")
 @click.option("--include-all", is_flag=True, help="Include authoritative proposals for spot-checking.")
 @click.option("--item-id", default=None, help="Opaque queue item to revise.")
 @click.option(
@@ -504,18 +511,23 @@ def sync(
 @click.option("--reason", default=None, help="Optional private reason for a deferred item.")
 @click.option("--exclude", is_flag=True, help="Explicitly exclude one deferred item from apply.")
 @click.option("--apply", "apply_draft", is_flag=True, help="Apply a complete draft to its Provisional Playlist.")
+@click.option("--approve", "approve_draft", is_flag=True, help="Separately Approve an applied draft's stable playlist.")
+@click.option("--discard", "discard_draft", is_flag=True, help="Explicitly retire an unapplied draft without authority.")
+@click.option("--supersede", "supersede_draft", is_flag=True, help="Start fresh from an explicitly discarded draft.")
+@click.option("--link-transfer", default=None, help="Link a Preview draft to a distinct publishing Batch or Transfer.")
 @click.option("--no-cache", is_flag=True, help="Bypass retained matching knowledge.")
 @click.option("--cache-path", default=DEFAULT_MATCHING_KNOWLEDGE_PATH, show_default=True)
 @click.option("--state-path", default=DEFAULT_PUBLICATION_MANIFEST_PATH, show_default=True)
-@click.option("--local-audio-audition", is_flag=True, help="Enable authorized audition facts for this session.")
 @click.option("--authorize-private-source", is_flag=True, help="Authorize this bounded Rekordbox selection.")
 @click.option("--authorize-spotify-write", is_flag=True, help="Authorize explicit draft application.")
 @click.option("--review-origin", default="http://127.0.0.1:8000", show_default=True)
 @click.option("--json", "agent_json", is_flag=True, help="Emit the privacy-redacted agent contract.")
 def qualification_command(
-    transfer_id: str,
+    transfer_id: str | None,
+    xml_path_argument: str | None,
     xml_path: str | None,
-    playlist: str,
+    draft_id: str | None,
+    playlist: str | None,
     include_all: bool,
     item_id: str | None,
     decision: str | None,
@@ -523,16 +535,19 @@ def qualification_command(
     reason: str | None,
     exclude: bool,
     apply_draft: bool,
+    approve_draft: bool,
+    discard_draft: bool,
+    supersede_draft: bool,
+    link_transfer: str | None,
     no_cache: bool,
     cache_path: str,
     state_path: str,
-    local_audio_audition: bool,
     authorize_private_source: bool,
     authorize_spotify_write: bool,
     review_origin: str,
     agent_json: bool,
 ) -> None:
-    """Obtain, revise, or apply one Rekordbox Qualification Draft."""
+    """Obtain or perform one explicit operation on a Qualification Draft."""
     from djsupport.agent import (
         AgentTransferContract,
         authorization_required_document,
@@ -565,59 +580,145 @@ def qualification_command(
         raise click.UsageError(
             "Qualification requires --authorize-private-source."
         )
+    if xml_path is not None and xml_path_argument is not None:
+        raise click.UsageError("Use the XML positional argument or --xml-path, not both.")
+    selected_xml_path = xml_path or xml_path_argument
     if (item_id is None) != (decision is None):
         raise click.UsageError("Use --item-id and --decision together.")
-    xml_path = _resolve_xml_path(xml_path)
-    cache = None if no_cache else MatchCache(cache_path)
-    if cache is not None:
-        cache.load()
-    transfer = Transfer(
-        source=RekordboxPlaylistSource(
-            xml_path, include_locations=local_audio_audition,
-        ),
-        spotify=SpotifyMatcher(get_client()),
-        publishing_guards=AccountPublishingGuards(),
-        matching_knowledge=(
-            EphemeralMatchingKnowledge()
-            if cache is None else MatchCacheKnowledge(cache)
-        ),
-        publication_storage=FilePublicationStorage(state_path),
-        transfer_storage=FileTransferStorage(
-            str(Path(state_path).with_suffix(".transfers.json"))
-        ),
-        local_audition=(
-            LocalSourceAudition() if local_audio_audition else None
-        ),
-    )
+    operation_count = sum((
+        bool(item_id), apply_draft, approve_draft, discard_draft,
+        supersede_draft, link_transfer is not None,
+    ))
+    if operation_count > 1:
+        raise click.UsageError(
+            "Choose exactly one draft operation per invocation; Apply and "
+            "Approval are always separate."
+        )
+    if draft_id is None:
+        if operation_count:
+            raise click.UsageError("Draft operations require --draft-id.")
+        if transfer_id is None or playlist is None:
+            raise click.UsageError(
+                "Obtaining a draft requires TRANSFER_ID and --playlist."
+            )
+    elif transfer_id is not None or playlist is not None or include_all:
+        raise click.UsageError(
+            "Use --draft-id by itself for resumable draft-scoped operations."
+        )
+    try:
+        selected_xml_path = _resolve_xml_path(selected_xml_path)
+    except (click.ClickException, OSError, ValueError) as exc:
+        if not agent_json:
+            raise
+        click.echo(json.dumps(
+            error_document("qualification", "private_source_unavailable"),
+            sort_keys=True,
+        ))
+        raise click.exceptions.Exit(2) from exc
     authorization = TransferAuthorization(
         private_source=True,
         spotify_write=authorize_spotify_write,
     )
-    contract = AgentTransferContract(transfer)
-    request = QualificationRequest(
-        transfer_id=transfer_id,
-        playlist_reference=playlist,
-        include_all=include_all,
-    )
     try:
-        document = contract.qualification_draft(
-            request, authorization, review_origin=review_origin,
+        transfer_storage = FileTransferStorage(
+            str(Path(state_path).with_suffix(".transfers.json"))
         )
-        draft_id = document.get("draft_id")
-        if draft_id and item_id and decision:
-            transfer.record_qualification(
+        if draft_id is not None:
+            stored_draft = transfer_storage.load_qualification(draft_id)
+            stored_state = (
+                transfer_storage.load_transfer(stored_draft.transfer_id)
+                if stored_draft is not None else None
+            )
+            if stored_draft is None or stored_state is None:
+                raise ValueError("Qualification Draft is unavailable")
+            local_audio_audition = bool(
+                stored_state.request.get("local_audio_audition", False)
+            )
+            no_cache = not bool(
+                stored_state.request.get("retain_matching_knowledge", True)
+            )
+        else:
+            assert transfer_id is not None and playlist is not None
+            stored_batch = transfer_storage.load_batch(transfer_id)
+            stored_transfer_id = transfer_id
+            if stored_batch is not None:
+                selected = [
+                    item for item in stored_batch.playlists
+                    if item.reference == playlist
+                ]
+                if len(selected) != 1:
+                    raise ValueError("Qualification playlist is unavailable")
+                stored_transfer_id = selected[0].transfer_id
+            stored_state = transfer_storage.load_transfer(stored_transfer_id)
+            if stored_state is None:
+                raise ValueError("Qualification Transfer is unavailable")
+            local_audio_audition = bool(
+                stored_state.request.get("local_audio_audition", False)
+            )
+            no_cache = not bool(
+                stored_state.request.get("retain_matching_knowledge", True)
+            )
+        cache = None if no_cache else MatchCache(cache_path)
+        if cache is not None:
+            cache.load()
+        transfer = Transfer(
+            source=RekordboxPlaylistSource(
+                selected_xml_path, include_locations=local_audio_audition,
+            ),
+            spotify=SpotifyMatcher(get_client()),
+            publishing_guards=AccountPublishingGuards(),
+            matching_knowledge=(
+                EphemeralMatchingKnowledge()
+                if cache is None else MatchCacheKnowledge(cache)
+            ),
+            publication_storage=FilePublicationStorage(state_path),
+            transfer_storage=transfer_storage,
+            local_audition=(
+                LocalSourceAudition() if local_audio_audition else None
+            ),
+        )
+        contract = AgentTransferContract(transfer)
+        if draft_id is None:
+            assert transfer_id is not None and playlist is not None
+            document = contract.qualification_draft(
+                QualificationRequest(
+                    transfer_id=transfer_id,
+                    playlist_reference=playlist,
+                    include_all=include_all,
+                ),
+                authorization,
+                review_origin=review_origin,
+            )
+        elif item_id and decision:
+            document = contract.record_qualification(
                 draft_id,
                 item_id,
                 QualificationDecision(decision),
+                authorization,
                 spotify_reference=spotify_reference,
                 reason=reason,
                 exclude=exclude,
+                review_origin=review_origin,
             )
+        elif apply_draft:
+            document = contract.apply_qualification(draft_id, authorization)
+        elif approve_draft:
+            document = contract.approve_qualification(draft_id, authorization)
+        elif discard_draft:
+            document = contract.discard_qualification(draft_id, authorization)
+        elif supersede_draft:
+            document = contract.supersede_qualification(
+                draft_id, authorization, review_origin=review_origin,
+            )
+        elif link_transfer is not None:
+            document = contract.link_qualification(
+                draft_id, link_transfer, authorization,
+                review_origin=review_origin,
+            )
+        else:
             document = contract.qualification_progress(
                 draft_id, authorization, review_origin=review_origin,
             )
-        if draft_id and apply_draft:
-            document = contract.apply_qualification(draft_id, authorization)
     except (OSError, PermissionError, ValueError) as exc:
         if agent_json:
             click.echo(json.dumps(
@@ -628,10 +729,27 @@ def qualification_command(
         raise click.ClickException("Qualification operation is unavailable.") from exc
     if agent_json:
         click.echo(json.dumps(document, sort_keys=True))
-        if document["status"] in {"authorization_required", "error"}:
+        if document["status"] in {
+            "authorization_required", "error", "review_required",
+        }:
             raise click.exceptions.Exit(2)
         return
-    view = transfer.qualification(document["draft_id"])
+    if document["status"] in {"authorization_required", "error"}:
+        raise click.ClickException("Qualification operation is unavailable.")
+    if document["status"] == "review_required":
+        handle = document.get("draft_id", "the selected draft")
+        raise click.ClickException(
+            f"Qualification review required for {handle}; use --discard "
+            "before an explicit --supersede."
+        )
+    if document["phase"] == "qualification_approval":
+        click.echo(
+            f"Qualification Approval: {document['status']}; "
+            f"{document['counts']['approved']} approved, "
+            f"{document['counts']['rejected']} rejected."
+        )
+        return
+    view = transfer.qualification(document["draft_id"], authorization)
     click.echo(
         f"Qualification Draft {view.draft_id}: {view.status.value}; "
         f"{len(view.items)} items, {view.pending} pending, "
@@ -684,7 +802,10 @@ def approve(
     from djsupport.transfer import (
         BeatportChartSource,
         FilePublicationStorage,
+        FileTransferStorage,
         MatchCacheKnowledge,
+        SpotifyPlaylistChanged,
+        SpotifyPlaylistReviewRequired,
         SpotifyMatcher,
         Transfer,
     )
@@ -697,12 +818,19 @@ def approve(
         publishing_guards=AccountPublishingGuards(),
         matching_knowledge=MatchCacheKnowledge(cache),
         publication_storage=FilePublicationStorage(state_path),
+        transfer_storage=FileTransferStorage(
+            str(Path(state_path).with_suffix(".transfers.json"))
+        ),
     )
     try:
         if review_csv is None:
             review = transfer.approve(playlist_id)
         else:
             review = transfer.approve(playlist_id, corrections=review_csv)
+    except (SpotifyPlaylistChanged, SpotifyPlaylistReviewRequired) as exc:
+        raise click.ClickException(
+            "Playlist review is required before Approval."
+        ) from exc
     except ValueError as exc:
         raise click.ClickException(str(exc)) from exc
     if review.status.value == "abandoned":

--- a/djsupport/local_audition.py
+++ b/djsupport/local_audition.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import os
 import re
 import secrets
 import time
@@ -9,6 +10,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Callable, Iterator
 from urllib.parse import unquote, urlparse
+from urllib.request import url2pathname
 
 from djsupport.rekordbox import Track
 
@@ -183,7 +185,10 @@ class LocalSourceAudition:
             return LocalAuditionResult.unavailable("unsupported_location")
         if parsed.scheme == "file" and parsed.netloc not in ("", "localhost"):
             return LocalAuditionResult.unavailable("unsupported_location")
-        raw_path = unquote(parsed.path) if parsed.scheme else location
+        raw_path = (
+            self._file_uri_path(parsed.path)
+            if parsed.scheme else location
+        )
         if not raw_path:
             return LocalAuditionResult.unavailable("missing_location")
         if any(character in raw_path for character in ("*", "?", "[", "]")):
@@ -203,6 +208,15 @@ class LocalSourceAudition:
         except OSError:
             return LocalAuditionResult.unavailable("unreadable_media")
         return path, media_type, size
+
+    @staticmethod
+    def _file_uri_path(uri_path: str, *, windows: bool | None = None) -> str:
+        """Convert a local file-URI path using the host platform's rules."""
+        decoded = unquote(uri_path)
+        windows = os.name == "nt" if windows is None else windows
+        if windows and re.match(r"^/[A-Za-z]:[/\\]", decoded):
+            decoded = decoded[1:]
+        return url2pathname(decoded)
 
     def _range(
         self, header: str | None, total: int,

--- a/djsupport/local_audition.py
+++ b/djsupport/local_audition.py
@@ -1,0 +1,243 @@
+"""Process-local, path-redacted media adapter for selected Rekordbox audio."""
+
+from __future__ import annotations
+
+import re
+import secrets
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Callable, Iterator
+from urllib.parse import unquote, urlparse
+
+from djsupport.rekordbox import Track
+
+
+MEDIA_TYPES = {
+    ".aif": "audio/aiff",
+    ".aiff": "audio/aiff",
+    ".flac": "audio/flac",
+    ".m4a": "audio/mp4",
+    ".mp3": "audio/mpeg",
+    ".ogg": "audio/ogg",
+    ".wav": "audio/wav",
+}
+
+
+@dataclass(frozen=True)
+class LocalAuditionCapability:
+    available: bool = True
+    reason: str | None = None
+
+
+@dataclass(frozen=True)
+class LocalAuditionResult:
+    """Path-free facts returned after one explicitly authorized media open."""
+
+    status: str
+    handle: str | None = None
+    media_type: str | None = None
+    content_length: int = 0
+    reason: str | None = None
+    expires_in: int | None = None
+
+    @classmethod
+    def unavailable(cls, reason: str) -> LocalAuditionResult:
+        return cls(status="unavailable", reason=reason)
+
+
+@dataclass(frozen=True)
+class AuditionStream:
+    status_code: int
+    media_type: str
+    content_length: int
+    body: Iterator[bytes]
+    content_range: str | None = None
+
+
+class AuditionHandleUnavailable(LookupError):
+    """An audition handle is invalid, expired, or process-local elsewhere."""
+
+
+class AuditionRangeNotSatisfiable(ValueError):
+    def __init__(self, total_size: int) -> None:
+        super().__init__("Audition byte range is not satisfiable")
+        self.total_size = total_size
+
+
+@dataclass
+class _AuditionResource:
+    transfer_id: str
+    item_id: str
+    path: Path
+    media_type: str
+    content_length: int
+    expires_at: float
+
+
+class LocalSourceAudition:
+    """Issue short-lived handles for exact selected local audio references."""
+
+    def __init__(
+        self,
+        *,
+        ttl_seconds: int = 600,
+        max_range_bytes: int = 2 * 1024 * 1024,
+        chunk_bytes: int = 64 * 1024,
+        clock: Callable[[], float] = time.monotonic,
+    ) -> None:
+        self._ttl_seconds = ttl_seconds
+        self._max_range_bytes = max_range_bytes
+        self._chunk_bytes = chunk_bytes
+        self._clock = clock
+        self._resources: dict[str, _AuditionResource] = {}
+
+    def capability(self) -> LocalAuditionCapability:
+        """Inspect support without reading source media."""
+        return LocalAuditionCapability()
+
+    def preflight(self, track: Track) -> LocalAuditionResult:
+        resolved = self._resolve_track(track)
+        if isinstance(resolved, LocalAuditionResult):
+            return resolved
+        path, media_type, size = resolved
+        del path
+        return LocalAuditionResult(
+            status="available",
+            media_type=media_type,
+            content_length=size,
+        )
+
+    def open(
+        self, transfer_id: str, item_id: str, track: Track,
+    ) -> LocalAuditionResult:
+        resolved = self._resolve_track(track)
+        if isinstance(resolved, LocalAuditionResult):
+            return resolved
+        path, media_type, size = resolved
+        self._purge_expired()
+        for handle, resource in list(self._resources.items()):
+            if (
+                resource.transfer_id == transfer_id
+                and resource.item_id == item_id
+            ):
+                self._resources.pop(handle, None)
+        handle = secrets.token_urlsafe(32)
+        self._resources[handle] = _AuditionResource(
+            transfer_id=transfer_id,
+            item_id=item_id,
+            path=path,
+            media_type=media_type,
+            content_length=size,
+            expires_at=self._clock() + self._ttl_seconds,
+        )
+        return LocalAuditionResult(
+            status="available",
+            handle=handle,
+            media_type=media_type,
+            content_length=size,
+            expires_in=self._ttl_seconds,
+        )
+
+    def invalidate_transfer(self, transfer_id: str) -> None:
+        for handle, resource in list(self._resources.items()):
+            if resource.transfer_id == transfer_id:
+                self._resources.pop(handle, None)
+
+    def stream(
+        self, handle: str | None, range_header: str | None = None,
+    ) -> AuditionStream:
+        self._purge_expired()
+        if not handle or handle not in self._resources:
+            raise AuditionHandleUnavailable("Audition handle is unavailable")
+        resource = self._resources[handle]
+        start, end, status = self._range(
+            range_header, resource.content_length,
+        )
+        length = max(0, end - start + 1)
+        return AuditionStream(
+            status_code=status,
+            media_type=resource.media_type,
+            content_length=length,
+            content_range=(
+                f"bytes {start}-{end}/{resource.content_length}"
+                if status == 206 else None
+            ),
+            body=self._read(resource.path, start, length),
+        )
+
+    def _purge_expired(self) -> None:
+        now = self._clock()
+        for handle, resource in list(self._resources.items()):
+            if resource.expires_at <= now:
+                self._resources.pop(handle, None)
+
+    def _resolve_track(
+        self, track: Track,
+    ) -> tuple[Path, str, int] | LocalAuditionResult:
+        location = track.location
+        if not location:
+            return LocalAuditionResult.unavailable("missing_location")
+        parsed = urlparse(location)
+        if parsed.scheme and parsed.scheme != "file":
+            return LocalAuditionResult.unavailable("unsupported_location")
+        if parsed.scheme == "file" and parsed.netloc not in ("", "localhost"):
+            return LocalAuditionResult.unavailable("unsupported_location")
+        raw_path = unquote(parsed.path) if parsed.scheme else location
+        if not raw_path:
+            return LocalAuditionResult.unavailable("missing_location")
+        if any(character in raw_path for character in ("*", "?", "[", "]")):
+            return LocalAuditionResult.unavailable("unsafe_location")
+        path = Path(raw_path)
+        media_type = MEDIA_TYPES.get(path.suffix.casefold())
+        if media_type is None:
+            return LocalAuditionResult.unavailable("unsupported_format")
+        try:
+            if not path.is_file():
+                return LocalAuditionResult.unavailable("missing_file")
+            size = path.stat().st_size
+            with path.open("rb"):
+                pass
+        except PermissionError:
+            return LocalAuditionResult.unavailable("unreadable_media")
+        except OSError:
+            return LocalAuditionResult.unavailable("unreadable_media")
+        return path, media_type, size
+
+    def _range(
+        self, header: str | None, total: int,
+    ) -> tuple[int, int, int]:
+        if header is None:
+            return 0, total - 1, 200
+        match = re.fullmatch(r"bytes=(\d*)-(\d*)", header.strip())
+        if match is None or not any(match.groups()) or total <= 0:
+            raise AuditionRangeNotSatisfiable(total)
+        start_text, end_text = match.groups()
+        if start_text:
+            start = int(start_text)
+            end = int(end_text) if end_text else min(
+                total - 1, start + self._max_range_bytes - 1,
+            )
+        else:
+            suffix = int(end_text)
+            if suffix <= 0 or suffix > self._max_range_bytes:
+                raise AuditionRangeNotSatisfiable(total)
+            start = max(0, total - suffix)
+            end = total - 1
+        if (
+            start < 0 or start >= total or end < start or end >= total
+            or end - start + 1 > self._max_range_bytes
+        ):
+            raise AuditionRangeNotSatisfiable(total)
+        return start, end, 206
+
+    def _read(self, path: Path, start: int, length: int) -> Iterator[bytes]:
+        with path.open("rb") as media:
+            media.seek(start)
+            remaining = length
+            while remaining:
+                chunk = media.read(min(self._chunk_bytes, remaining))
+                if not chunk:
+                    break
+                remaining -= len(chunk)
+                yield chunk

--- a/djsupport/matcher.py
+++ b/djsupport/matcher.py
@@ -172,7 +172,16 @@ def _score_components(track: Track, result: dict) -> dict[str, float]:
 
 def _classify_version_match(track: Track, result: dict) -> str:
     """Classify version agreement as exact or fallback_version."""
-    track_mix = _extract_mix_descriptor(track.name)
+    retained_version = _normalize(track.version)
+    track_mix = (
+        retained_version
+        if retained_version and re.search(
+            r"\b(mix|remix|edit|version|dub|original|extended|radio|"
+            r"instrumental|interpretation|short)\b",
+            retained_version,
+        )
+        else _extract_mix_descriptor(track.name)
+    )
     result_mix = _extract_mix_descriptor(result["name"])
 
     track_named_variant = _is_named_variant(track_mix)

--- a/djsupport/migration.py
+++ b/djsupport/migration.py
@@ -24,8 +24,8 @@ LEGACY_STATE_FILES = (
     ".djsupport_beatport_playlists.json",
 )
 MIGRATION_VERSION = 1
-MATCHING_KNOWLEDGE_VERSION = 2
-SUPPORTED_PUBLICATION_VERSIONS = (1, 2, 3, 4, 5)
+MATCHING_KNOWLEDGE_VERSION = 3
+SUPPORTED_PUBLICATION_VERSIONS = (1, 2, 3, 4, 5, 6)
 SPOTIFY_TRACK_URI = re.compile(r"^spotify:track:[A-Za-z0-9]{22}$")
 CACHE_FIELDS = {
     "spotify_uri", "spotify_name", "spotify_artist", "score", "matched",
@@ -330,7 +330,7 @@ class LegacyMigration:
             }
         data = json.loads(path.read_text())
         if (
-            data.get("version") not in (1, MATCHING_KNOWLEDGE_VERSION)
+            data.get("version") not in (1, 2, MATCHING_KNOWLEDGE_VERSION)
             or not isinstance(data.get("entries"), dict)
         ):
             raise ValueError("Current matching knowledge is unsupported or malformed")

--- a/djsupport/rekordbox.py
+++ b/djsupport/rekordbox.py
@@ -17,6 +17,7 @@ class Track:
     date_added: str  # e.g. "2024-03-15"
     duration: int = 0  # seconds, from TotalTime attribute
     location: str = ""  # private Rekordbox audio reference; never report this value
+    version: str = ""  # retained Rekordbox Mix/version metadata when available
 
     @property
     def display(self) -> str:
@@ -59,6 +60,7 @@ def parse_xml(
                 date_added=track_el.get("DateAdded", ""),
                 duration=int(total_time) if total_time.isdigit() else 0,
                 location=(track_el.get("Location", "") if include_locations else ""),
+                version=track_el.get("Mix", ""),
             )
 
     # Parse playlist tree

--- a/djsupport/report.py
+++ b/djsupport/report.py
@@ -29,13 +29,19 @@ class ReviewTrack:
     source_name: str
     source_artist: str = ""
     source_title: str = ""
+    source_release: str = ""
+    source_label: str = ""
+    source_version: str = ""
     source_duration: int = 0
     spotify_uri: str = ""
     spotify_name: str = ""
     spotify_artist: str = ""
+    spotify_release: str = ""
+    spotify_duration: int = 0
     score: float = 0.0
     match_type: str = "unmatched"
     score_reasons: tuple[str, ...] = ()
+    authority_status: str = "proposal"
 
 
 @dataclass(frozen=True)
@@ -421,7 +427,8 @@ def save_review_csv(report: SyncReport, path: str) -> None:
         writer.writerow([
             "source_track_id", "source_track", "spotify_url", "spotify_track",
             "score", "match_type", "score_reasons", "source_artist", "source_title",
-            "source_duration",
+            "source_release", "source_label", "source_version", "source_duration",
+            "spotify_release", "spotify_duration", "authority_status",
         ])
         for playlist in report.playlists:
             review_items = (
@@ -446,7 +453,13 @@ def save_review_csv(report: SyncReport, path: str) -> None:
                         "; ".join(item.score_reasons),
                         item.source_artist,
                         item.source_title,
+                        item.source_release,
+                        item.source_label,
+                        item.source_version,
                         item.source_duration,
+                        item.spotify_release,
+                        item.spotify_duration,
+                        item.authority_status,
                     ])
                 continue
             for match in playlist.matched:
@@ -458,6 +471,12 @@ def save_review_csv(report: SyncReport, path: str) -> None:
                     f"{match.score:.1f}",
                     match.match_type,
                     "; ".join(match.score_reasons),
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
                     "",
                     "",
                     "",

--- a/djsupport/static/index.html
+++ b/djsupport/static/index.html
@@ -780,13 +780,18 @@
                 <div class="qualification-panel-label">One outcome</div>
                 <p class="decision-copy">This draft has no matching or playlist authority. Choose only what you verified.</p>
                 <div id="decision-actions">
-                    <button class="decision-btn decision-btn--correct" type="button" onclick="submitQualification('keep_proposal')">CORRECT</button>
-                    <button class="decision-btn" type="button" onclick="submitQualification('correction')">WRONG — FIND ANOTHER</button>
-                    <button class="decision-btn" type="button" onclick="submitQualification('deferred')">CANNOT VERIFY</button>
-                    <button class="decision-btn decision-btn--danger" type="button" onclick="submitQualification('reject_proposal')">NOT MY SOURCE</button>
+                    <button data-decision="keep_proposal" class="decision-btn decision-btn--correct" type="button" onclick="submitQualification('keep_proposal')">CORRECT</button>
+                    <button data-decision="correction" class="decision-btn" type="button" onclick="submitQualification('correction')">WRONG — FIND ANOTHER</button>
+                    <button data-decision="deferred" class="decision-btn" type="button" onclick="submitQualification('deferred')">CANNOT VERIFY</button>
+                    <button data-decision="reject_proposal" class="decision-btn decision-btn--danger" type="button" onclick="submitQualification('reject_proposal')">NOT MY SOURCE</button>
                 </div>
                 <p class="draft-authority">Applying changes only the linked Provisional Playlist. Approval remains a later, separate operation.</p>
+                <button id="include-all-btn" class="btn btn--ghost apply-draft hidden" type="button" onclick="includeAllQualification()">INCLUDE ALL PROPOSALS</button>
                 <button id="apply-draft-btn" class="btn btn--disabled apply-draft" type="button" onclick="applyQualification()" disabled>APPLY DRAFT</button>
+                <button id="link-draft-btn" class="btn btn--ghost apply-draft hidden" type="button" onclick="linkQualification()">LINK PUBLISHED MIRROR</button>
+                <button id="approve-draft-btn" class="btn btn--accent apply-draft hidden" type="button" onclick="approveQualification()">APPROVE PLAYLIST</button>
+                <button id="discard-draft-btn" class="btn btn--ghost apply-draft hidden" type="button" onclick="discardQualification()">DISCARD DRAFT</button>
+                <button id="supersede-draft-btn" class="btn btn--ghost apply-draft hidden" type="button" onclick="supersedeQualification()">START FRESH REVIEW</button>
             </aside>
         </div>
     </main>
@@ -901,11 +906,34 @@
             return `<div class="evidence-row"><span class="evidence-key">${esc(key)}</span><span class="evidence-value">${esc(value || 'Not retained')}</span></div>`;
         }
 
+        function availabilityEvidence(proposal) {
+            const details = [proposal.availability_status || 'unknown'];
+            if (proposal.availability_reason) details.push(proposal.availability_reason.replace(/_/g, ' '));
+            details.push(proposal.availability_checked_at
+                ? `checked ${proposal.availability_checked_at}`
+                : 'not checked');
+            if (proposal.availability_source) details.push(proposal.availability_source.replace(/_/g, ' '));
+            return details.join(' · ');
+        }
+
         function renderQualification() {
             if (!qualificationData) return;
             const items = qualificationData.items || [];
             const decided = items.filter((item) => item.decision && !(item.decision === 'deferred' && !item.excluded)).length;
             document.getElementById('qualification-progress').textContent = `${decided}/${items.length} outcomes · ${qualificationData.status.replace(/_/g, ' ')}`;
+            const nextActions = new Set(qualificationData.next_actions || []);
+            const apply = document.getElementById('apply-draft-btn');
+            const canApply = nextActions.has('apply') || nextActions.has('resume');
+            apply.disabled = !canApply;
+            apply.textContent = nextActions.has('resume') ? 'RESUME APPLY' : 'APPLY DRAFT';
+            apply.className = canApply ? 'btn btn--accent apply-draft' : 'btn btn--disabled apply-draft';
+            document.getElementById('link-draft-btn').classList.toggle('hidden', !nextActions.has('publish_and_link'));
+            document.getElementById('approve-draft-btn').classList.toggle('hidden', !nextActions.has('approve'));
+            document.getElementById('discard-draft-btn').classList.toggle('hidden', !nextActions.has('discard'));
+            document.getElementById('supersede-draft-btn').classList.toggle('hidden', !nextActions.has('supersede'));
+            document.getElementById('include-all-btn').classList.toggle(
+                'hidden', qualificationData.include_all || !['draft', 'ready'].includes(qualificationData.status)
+            );
             const queue = document.getElementById('qualification-queue');
             queue.innerHTML = '<div class="qualification-panel-label">Needs attention</div>' + items.map((item, index) => {
                 const state = item.decision ? item.decision.replace(/_/g, ' ') : item.proposal.attention_reasons.join(' · ');
@@ -913,13 +941,14 @@
             }).join('');
             if (!items.length) {
                 document.getElementById('qualification-empty').textContent = 'No proposals currently need attention.';
-                const emptyApply = document.getElementById('apply-draft-btn');
-                emptyApply.disabled = false;
-                emptyApply.className = 'btn btn--accent apply-draft';
                 return;
             }
             qualificationIndex = Math.min(qualificationIndex, items.length - 1);
             const item = items[qualificationIndex];
+            const permitted = new Set(item.permitted_actions || []);
+            document.querySelectorAll('#decision-actions [data-decision]').forEach((button) => {
+                button.classList.toggle('hidden', !permitted.has(button.dataset.decision));
+            });
             document.getElementById('qualification-empty').classList.add('hidden');
             document.getElementById('qualification-item').classList.remove('hidden');
             document.getElementById('qualification-title').textContent = item.source.title;
@@ -934,7 +963,7 @@
             localPlayer.load();
             localPlayer.classList.add('hidden');
             const localButton = document.getElementById('local-play-btn');
-            const localAvailable = item.audition_status === 'available';
+            const localAvailable = ['available', 'available_on_request'].includes(item.audition_status);
             localButton.classList.toggle('hidden', !localAvailable);
             document.getElementById('local-player-copy').textContent = localAvailable
                 ? 'Open this exact selected occurrence after private-source authorization.'
@@ -960,13 +989,11 @@
                     ${evidenceRow('Spotify', `${item.spotify.artist} — ${item.spotify.name}`)}
                     ${evidenceRow('Release', item.spotify.release)}
                     ${evidenceRow('Duration', formatDuration(item.spotify.duration))}
+                    ${evidenceRow('Authority', item.proposal.authority_status)}
+                    ${evidenceRow('Availability', availabilityEvidence(item.proposal))}
                     ${evidenceRow('Match type', item.proposal.match_type.replace(/_/g, ' '))}
                     ${evidenceRow('Evidence', `${item.proposal.score.toFixed(0)} · ${item.proposal.score_reasons.join(', ')}`)}
                 </div>`;
-            const complete = qualificationData.counts.pending === 0 && qualificationData.counts.deferred === 0;
-            const apply = document.getElementById('apply-draft-btn');
-            apply.disabled = !complete;
-            apply.className = complete ? 'btn btn--accent apply-draft' : 'btn btn--disabled apply-draft';
         }
 
         function selectQualification(index) {
@@ -1000,12 +1027,16 @@
             const item = qualificationData.items[qualificationIndex];
             let spotifyReference = null;
             let reason = null;
+            let exclude = false;
             if (decision === 'correction') {
                 spotifyReference = window.prompt('Paste the explicitly selected Spotify track URL or URI:');
                 if (!spotifyReference) return;
             }
             if (decision === 'deferred') {
                 reason = window.prompt('Optional private note (leave blank for none):') || null;
+                exclude = window.confirm(
+                    'Explicitly exclude this unresolved proposal from draft application? Cancel keeps it deferred and blocks Apply.'
+                );
             }
             const response = await fetch(
                 `/rekordbox/qualification/drafts/${encodeURIComponent(qualificationData.draft_id)}/decisions`,
@@ -1017,6 +1048,7 @@
                         decision,
                         spotify_reference: spotifyReference,
                         reason,
+                        exclude,
                         authorize_private_source: true,
                     }),
                 },
@@ -1032,6 +1064,24 @@
             qualificationIndex = next >= 0 ? next : Math.max(0, qualificationData.items.findIndex(
                 (candidate) => !candidate.decision || (candidate.decision === 'deferred' && !candidate.excluded)
             ));
+            renderQualification();
+        }
+
+        async function includeAllQualification() {
+            const response = await fetch(
+                `/rekordbox/qualification/drafts/${encodeURIComponent(qualificationData.draft_id)}/include-all`,
+                {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({ authorize_private_source: true }),
+                },
+            );
+            if (!response.ok) {
+                const result = await response.json();
+                document.getElementById('qualification-progress').textContent = result.detail || 'Spot-check queue unavailable';
+                return;
+            }
+            qualificationData = await response.json();
             renderQualification();
         }
 
@@ -1052,6 +1102,86 @@
             document.getElementById('qualification-progress').textContent = response.ok
                 ? 'Draft applied · Approval remains separate'
                 : (result.detail || 'Draft application blocked');
+            if (response.ok) await loadQualification(qualificationData.draft_id);
+        }
+
+        async function linkQualification() {
+            const publishingTransferId = window.prompt('Paste the completed publishing Batch or Transfer ID:');
+            if (!publishingTransferId) return;
+            const response = await fetch(
+                `/rekordbox/qualification/drafts/${encodeURIComponent(qualificationData.draft_id)}/link`,
+                {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({
+                        publishing_transfer_id: publishingTransferId,
+                        authorize_private_source: true,
+                    }),
+                },
+            );
+            const result = await response.json();
+            if (!response.ok) {
+                document.getElementById('qualification-progress').textContent = result.detail || 'Link blocked';
+                return;
+            }
+            qualificationData = result;
+            renderQualification();
+        }
+
+        async function discardQualification() {
+            if (!window.confirm('Discard this draft? It creates no authority and keeps Approval blocked until a fresh draft is applied.')) return;
+            const response = await fetch(
+                `/rekordbox/qualification/drafts/${encodeURIComponent(qualificationData.draft_id)}/discard`,
+                {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({ authorize_private_source: true }),
+                },
+            );
+            if (response.ok) {
+                qualificationData = await response.json();
+                renderQualification();
+            } else {
+                const result = await response.json();
+                document.getElementById('qualification-progress').textContent = result.detail || 'Discard blocked';
+            }
+        }
+
+        async function supersedeQualification() {
+            const response = await fetch(
+                `/rekordbox/qualification/drafts/${encodeURIComponent(qualificationData.draft_id)}/supersede`,
+                {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({ authorize_private_source: true }),
+                },
+            );
+            const result = await response.json();
+            if (!response.ok) {
+                document.getElementById('qualification-progress').textContent = result.detail || 'Fresh review blocked';
+                return;
+            }
+            qualificationData = result;
+            history.replaceState(null, '', `/qualification/${encodeURIComponent(result.draft_id)}`);
+            renderQualification();
+        }
+
+        async function approveQualification() {
+            if (!window.confirm('Approve the stable Provisional Playlist and record matching authority?')) return;
+            const response = await fetch(
+                `/rekordbox/qualification/drafts/${encodeURIComponent(qualificationData.draft_id)}/approve`,
+                {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({
+                        authorize_private_source: true,
+                    }),
+                },
+            );
+            const result = await response.json();
+            document.getElementById('qualification-progress').textContent = response.ok
+                ? `Playlist ${result.status.replace(/_/g, ' ')}`
+                : (result.detail || 'Approval blocked');
         }
 
         // URL validation

--- a/djsupport/static/index.html
+++ b/djsupport/static/index.html
@@ -1,4 +1,5 @@
 <!DOCTYPE html>
+<!-- classification: public -->
 <html lang="en">
 <head>
     <meta charset="UTF-8">
@@ -366,7 +367,252 @@
         .section-content { overflow: hidden; }
         .section-content--hidden { display: none; }
 
+        /* Rekordbox Qualification Workspace */
+        .qualification-shell {
+            width: min(1480px, 100%);
+            margin: 0 auto;
+            padding: 32px;
+        }
+        .qualification-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: flex-end;
+            gap: 24px;
+            padding-bottom: 24px;
+            border-bottom: 1px solid var(--border);
+        }
+        .qualification-header .logo { justify-content: flex-start; }
+        .qualification-kicker {
+            color: var(--accent);
+            font-size: 10px;
+            letter-spacing: 2.5px;
+            text-transform: uppercase;
+            margin-bottom: 7px;
+        }
+        .qualification-progress {
+            color: var(--text-secondary);
+            font-size: 11px;
+            letter-spacing: 1.5px;
+            text-align: right;
+            text-transform: uppercase;
+        }
+        .qualification-grid {
+            display: grid;
+            grid-template-columns: minmax(210px, 0.75fr) minmax(520px, 2fr) minmax(230px, 0.85fr);
+            grid-template-areas: "queue evidence decisions";
+            min-height: calc(100vh - 143px);
+        }
+        .qualification-queue {
+            grid-area: queue;
+            padding: 28px 22px 28px 0;
+            border-right: 1px solid var(--border);
+            overflow-y: auto;
+        }
+        .qualification-workspace {
+            grid-area: evidence;
+            padding: 28px;
+            min-width: 0;
+        }
+        .decision-rail {
+            grid-area: decisions;
+            padding: 28px 0 28px 22px;
+            border-left: 1px solid var(--border);
+        }
+        .qualification-panel-label {
+            color: var(--text-muted);
+            font-size: 10px;
+            letter-spacing: 2px;
+            text-transform: uppercase;
+            margin-bottom: 16px;
+        }
+        .queue-item {
+            display: block;
+            width: 100%;
+            border: 0;
+            border-left: 2px solid transparent;
+            background: transparent;
+            color: var(--text-secondary);
+            font: inherit;
+            padding: 12px;
+            text-align: left;
+            cursor: pointer;
+        }
+        .queue-item + .queue-item { border-top: 1px solid var(--border); }
+        .queue-item--active {
+            border-left-color: var(--accent);
+            background: var(--surface);
+            color: var(--text-primary);
+        }
+        .queue-item__artist {
+            display: block;
+            font-size: 10px;
+            color: var(--text-muted);
+            overflow: hidden;
+            text-overflow: ellipsis;
+            white-space: nowrap;
+        }
+        .queue-item__title {
+            display: block;
+            font-size: 12px;
+            margin-top: 4px;
+            overflow: hidden;
+            text-overflow: ellipsis;
+            white-space: nowrap;
+        }
+        .queue-item__state {
+            display: block;
+            color: var(--accent);
+            font-size: 9px;
+            letter-spacing: 1px;
+            margin-top: 7px;
+            text-transform: uppercase;
+        }
+        .comparison-title {
+            font-family: 'Inter', sans-serif;
+            font-size: clamp(22px, 3vw, 38px);
+            line-height: 1.1;
+            overflow-wrap: anywhere;
+        }
+        .comparison-artist {
+            color: var(--text-secondary);
+            font-size: 13px;
+            margin-top: 9px;
+        }
+        .attention-tags {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 7px;
+            margin: 18px 0 24px;
+        }
+        .attention-tag {
+            border: 1px solid var(--accent-dim);
+            color: var(--accent);
+            font-size: 9px;
+            letter-spacing: 1px;
+            padding: 5px 7px;
+            text-transform: uppercase;
+        }
+        .player-grid {
+            display: grid;
+            grid-template-columns: repeat(2, minmax(0, 1fr));
+            gap: 16px;
+        }
+        .player-card, .evidence-card {
+            background: var(--surface);
+            border: 1px solid var(--border);
+            border-radius: 6px;
+            min-width: 0;
+            padding: 18px;
+        }
+        .player-card__heading {
+            color: var(--text-secondary);
+            font-size: 10px;
+            letter-spacing: 2px;
+            text-transform: uppercase;
+        }
+        .local-player-copy {
+            color: var(--text-muted);
+            font-size: 11px;
+            line-height: 1.5;
+            margin: 24px 0;
+            min-height: 34px;
+        }
+        #local-player { width: 100%; margin-top: 13px; }
+        #spotify-player {
+            width: 100%;
+            height: 152px;
+            border: 0;
+            margin-top: 14px;
+        }
+        .spotify-open {
+            color: var(--accent);
+            display: inline-block;
+            font-size: 10px;
+            letter-spacing: 1.5px;
+            margin-top: 12px;
+            text-decoration: none;
+        }
+        .evidence-card { margin-top: 16px; }
+        .evidence-grid {
+            display: grid;
+            grid-template-columns: repeat(2, minmax(0, 1fr));
+            gap: 1px;
+            background: var(--border);
+            margin-top: 14px;
+        }
+        .evidence-column { background: var(--surface); padding: 8px 15px; }
+        .evidence-row {
+            display: grid;
+            grid-template-columns: 88px minmax(0, 1fr);
+            gap: 10px;
+            border-bottom: 1px solid var(--border);
+            padding: 9px 0;
+            font-size: 10px;
+        }
+        .evidence-row:last-child { border-bottom: 0; }
+        .evidence-key { color: var(--text-muted); text-transform: uppercase; }
+        .evidence-value { color: var(--text-primary); overflow-wrap: anywhere; }
+        .decision-copy {
+            color: var(--text-muted);
+            font-size: 11px;
+            line-height: 1.6;
+            margin-bottom: 18px;
+        }
+        .decision-btn {
+            background: transparent;
+            border: 1px solid var(--border-strong);
+            color: var(--text-primary);
+            cursor: pointer;
+            display: block;
+            font: 500 10px 'IBM Plex Mono', monospace;
+            letter-spacing: 1px;
+            margin-top: 9px;
+            padding: 13px 12px;
+            text-align: left;
+            text-transform: uppercase;
+            width: 100%;
+        }
+        .decision-btn:hover, .decision-btn:focus { border-color: var(--accent); }
+        .decision-btn--correct { color: var(--accent); }
+        .decision-btn--danger { color: var(--error); }
+        .draft-authority {
+            border-top: 1px solid var(--border);
+            color: var(--text-muted);
+            font-size: 9px;
+            line-height: 1.5;
+            margin-top: 22px;
+            padding-top: 16px;
+            text-transform: uppercase;
+        }
+        .apply-draft {
+            margin-top: 18px;
+            padding: 12px;
+            width: 100%;
+        }
+        .qualification-empty {
+            color: var(--text-muted);
+            font-size: 12px;
+            line-height: 1.7;
+            padding: 70px 0;
+        }
+
         .hidden { display: none !important; }
+
+        @media (max-width: 980px) {
+            .qualification-grid {
+                grid-template-columns: 220px minmax(0, 1fr);
+                grid-template-areas:
+                    "queue evidence"
+                    "queue decisions";
+            }
+            .decision-rail {
+                border-left: 0;
+                border-top: 1px solid var(--border);
+                padding: 22px 28px 32px;
+            }
+            .decision-btn { display: inline-block; margin-right: 6px; width: auto; }
+            .apply-draft { display: block; width: auto; }
+        }
 
         /* Mobile */
         @media (max-width: 640px) {
@@ -376,6 +622,31 @@
             .logo img { width: 32px; height: 32px; }
             .input-box, .input-underline { font-size: 13px; }
             .results-table td { font-size: 10px; max-width: 120px; }
+            .qualification-shell { padding: 20px 18px; }
+            .qualification-header { align-items: flex-start; }
+            .qualification-header .logo { font-size: 20px; }
+            .qualification-progress { font-size: 9px; }
+            .qualification-grid {
+                display: grid;
+                grid-template-columns: 1fr;
+                grid-template-areas: "queue" "evidence" "decisions";
+                min-height: 0;
+            }
+            .qualification-queue {
+                border-bottom: 1px solid var(--border);
+                border-right: 0;
+                display: grid;
+                grid-auto-flow: column;
+                grid-auto-columns: minmax(170px, 72vw);
+                overflow-x: auto;
+                padding: 16px 0;
+            }
+            .qualification-queue .qualification-panel-label { display: none; }
+            .queue-item + .queue-item { border-left: 1px solid var(--border); border-top: 0; }
+            .qualification-workspace { padding: 24px 0; }
+            .decision-rail { padding: 22px 0; }
+            .player-grid, .evidence-grid { grid-template-columns: 1fr; }
+            .decision-btn { display: block; width: 100%; }
         }
     </style>
 </head>
@@ -467,6 +738,59 @@
         </div>
     </div>
 
+    <!-- ===== REKORDBOX QUALIFICATION WORKSPACE ===== -->
+    <main id="qualification-section" class="qualification-shell hidden fade-in">
+        <header class="qualification-header">
+            <div>
+                <div class="qualification-kicker">Rekordbox Qualification Draft</div>
+                <div class="logo"><img src="/static/logo.png" alt="djsupport logo">DJSUPPORT</div>
+            </div>
+            <div id="qualification-progress" class="qualification-progress">Loading draft</div>
+        </header>
+        <div class="qualification-grid">
+            <nav id="qualification-queue" class="qualification-queue" aria-label="Qualification queue">
+                <div class="qualification-panel-label">Needs attention</div>
+            </nav>
+            <section class="qualification-workspace" aria-live="polite">
+                <div id="qualification-empty" class="qualification-empty">Loading retained comparison evidence…</div>
+                <div id="qualification-item" class="hidden">
+                    <h1 id="qualification-title" class="comparison-title"></h1>
+                    <p id="qualification-artist" class="comparison-artist"></p>
+                    <div id="attention-tags" class="attention-tags"></div>
+                    <div class="player-grid">
+                        <article class="player-card">
+                            <div class="player-card__heading">Selected local source</div>
+                            <p id="local-player-copy" class="local-player-copy"></p>
+                            <button id="local-play-btn" class="decision-btn" type="button" onclick="playLocalSource()">PLAY LOCAL SOURCE</button>
+                            <audio id="local-player" class="hidden" controls preload="metadata"></audio>
+                        </article>
+                        <article class="player-card">
+                            <div class="player-card__heading">Spotify proposal</div>
+                            <iframe id="spotify-player" title="Spotify proposal player" loading="lazy" allow="encrypted-media; fullscreen" src="about:blank"></iframe>
+                            <a id="spotify-open" class="spotify-open" target="_blank" rel="noopener noreferrer">OPEN IN SPOTIFY</a>
+                        </article>
+                    </div>
+                    <article class="evidence-card">
+                        <div class="player-card__heading">Retained comparison evidence</div>
+                        <div id="evidence-grid" class="evidence-grid"></div>
+                    </article>
+                </div>
+            </section>
+            <aside class="decision-rail">
+                <div class="qualification-panel-label">One outcome</div>
+                <p class="decision-copy">This draft has no matching or playlist authority. Choose only what you verified.</p>
+                <div id="decision-actions">
+                    <button class="decision-btn decision-btn--correct" type="button" onclick="submitQualification('keep_proposal')">CORRECT</button>
+                    <button class="decision-btn" type="button" onclick="submitQualification('correction')">WRONG — FIND ANOTHER</button>
+                    <button class="decision-btn" type="button" onclick="submitQualification('deferred')">CANNOT VERIFY</button>
+                    <button class="decision-btn decision-btn--danger" type="button" onclick="submitQualification('reject_proposal')">NOT MY SOURCE</button>
+                </div>
+                <p class="draft-authority">Applying changes only the linked Provisional Playlist. Approval remains a later, separate operation.</p>
+                <button id="apply-draft-btn" class="btn btn--disabled apply-draft" type="button" onclick="applyQualification()" disabled>APPLY DRAFT</button>
+            </aside>
+        </div>
+    </main>
+
     <!-- ===== ERROR STATE ===== -->
     <div id="error-section" class="container container--left hidden fade-in">
         <div class="logo"><img src="/static/logo.png" alt="djsupport logo">DJSUPPORT</div>
@@ -493,6 +817,9 @@
         const fieldLabel = document.getElementById('field-label');
 
         let recentMatches = [];
+        let qualificationData = null;
+        let qualificationIndex = 0;
+        const qualificationMatch = window.location.pathname.match(/^\/qualification\/([^/]+)$/);
 
         // HTML escape helper to prevent XSS from Beatport data
         function esc(s) {
@@ -524,7 +851,7 @@
 
         const activeTransferKey = 'djsupport.activeTransfer';
         const activeTransferId = localStorage.getItem(activeTransferKey);
-        if (activeTransferId) {
+        if (activeTransferId && !qualificationMatch) {
             document.getElementById('input-section').classList.add('hidden');
             document.getElementById('progress-section').classList.remove('hidden');
             fetch(`/sync/${activeTransferId}/resume`, { method: 'POST' })
@@ -536,6 +863,195 @@
                     localStorage.removeItem(activeTransferKey);
                     showError('Unable to reload the previous Transfer');
                 });
+        }
+
+        if (qualificationMatch) {
+            document.getElementById('input-section').classList.add('hidden');
+            document.getElementById('progress-section').classList.add('hidden');
+            document.getElementById('results-section').classList.add('hidden');
+            document.getElementById('error-section').classList.add('hidden');
+            document.getElementById('qualification-section').classList.remove('hidden');
+            loadQualification(decodeURIComponent(qualificationMatch[1]));
+        }
+
+        async function loadQualification(draftId) {
+            try {
+                const response = await fetch(
+                    `/rekordbox/qualification/drafts/${encodeURIComponent(draftId)}?authorize_private_source=true`,
+                    { cache: 'no-store' },
+                );
+                if (!response.ok) throw new Error('Qualification Draft is unavailable');
+                qualificationData = await response.json();
+                qualificationIndex = Math.max(0, qualificationData.items.findIndex(
+                    (item) => !item.decision || (item.decision === 'deferred' && !item.excluded)
+                ));
+                renderQualification();
+            } catch (error) {
+                document.getElementById('qualification-empty').textContent = error.message;
+            }
+        }
+
+        function formatDuration(seconds) {
+            if (!seconds) return 'Not retained';
+            const minutes = Math.floor(seconds / 60);
+            return `${minutes}:${String(seconds % 60).padStart(2, '0')}`;
+        }
+
+        function evidenceRow(key, value) {
+            return `<div class="evidence-row"><span class="evidence-key">${esc(key)}</span><span class="evidence-value">${esc(value || 'Not retained')}</span></div>`;
+        }
+
+        function renderQualification() {
+            if (!qualificationData) return;
+            const items = qualificationData.items || [];
+            const decided = items.filter((item) => item.decision && !(item.decision === 'deferred' && !item.excluded)).length;
+            document.getElementById('qualification-progress').textContent = `${decided}/${items.length} outcomes · ${qualificationData.status.replace(/_/g, ' ')}`;
+            const queue = document.getElementById('qualification-queue');
+            queue.innerHTML = '<div class="qualification-panel-label">Needs attention</div>' + items.map((item, index) => {
+                const state = item.decision ? item.decision.replace(/_/g, ' ') : item.proposal.attention_reasons.join(' · ');
+                return `<button type="button" class="queue-item${index === qualificationIndex ? ' queue-item--active' : ''}" onclick="selectQualification(${index})"><span class="queue-item__artist">${esc(item.source.artist)}</span><span class="queue-item__title">${esc(item.source.title)}</span><span class="queue-item__state">${esc(state || 'spot check')}</span></button>`;
+            }).join('');
+            if (!items.length) {
+                document.getElementById('qualification-empty').textContent = 'No proposals currently need attention.';
+                const emptyApply = document.getElementById('apply-draft-btn');
+                emptyApply.disabled = false;
+                emptyApply.className = 'btn btn--accent apply-draft';
+                return;
+            }
+            qualificationIndex = Math.min(qualificationIndex, items.length - 1);
+            const item = items[qualificationIndex];
+            document.getElementById('qualification-empty').classList.add('hidden');
+            document.getElementById('qualification-item').classList.remove('hidden');
+            document.getElementById('qualification-title').textContent = item.source.title;
+            document.getElementById('qualification-artist').textContent = item.source.artist;
+            document.getElementById('attention-tags').innerHTML = item.proposal.attention_reasons.map(
+                (reason) => `<span class="attention-tag">${esc(reason.replace(/_/g, ' '))}</span>`
+            ).join('');
+
+            const localPlayer = document.getElementById('local-player');
+            localPlayer.pause();
+            localPlayer.removeAttribute('src');
+            localPlayer.load();
+            localPlayer.classList.add('hidden');
+            const localButton = document.getElementById('local-play-btn');
+            const localAvailable = item.audition_status === 'available';
+            localButton.classList.toggle('hidden', !localAvailable);
+            document.getElementById('local-player-copy').textContent = localAvailable
+                ? 'Open this exact selected occurrence after private-source authorization.'
+                : item.audition_reason
+                ? `Local audition unavailable: ${item.audition_reason.replace(/_/g, ' ')}.`
+                : 'Local audition is not available for this selected source.';
+
+            const spotifyPlayer = document.getElementById('spotify-player');
+            spotifyPlayer.src = item.spotify.embed_url || 'about:blank';
+            spotifyPlayer.classList.toggle('hidden', !item.spotify.embed_url);
+            const spotifyOpen = document.getElementById('spotify-open');
+            spotifyOpen.href = item.spotify.open_url || '#';
+            spotifyOpen.classList.toggle('hidden', !item.spotify.open_url);
+            document.getElementById('evidence-grid').innerHTML =
+                `<div class="evidence-column">
+                    ${evidenceRow('Source', `${item.source.artist} — ${item.source.title}`)}
+                    ${evidenceRow('Version', item.source.version)}
+                    ${evidenceRow('Release', item.source.release)}
+                    ${evidenceRow('Label', item.source.label)}
+                    ${evidenceRow('Duration', formatDuration(item.source.duration))}
+                </div>
+                <div class="evidence-column">
+                    ${evidenceRow('Spotify', `${item.spotify.artist} — ${item.spotify.name}`)}
+                    ${evidenceRow('Release', item.spotify.release)}
+                    ${evidenceRow('Duration', formatDuration(item.spotify.duration))}
+                    ${evidenceRow('Match type', item.proposal.match_type.replace(/_/g, ' '))}
+                    ${evidenceRow('Evidence', `${item.proposal.score.toFixed(0)} · ${item.proposal.score_reasons.join(', ')}`)}
+                </div>`;
+            const complete = qualificationData.counts.pending === 0 && qualificationData.counts.deferred === 0;
+            const apply = document.getElementById('apply-draft-btn');
+            apply.disabled = !complete;
+            apply.className = complete ? 'btn btn--accent apply-draft' : 'btn btn--disabled apply-draft';
+        }
+
+        function selectQualification(index) {
+            qualificationIndex = index;
+            renderQualification();
+        }
+
+        async function playLocalSource() {
+            const item = qualificationData.items[qualificationIndex];
+            const response = await fetch(
+                `/rekordbox/qualification/drafts/${encodeURIComponent(qualificationData.draft_id)}/audition/${encodeURIComponent(item.item_id)}`,
+                {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({ authorize_private_source: true }),
+                },
+            );
+            const result = await response.json();
+            if (!response.ok || result.status !== 'available') {
+                document.getElementById('local-player-copy').textContent = 'Local audition is unavailable for this source.';
+                return;
+            }
+            const player = document.getElementById('local-player');
+            player.src = result.media_url;
+            player.classList.remove('hidden');
+            document.getElementById('local-play-btn').classList.add('hidden');
+            await player.play().catch(() => {});
+        }
+
+        async function submitQualification(decision) {
+            const item = qualificationData.items[qualificationIndex];
+            let spotifyReference = null;
+            let reason = null;
+            if (decision === 'correction') {
+                spotifyReference = window.prompt('Paste the explicitly selected Spotify track URL or URI:');
+                if (!spotifyReference) return;
+            }
+            if (decision === 'deferred') {
+                reason = window.prompt('Optional private note (leave blank for none):') || null;
+            }
+            const response = await fetch(
+                `/rekordbox/qualification/drafts/${encodeURIComponent(qualificationData.draft_id)}/decisions`,
+                {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({
+                        item_id: item.item_id,
+                        decision,
+                        spotify_reference: spotifyReference,
+                        reason,
+                        authorize_private_source: true,
+                    }),
+                },
+            );
+            if (!response.ok) {
+                document.getElementById('qualification-progress').textContent = 'Outcome could not be staged';
+                return;
+            }
+            qualificationData = await response.json();
+            const next = qualificationData.items.findIndex(
+                (candidate, index) => index > qualificationIndex && !candidate.decision
+            );
+            qualificationIndex = next >= 0 ? next : Math.max(0, qualificationData.items.findIndex(
+                (candidate) => !candidate.decision || (candidate.decision === 'deferred' && !candidate.excluded)
+            ));
+            renderQualification();
+        }
+
+        async function applyQualification() {
+            if (!window.confirm('Apply this completed draft to the linked Provisional Playlist? This does not Approve it.')) return;
+            const response = await fetch(
+                `/rekordbox/qualification/drafts/${encodeURIComponent(qualificationData.draft_id)}/apply`,
+                {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({
+                        authorize_private_source: true,
+                        authorize_spotify_write: true,
+                    }),
+                },
+            );
+            const result = await response.json();
+            document.getElementById('qualification-progress').textContent = response.ok
+                ? 'Draft applied · Approval remains separate'
+                : (result.detail || 'Draft application blocked');
         }
 
         // URL validation

--- a/djsupport/transfer.py
+++ b/djsupport/transfer.py
@@ -14,6 +14,7 @@ import os
 import re
 import sys
 import tempfile
+import threading
 import time
 from collections import Counter
 from contextlib import contextmanager
@@ -57,7 +58,7 @@ from djsupport.spotify import (
 )
 
 
-PUBLICATION_MANIFEST_VERSION = 5
+PUBLICATION_MANIFEST_VERSION = 6
 TRANSFER_STATE_VERSION = 4
 EXPENSIVE_BATCH_LOOKUP_THRESHOLD = 100
 SPOTIFY_TRACK_URI = re.compile(r"^spotify:track:([A-Za-z0-9]{22})$")
@@ -297,6 +298,7 @@ class BatchPlaylistState:
     name: str
     reference: str
     transfer_id: str
+    selection_token: str = ""
     phase: BatchPhase = BatchPhase.PENDING
     outcome: PlaylistOutcome = PlaylistOutcome.PENDING
     error: str | None = None
@@ -326,6 +328,7 @@ class BatchState:
     local_audio_identity: bool = False
     local_audio_audition: bool = False
     plan_id: str = ""
+    revision: int = 0
 
     @classmethod
     def from_dict(cls, value: dict) -> BatchState:
@@ -365,6 +368,7 @@ class QualificationStatus(str, Enum):
     PAUSED = "paused"
     APPLIED = "applied"
     REVIEW_REQUIRED = "review_required"
+    DISCARDED = "discarded"
 
 
 @dataclass(frozen=True)
@@ -398,7 +402,13 @@ class QualificationDraftState:
     mutation_snapshots: list[str] = field(default_factory=list)
     completed_chunks: list[str] = field(default_factory=list)
     applied_manifest: dict | None = None
+    applied_uris: list[str] = field(default_factory=list)
     audition_statuses: dict[str, dict] = field(default_factory=dict)
+    audition_selection_digest: str | None = None
+    supersedes: str | None = None
+    superseded_by: str | None = None
+    review_reason: str | None = None
+    revision: int = 0
 
     @classmethod
     def from_dict(cls, value: dict) -> QualificationDraftState:
@@ -406,7 +416,13 @@ class QualificationDraftState:
             "mutation_snapshots": [],
             "completed_chunks": [],
             "applied_manifest": None,
+            "applied_uris": [],
             "audition_statuses": {},
+            "audition_selection_digest": None,
+            "supersedes": None,
+            "superseded_by": None,
+            "review_reason": None,
+            "revision": 0,
             **value,
             "status": QualificationStatus(
                 value.get("status", QualificationStatus.DRAFT.value)
@@ -443,6 +459,11 @@ class QualificationItem:
     correction_uri: str | None = None
     deferred_reason: str | None = None
     excluded: bool = False
+    availability_status: str = "unknown"
+    availability_reason: str | None = "not_checked"
+    availability_checked_at: str | None = None
+    availability_source: str | None = None
+    permitted_actions: tuple[QualificationDecision, ...] = ()
 
 
 @dataclass(frozen=True)
@@ -471,7 +492,34 @@ class QualificationView:
         return self.pending == 0 and self.deferred == 0
 
     @property
+    def next_actions(self) -> tuple[str, ...]:
+        """Return policy-owned lifecycle actions for thin clients."""
+        if self.status == QualificationStatus.APPLIED:
+            return ("approve",)
+        if self.status == QualificationStatus.DISCARDED:
+            return ("supersede",)
+        if self.status in {
+            QualificationStatus.APPLYING,
+            QualificationStatus.PAUSED,
+        }:
+            return ("resume",)
+        if self.status == QualificationStatus.REVIEW_REQUIRED:
+            return ("review", "discard")
+        if self.complete and self.spotify_playlist_id is None:
+            return ("publish_and_link", "discard")
+        if self.complete:
+            return ("apply", "discard")
+        return ("review", "discard")
+
+    @property
     def current_item(self) -> QualificationItem | None:
+        if self.status in {
+            QualificationStatus.APPLYING,
+            QualificationStatus.PAUSED,
+            QualificationStatus.APPLIED,
+            QualificationStatus.DISCARDED,
+        }:
+            return None
         return next((
             item for item in self.items
             if item.decision is None
@@ -582,6 +630,10 @@ class SpotifyPlaylistChanged(RuntimeError):
 class SpotifyPlaylistReviewRequired(RuntimeError):
     """Approval encountered playlist facts requiring an explicit user decision."""
 
+    def __init__(self, message: str, *, draft_id: str | None = None) -> None:
+        super().__init__(message)
+        self.draft_id = draft_id
+
 
 class SourceNotFound(ValueError):
     """Raised only when an exact requested source selection does not exist."""
@@ -662,6 +714,8 @@ class TransferState:
     local_audio_unavailable: int = 0
     local_audio_reused: int = 0
     local_evidence_ids: dict[str, str] = field(default_factory=dict)
+    audition_selection_digest: str | None = None
+    revision: int = 0
 
     @classmethod
     def from_dict(cls, value: dict) -> TransferState:
@@ -670,7 +724,9 @@ class TransferState:
             "completed_chunks": [], "api_lookups": 0,
             "local_audio_eligible": 0, "local_audio_observed": 0,
             "local_audio_unavailable": 0, "local_audio_reused": 0,
-            "local_evidence_ids": {}, **value,
+            "local_evidence_ids": {}, "audition_selection_digest": None,
+            "revision": 0,
+            **value,
             "status": TransferStatus(value["status"]),
         })
 
@@ -710,6 +766,14 @@ class PublicationItem:
     source_duration: int = 0
     authoritative: bool = False
     local_evidence_id: str | None = None
+    availability_status: str = "unknown"
+    availability_reason: str | None = "not_checked"
+    availability_checked_at: str | None = None
+    availability_source: str | None = None
+    qualification_outcome: str | None = None
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "score_reasons", tuple(self.score_reasons))
 
 
 @dataclass(frozen=True)
@@ -836,20 +900,43 @@ class FilePublicationStorage:
         self.manifests: list[dict] = []
         self.approvals: list[dict] = []
         self.mirrors: list[dict] = []
+        self._loaded_once = False
         self.load()
 
     def load(self) -> None:
         if not self.path.exists():
+            if self._loaded_once:
+                raise ValueError(
+                    "Publication state is unavailable; restore it before use"
+                )
+            self._loaded_once = True
             return
         try:
             data = json.loads(self.path.read_text())
-        except (json.JSONDecodeError, OSError):
-            return
-        if data.get("version") not in (1, 2, 3, 4, PUBLICATION_MANIFEST_VERSION):
-            return
-        self.manifests = data.get("manifests", [])
-        self.approvals = data.get("approvals", data.get("reviews", []))
-        self.mirrors = data.get("mirrors", [])
+        except (json.JSONDecodeError, OSError) as exc:
+            raise ValueError(
+                "Publication state is malformed; restore it before use"
+            ) from exc
+        if not isinstance(data, dict) or data.get("version") not in (
+            1, 2, 3, 4, 5, PUBLICATION_MANIFEST_VERSION,
+        ):
+            raise ValueError(
+                "Publication state schema is unsupported; upgrade djsupport "
+                "before using this file"
+            )
+        manifests = data.get("manifests", [])
+        approvals = data.get("approvals", data.get("reviews", []))
+        mirrors = data.get("mirrors", [])
+        if not all(isinstance(value, list) for value in (
+            manifests, approvals, mirrors,
+        )):
+            raise ValueError(
+                "Publication state is malformed; restore it before use"
+            )
+        self.manifests = manifests
+        self.approvals = approvals
+        self.mirrors = mirrors
+        self._loaded_once = True
 
     def _save(self, manifests: list[dict], approvals: list[dict]) -> None:
         self.path.parent.mkdir(parents=True, exist_ok=True)
@@ -1024,6 +1111,12 @@ class TransferStorage(Protocol):
         self, draft_id: str, state: QualificationDraftState,
     ) -> None: ...
 
+    def save_qualification_successor(
+        self,
+        discarded: QualificationDraftState,
+        successor: QualificationDraftState,
+    ) -> None: ...
+
     def qualifications_for_playlist(
         self, account_id: str, playlist_id: str,
     ) -> list[QualificationDraftState]: ...
@@ -1032,11 +1125,55 @@ class TransferStorage(Protocol):
 class FileTransferStorage:
     """Atomically persisted, versioned state for resumable Transfers."""
 
+    _thread_locks: dict[str, threading.RLock] = {}
+    _thread_locks_guard = threading.Lock()
+
     def __init__(self, path: str | Path) -> None:
         self.path = Path(path)
         self.transfers: dict[str, TransferState] = {}
         self.batches: dict[str, BatchState] = {}
         self.qualifications: dict[str, QualificationDraftState] = {}
+        lock_key = str(self.path.resolve())
+        with self._thread_locks_guard:
+            self._thread_lock = self._thread_locks.setdefault(
+                lock_key, threading.RLock(),
+            )
+        self._load()
+
+    @contextmanager
+    def _exclusive(self):
+        lock_path = self.path.with_suffix(f"{self.path.suffix}.lock")
+        lock_path.parent.mkdir(parents=True, exist_ok=True)
+        with self._thread_lock, lock_path.open("a+") as lock_file:
+            if os.name == "nt":
+                lock_file.seek(0)
+                if not lock_file.read(1):
+                    lock_file.write("0")
+                    lock_file.flush()
+                lock_file.seek(0)
+                msvcrt.locking(lock_file.fileno(), msvcrt.LK_LOCK, 1)
+            else:
+                fcntl.flock(lock_file.fileno(), fcntl.LOCK_EX)
+            try:
+                yield
+            finally:
+                if os.name == "nt":
+                    lock_file.seek(0)
+                    msvcrt.locking(lock_file.fileno(), msvcrt.LK_UNLCK, 1)
+                else:
+                    fcntl.flock(lock_file.fileno(), fcntl.LOCK_UN)
+
+    def refresh(self) -> None:
+        """Reload complete authoritative state under its file lock."""
+        with self._exclusive():
+            self._reload_unlocked()
+
+    def _reload_unlocked(self) -> None:
+        if not self.path.exists():
+            self.transfers = {}
+            self.batches = {}
+            self.qualifications = {}
+            return
         self._load()
 
     def _load(self) -> None:
@@ -1044,40 +1181,65 @@ class FileTransferStorage:
             return
         try:
             data = json.loads(self.path.read_text())
-        except (json.JSONDecodeError, OSError):
-            return
-        if data.get("version") in (1, 2, 3, TRANSFER_STATE_VERSION):
-            for transfer_id, state in data.get("transfers", {}).items():
-                try:
-                    self.transfers[transfer_id] = TransferState.from_dict(state)
-                except (KeyError, TypeError, ValueError):
-                    continue
-            for transfer_id, state in data.get("batches", {}).items():
-                try:
-                    self.batches[transfer_id] = BatchState.from_dict(state)
-                except (KeyError, TypeError, ValueError):
-                    continue
-            for draft_id, state in data.get("qualifications", {}).items():
-                try:
-                    self.qualifications[draft_id] = (
-                        QualificationDraftState.from_dict(state)
-                    )
-                except (KeyError, TypeError, ValueError):
-                    continue
+        except (json.JSONDecodeError, OSError) as exc:
+            raise ValueError(
+                "Transfer state is malformed; repair or restore it before use"
+            ) from exc
+        if not isinstance(data, dict) or data.get("version") not in (
+            1, 2, 3, TRANSFER_STATE_VERSION,
+        ):
+            raise ValueError(
+                "Transfer state schema is unsupported; upgrade djsupport "
+                "before using this file"
+            )
+        sections = {
+            "transfers": data.get("transfers", {}),
+            "batches": data.get("batches", {}),
+            "qualifications": data.get("qualifications", {}),
+        }
+        if not all(isinstance(value, dict) for value in sections.values()):
+            raise ValueError(
+                "Transfer state is malformed; repair or restore it before use"
+            )
+        try:
+            transfers = {
+                transfer_id: TransferState.from_dict(state)
+                for transfer_id, state in sections["transfers"].items()
+            }
+            batches = {
+                transfer_id: BatchState.from_dict(state)
+                for transfer_id, state in sections["batches"].items()
+            }
+            qualifications = {
+                draft_id: QualificationDraftState.from_dict(state)
+                for draft_id, state in sections["qualifications"].items()
+            }
+            if any(
+                draft_id != draft.draft_id
+                for draft_id, draft in qualifications.items()
+            ):
+                raise ValueError(
+                    "Qualification map key does not match embedded draft identity"
+                )
+        except (KeyError, TypeError, ValueError) as exc:
+            raise ValueError(
+                "Transfer state is malformed; repair or restore it before use"
+            ) from exc
+        self.transfers = transfers
+        self.batches = batches
+        self.qualifications = qualifications
 
     def load_transfer(self, transfer_id: str) -> TransferState | None:
         return self.transfers.get(transfer_id)
 
     def save_transfer(self, transfer_id: str, state: TransferState) -> None:
-        self.transfers = {**self.transfers, transfer_id: state}
-        self._save()
+        self._save_entity("transfers", transfer_id, state)
 
     def load_batch(self, transfer_id: str) -> BatchState | None:
         return self.batches.get(transfer_id)
 
     def save_batch(self, transfer_id: str, state: BatchState) -> None:
-        self.batches = {**self.batches, transfer_id: state}
-        self._save()
+        self._save_entity("batches", transfer_id, state)
 
     def load_qualification(
         self, draft_id: str,
@@ -1087,8 +1249,56 @@ class FileTransferStorage:
     def save_qualification(
         self, draft_id: str, state: QualificationDraftState,
     ) -> None:
-        self.qualifications = {**self.qualifications, draft_id: state}
-        self._save()
+        self._save_entity("qualifications", draft_id, state)
+
+    def save_qualification_successor(
+        self,
+        discarded: QualificationDraftState,
+        successor: QualificationDraftState,
+    ) -> None:
+        """Persist both sides of an explicit supersession atomically."""
+        with self._exclusive():
+            self._reload_unlocked()
+            latest = self.qualifications.get(discarded.draft_id)
+            if latest is None or latest.revision != discarded.revision:
+                raise ValueError(
+                    "Transfer state changed concurrently; reload before retry"
+                )
+            if successor.draft_id in self.qualifications:
+                raise ValueError("Qualification successor already exists")
+            old_revision = discarded.revision
+            new_revision = successor.revision
+            discarded.revision += 1
+            successor.revision += 1
+            self.qualifications = {
+                **self.qualifications,
+                discarded.draft_id: discarded,
+                successor.draft_id: successor,
+            }
+            try:
+                self._save()
+            except Exception:
+                discarded.revision = old_revision
+                successor.revision = new_revision
+                raise
+
+    def _save_entity(self, section: str, key: str, state) -> None:
+        with self._exclusive():
+            self._reload_unlocked()
+            collection = getattr(self, section)
+            latest = collection.get(key)
+            if latest is not None and latest.revision != state.revision:
+                raise ValueError(
+                    "Transfer state changed concurrently; reload before retry"
+                )
+            previous_revision = state.revision
+            state.revision = previous_revision + 1
+            setattr(self, section, {**collection, key: state})
+            try:
+                self._save()
+            except Exception:
+                state.revision = previous_revision
+                raise
 
     def qualifications_for_playlist(
         self, account_id: str, playlist_id: str,
@@ -1165,6 +1375,10 @@ class MatchingKnowledge(Protocol):
     ) -> LocalAudioObservation | None: ...
 
     def approval_conflict(self, item: PublicationItem) -> bool: ...
+
+    def local_audio_approval_conflict(
+        self, item: PublicationItem, account_id: str,
+    ) -> ApprovalConflict | None: ...
 
 
 class BeatportChartSource:
@@ -1479,7 +1693,10 @@ class SpotifyMatcher:
             "artist": ", ".join(artist["name"] for artist in track["artists"]),
             "album": (track.get("album") or {}).get("name", ""),
             "duration_ms": int(track.get("duration_ms", 0)),
-            "is_playable": track.get("is_playable", True),
+            "is_playable": track.get("is_playable"),
+            "restrictions": track.get("restrictions"),
+            "linked_from": track.get("linked_from"),
+            "is_local": track.get("is_local", False),
         }
 
 
@@ -1490,6 +1707,10 @@ class MatchCacheKnowledge:
 
     def __init__(self, cache: MatchCache) -> None:
         self._cache = cache
+
+    def refresh(self) -> None:
+        """Reload durable authority before a guarded policy decision."""
+        self._cache.reload_strict()
 
     def lookup(self, track: Track, threshold: int) -> dict | None:
         entry = self._cache.lookup(
@@ -1507,6 +1728,10 @@ class MatchCacheKnowledge:
             "match_type": entry.match_type or "exact",
             "score_reasons": list(entry.score_reasons),
             "authoritative": entry.approval_status == "approved",
+            "availability_status": entry.availability_status,
+            "availability_reason": entry.availability_reason,
+            "availability_checked_at": entry.availability_checked_at,
+            "availability_source": entry.availability_source,
         }
 
     def should_retry(
@@ -1539,6 +1764,10 @@ class MatchCacheKnowledge:
                 "score_reasons": list(item.score_reasons),
                 "spotify_release": item.spotify_release,
                 "spotify_duration": item.spotify_duration,
+                "availability_status": item.availability_status,
+                "availability_reason": item.availability_reason,
+                "availability_checked_at": item.availability_checked_at,
+                "availability_source": item.availability_source,
             }, item.source_duration,
         )
         return ApprovalConflict(**conflict) if conflict else None
@@ -1555,6 +1784,10 @@ class MatchCacheKnowledge:
                 "score_reasons": list(item.score_reasons),
                 "spotify_release": item.spotify_release,
                 "spotify_duration": item.spotify_duration,
+                "availability_status": item.availability_status,
+                "availability_reason": item.availability_reason,
+                "availability_checked_at": item.availability_checked_at,
+                "availability_source": item.availability_source,
             }, item.source_duration,
         )
 
@@ -1633,7 +1866,26 @@ class MatchCacheKnowledge:
                 "score_reasons": list(item.score_reasons),
                 "spotify_release": item.spotify_release,
                 "spotify_duration": item.spotify_duration,
+                "availability_status": item.availability_status,
+                "availability_reason": item.availability_reason,
+                "availability_checked_at": item.availability_checked_at,
+                "availability_source": item.availability_source,
             },
+        )
+        return ApprovalConflict(**conflict) if conflict else None
+
+    def local_audio_approval_conflict(
+        self, item: PublicationItem, account_id: str,
+    ) -> ApprovalConflict | None:
+        if item.local_evidence_id is None:
+            return None
+        conflict = self._cache.fingerprint_approval_conflict(
+            evidence_id=item.local_evidence_id,
+            account_id=account_id,
+            spotify_uri=item.spotify_uri,
+            source_artist=item.source_artist,
+            source_title=item.source_title,
+            source_duration=item.source_duration,
         )
         return ApprovalConflict(**conflict) if conflict else None
 
@@ -1661,7 +1913,19 @@ class MatchCacheKnowledge:
         )
 
     def approval_conflict(self, item: PublicationItem) -> bool:
-        return any(
+        retained = self._cache.lookup(
+            item.source_artist,
+            item.source_title,
+            100,
+            item.source_duration,
+        )
+        conflicts_with_approved = bool(
+            retained is not None
+            and retained.approval_status == ApprovalStatus.APPROVED.value
+            and retained.spotify_uri
+            and retained.spotify_uri != item.spotify_uri
+        )
+        return conflicts_with_approved or any(
             conflict.get("source_artist") == item.source_artist
             and conflict.get("source_title") == item.source_title
             and int(conflict.get("source_duration", 0)) == item.source_duration
@@ -1734,6 +1998,11 @@ class EphemeralMatchingKnowledge:
     def approval_conflict(self, item: PublicationItem) -> bool:
         return False
 
+    def local_audio_approval_conflict(
+        self, item: PublicationItem, account_id: str,
+    ) -> ApprovalConflict | None:
+        return None
+
 
 class Transfer:
     """Coordinate a Transfer through source, Spotify, and storage seams."""
@@ -1764,10 +2033,14 @@ class Transfer:
 
     @staticmethod
     def private_source_authorization_requirement(
-        authorization: TransferAuthorization,
+        authorization: TransferAuthorization | None,
     ) -> str | None:
         """Own the policy for access to private source material."""
-        return None if authorization.private_source else "private_source"
+        return (
+            None
+            if authorization is not None and authorization.private_source
+            else "private_source"
+        )
 
     @staticmethod
     def authorization_requirement(
@@ -1959,6 +2232,18 @@ class Transfer:
             stored["location"] = track.location
         return stored
 
+    @classmethod
+    def _selection_token(
+        cls, selection: SourceSelection, *, include_locations: bool,
+    ) -> str:
+        material = [
+            cls._stored_track(track, include_location=include_locations)
+            for track in selection.tracks
+        ]
+        return hashlib.sha256(json.dumps(
+            material, sort_keys=True, separators=(",", ":"),
+        ).encode()).hexdigest()
+
     def plan_batch(self, request: BatchPlanRequest) -> BatchPlan:
         """Plan an explicitly selected Rekordbox Batch without side effects."""
         if request.local_audio_identity and not getattr(
@@ -1976,19 +2261,13 @@ class Transfer:
         )
         playlists = []
         for selection in selections:
-            selection_material = [
-                self._stored_track(
-                    track,
-                    include_location=(
-                        request.local_audio_identity
-                        or request.local_audio_audition
-                    ),
-                )
-                for track in selection.tracks
-            ]
-            selection_token = hashlib.sha256(json.dumps(
-                selection_material, sort_keys=True, separators=(",", ":"),
-            ).encode()).hexdigest()
+            selection_token = self._selection_token(
+                selection,
+                include_locations=(
+                    request.local_audio_identity
+                    or request.local_audio_audition
+                ),
+            )
             approved_match_hits = 0
             cache_hits = 0
             expected_uncached_lookups = 0
@@ -2130,6 +2409,7 @@ class Transfer:
                 playlists=[
                     BatchPlaylistState(
                         planned.name, planned.reference, f"{batch_id}:{index}",
+                        selection_token=planned.selection_token,
                     )
                     for index, planned in enumerate(plan.playlists)
                 ],
@@ -2163,7 +2443,7 @@ class Transfer:
                     transfer_id=item.transfer_id,
                     local_audio_identity=batch.local_audio_identity,
                     local_audio_audition=batch.local_audio_audition,
-                ))
+                ), expected_selection_token=item.selection_token)
             except Exception as exc:
                 if not self._is_shared_failure(exc) and not self._is_playlist_failure(exc):
                     raise
@@ -2338,6 +2618,8 @@ class Transfer:
             for method in ("load_qualification", "save_qualification")
         ):
             raise ValueError("Qualification requires durable Transfer storage")
+        if hasattr(self._transfer_storage, "refresh"):
+            self._transfer_storage.refresh()
         child_id, batch_id, state = self._qualification_transfer(request)
         if state.status != TransferStatus.COMPLETED:
             raise ValueError("Qualification requires a completed Transfer")
@@ -2345,6 +2627,39 @@ class Transfer:
             raise ValueError(
                 "Qualification is available only for Rekordbox Mirrors"
             )
+        initial_source_reference = state.selection.get("reference")
+        if not initial_source_reference:
+            raise ValueError("Qualification source selection is unavailable")
+        draft_id = hashlib.sha256(
+            f"qualification\0{child_id}\0{initial_source_reference}".encode()
+        ).hexdigest()
+        draft = self._transfer_storage.load_qualification(draft_id)
+        seen_drafts: set[str] = set()
+        while draft is not None and draft.superseded_by is not None:
+            if draft.draft_id in seen_drafts:
+                raise SpotifyPlaylistReviewRequired(
+                    "Qualification Draft lineage is invalid; review required",
+                    draft_id=draft.draft_id,
+                )
+            seen_drafts.add(draft.draft_id)
+            successor = self._transfer_storage.load_qualification(
+                draft.superseded_by
+            )
+            if successor is None:
+                raise SpotifyPlaylistReviewRequired(
+                    "Qualification Draft successor is unavailable; review required",
+                    draft_id=draft.draft_id,
+                )
+            draft = successor
+            draft_id = successor.draft_id
+        if draft is not None and draft.transfer_id != child_id:
+            linked_state = self._transfer_storage.load_transfer(
+                draft.transfer_id
+            )
+            if linked_state is not None:
+                child_id = draft.transfer_id
+                batch_id = draft.batch_id
+                state = linked_state
         source_reference = state.selection.get("reference")
         if not source_reference:
             raise ValueError("Qualification source selection is unavailable")
@@ -2362,12 +2677,32 @@ class Transfer:
                     state.spotify_playlist_id  # type: ignore[arg-type]
                 ).snapshot_id
             )
-        draft_id = hashlib.sha256(
-            f"qualification\0{child_id}\0{source_reference}".encode()
-        ).hexdigest()
-        draft = self._transfer_storage.load_qualification(draft_id)
+        if (
+            draft is None
+            and state.spotify_playlist_id is not None
+            and hasattr(
+                self._transfer_storage, "qualifications_for_playlist"
+            )
+        ):
+            linked = [
+                candidate
+                for candidate in self._transfer_storage.qualifications_for_playlist(
+                    account_id, state.spotify_playlist_id,
+                )
+                if candidate.transfer_id == child_id
+                and candidate.source_reference == source_reference
+                and candidate.superseded_by is None
+            ]
+            if len(linked) > 1:
+                raise SpotifyPlaylistReviewRequired(
+                    "Multiple Qualification Drafts claim this bounded Transfer; "
+                    "review required"
+                )
+            if linked:
+                draft = linked[0]
+                draft_id = draft.draft_id
         items = self._qualification_items(state, None)
-        selected_ids = [
+        requested_ids = [
             item.item_id for item in items
             if request.include_all or item.attention_reasons
         ]
@@ -2384,29 +2719,45 @@ class Transfer:
                 manifest_digest=manifest_digest,
                 selection_digest=selection_digest,
                 include_all=request.include_all,
-                item_ids=selected_ids,
+                item_ids=requested_ids,
                 decisions={},
                 status=QualificationStatus.DRAFT,
                 created_at=now,
                 updated_at=now,
+                audition_selection_digest=state.audition_selection_digest,
             )
         else:
             if draft.account_id != account_id:
                 raise ValueError(
                     "A Qualification Draft cannot resume under another Spotify account"
                 )
+            recoverable_manifest = (
+                draft.status in {
+                    QualificationStatus.APPLYING,
+                    QualificationStatus.PAUSED,
+                }
+                and draft.applied_manifest is not None
+                and manifest_digest == self._publication_digest(
+                    self._publication_from_stored(draft.applied_manifest)
+                )
+            )
             if (
                 draft.transfer_id != child_id
                 or draft.source_reference != source_reference
                 or draft.selection_digest != selection_digest
-                or draft.manifest_digest != manifest_digest
+                or (
+                    draft.manifest_digest != manifest_digest
+                    and not recoverable_manifest
+                )
                 or draft.playlist_id != state.spotify_playlist_id
             ):
                 draft.status = QualificationStatus.REVIEW_REQUIRED
+                draft.review_reason = "evidence_changed"
                 draft.updated_at = now
                 self._transfer_storage.save_qualification(draft_id, draft)
                 raise SpotifyPlaylistReviewRequired(
-                    "Qualification evidence changed; create a new bounded review"
+                    "Qualification evidence changed; create a new bounded review",
+                    draft_id=draft_id,
                 )
             if (
                 draft.playlist_head is not None
@@ -2416,18 +2767,38 @@ class Transfer:
                     QualificationStatus.APPLYING,
                     QualificationStatus.PAUSED,
                     QualificationStatus.APPLIED,
+                    QualificationStatus.DISCARDED,
                 }
             ):
                 draft.status = QualificationStatus.REVIEW_REQUIRED
+                draft.review_reason = "evidence_changed"
                 draft.updated_at = now
                 self._transfer_storage.save_qualification(draft_id, draft)
                 raise SpotifyPlaylistReviewRequired(
-                    "Spotify playlist changed; Qualification review required"
+                    "Spotify playlist changed; Qualification review required",
+                    draft_id=draft_id,
                 )
-            draft.include_all = request.include_all
-            draft.item_ids = selected_ids
+            draft.include_all = draft.include_all or request.include_all
+            selected_ids = [
+                item.item_id for item in items
+                if draft.include_all or item.attention_reasons
+            ]
+            draft.item_ids = list(dict.fromkeys([
+                *draft.item_ids, *selected_ids,
+            ]))
             draft.updated_at = now
-        self._preflight_qualification_audition(draft, state)
+            if draft.status in {
+                QualificationStatus.APPLYING,
+                QualificationStatus.PAUSED,
+                QualificationStatus.APPLIED,
+                QualificationStatus.DISCARDED,
+            }:
+                return self._qualification_view(draft, state)
+        try:
+            self._preflight_qualification_audition(draft, state)
+        except SpotifyPlaylistReviewRequired as exc:
+            exc.draft_id = draft_id
+            raise
         view = self._qualification_view(draft, state)
         draft.status = (
             QualificationStatus.READY if view.complete
@@ -2437,12 +2808,21 @@ class Transfer:
         self._transfer_storage.save_qualification(draft_id, draft)
         return self._qualification_view(draft, state)
 
-    def qualification(self, draft_id: str) -> QualificationView:
+    def qualification(
+        self,
+        draft_id: str,
+        authorization: TransferAuthorization | None = None,
+    ) -> QualificationView:
         """Render one durable draft without inferring any outcome."""
+        required = self.private_source_authorization_requirement(authorization)
+        if required:
+            raise PermissionError(required)
         if self._transfer_storage is None or not hasattr(
             self._transfer_storage, "load_qualification"
         ):
             raise ValueError("Qualification requires durable Transfer storage")
+        if hasattr(self._transfer_storage, "refresh"):
+            self._transfer_storage.refresh()
         draft = self._transfer_storage.load_qualification(draft_id)
         if draft is None:
             raise ValueError(f"Unknown Qualification Draft: {draft_id}")
@@ -2454,6 +2834,271 @@ class Transfer:
         if state is None:
             raise ValueError("Qualification Transfer evidence is unavailable")
         return self._qualification_view(draft, state)
+
+    def link_qualification(
+        self,
+        draft_id: str,
+        publishing_transfer_id: str,
+        authorization: TransferAuthorization,
+    ) -> QualificationView:
+        """Link one Preview draft to a distinct, equivalent Provisional Mirror."""
+        required = self.private_source_authorization_requirement(authorization)
+        if required:
+            raise PermissionError(required)
+        if self._transfer_storage is None or self._publication_storage is None:
+            raise ValueError(
+                "Qualification linking requires durable Transfer and publication state"
+            )
+        account_id = self._spotify.account_id()
+        with self._publishing_guards.acquire(account_id):
+            if hasattr(self._transfer_storage, "refresh"):
+                self._transfer_storage.refresh()
+            if hasattr(self._publication_storage, "load"):
+                self._publication_storage.load()
+            draft = self._transfer_storage.load_qualification(draft_id)
+            if draft is None:
+                raise ValueError(f"Unknown Qualification Draft: {draft_id}")
+            if draft.account_id != account_id:
+                raise ValueError(
+                    "A Qualification Draft cannot be linked under another account"
+                )
+            if draft.playlist_id is not None:
+                raise ValueError(
+                    "A Qualification Draft is already linked to a Provisional Playlist"
+                )
+            if draft.status in {
+                QualificationStatus.APPLYING,
+                QualificationStatus.PAUSED,
+                QualificationStatus.APPLIED,
+                QualificationStatus.DISCARDED,
+            }:
+                raise ValueError(
+                    "This Qualification Draft cannot be linked in its current state"
+                )
+            preview_state = self._transfer_storage.load_transfer(
+                draft.transfer_id
+            )
+            if preview_state is None or not preview_state.request.get(
+                "preview", False,
+            ):
+                raise ValueError(
+                    "Only a Preview Qualification Draft requires explicit linking"
+                )
+            if (
+                self._qualification_manifest_digest(preview_state)
+                != draft.manifest_digest
+            ):
+                draft.status = QualificationStatus.REVIEW_REQUIRED
+                draft.review_reason = "evidence_changed"
+                draft.updated_at = datetime.now().isoformat()
+                self._transfer_storage.save_qualification(draft_id, draft)
+                raise SpotifyPlaylistReviewRequired(
+                    "Preview Qualification evidence changed; review required",
+                    draft_id=draft_id,
+                )
+            target_id, target_batch_id, target_state = (
+                self._qualification_transfer(QualificationRequest(
+                    transfer_id=publishing_transfer_id,
+                    playlist_reference=draft.source_reference,
+                    include_all=draft.include_all,
+                ))
+            )
+            if target_id == draft.transfer_id:
+                raise ValueError(
+                    "Preview and publishing Transfers must remain distinct"
+                )
+            if (
+                target_state.status != TransferStatus.COMPLETED
+                or target_state.request.get("preview", False)
+                or target_state.request.get("mode") != TransferMode.MIRROR.value
+                or target_state.spotify_playlist_id is None
+            ):
+                raise ValueError(
+                    "Qualification linking requires a completed Provisional Mirror"
+                )
+            if target_state.account_id != account_id:
+                raise ValueError(
+                    "A Qualification Draft cannot be linked under another account"
+                )
+            target_selection_digest = self._qualification_selection_digest(
+                target_state.selection
+            )
+            if target_selection_digest != draft.selection_digest:
+                raise SpotifyPlaylistReviewRequired(
+                    "Publishing Transfer source evidence differs from the Preview",
+                    draft_id=draft_id,
+                )
+            if (
+                bool(preview_state.request.get("local_audio_audition", False))
+                != bool(target_state.request.get("local_audio_audition", False))
+                or draft.audition_selection_digest
+                != target_state.audition_selection_digest
+            ):
+                raise SpotifyPlaylistReviewRequired(
+                    "Publishing Transfer audition intent or evidence differs",
+                    draft_id=draft_id,
+                )
+            try:
+                current_selection = self._source.consume(
+                    draft.source_reference
+                )
+            except Exception as exc:
+                draft.status = QualificationStatus.REVIEW_REQUIRED
+                draft.review_reason = "evidence_changed"
+                draft.updated_at = datetime.now().isoformat()
+                self._transfer_storage.save_qualification(draft_id, draft)
+                raise SpotifyPlaylistReviewRequired(
+                    "Rekordbox source evidence is unavailable; review required",
+                    draft_id=draft_id,
+                ) from exc
+            current_public = {
+                "reference": current_selection.reference,
+                "tracks": [
+                    self._stored_track(track, include_location=False)
+                    for track in current_selection.tracks
+                ],
+            }
+            if (
+                self._qualification_selection_digest(current_public)
+                != draft.selection_digest
+                or (
+                    draft.audition_selection_digest is not None
+                    and self._qualification_audition_digest(current_selection)
+                    != draft.audition_selection_digest
+                )
+            ):
+                raise SpotifyPlaylistReviewRequired(
+                    "Rekordbox source selection changed; review required",
+                    draft_id=draft_id,
+                )
+            target_manifest = self._publication_storage.publication_for_playlist(
+                account_id, target_state.spotify_playlist_id,
+            )
+            if target_manifest is None or self._publication_digest(
+                target_manifest
+            ) != self._qualification_manifest_digest(target_state):
+                raise SpotifyPlaylistReviewRequired(
+                    "Provisional publication evidence changed; review required",
+                    draft_id=draft_id,
+                )
+            other_drafts = [
+                candidate
+                for candidate in self._transfer_storage.qualifications_for_playlist(
+                    account_id, target_state.spotify_playlist_id,
+                )
+                if candidate.draft_id != draft_id
+                and candidate.status not in {
+                    QualificationStatus.APPLIED,
+                    QualificationStatus.DISCARDED,
+                }
+            ]
+            if other_drafts:
+                raise SpotifyPlaylistReviewRequired(
+                    "The Provisional Playlist already has a Qualification Draft",
+                    draft_id=draft_id,
+                )
+
+            preview_items = {
+                (item.source_index, item.source_track_id): item
+                for item in self._qualification_items(preview_state, None)
+            }
+            target_items = {
+                (item.source_index, item.source_track_id): item
+                for item in self._qualification_items(target_state, None)
+            }
+            preview_by_id = {
+                item.item_id: item for item in preview_items.values()
+            }
+            mapped_ids: dict[str, str] = {}
+            for old_item_id in draft.item_ids:
+                old_item = preview_by_id.get(old_item_id)
+                if old_item is None:
+                    raise SpotifyPlaylistReviewRequired(
+                        "Preview Qualification evidence is incomplete",
+                        draft_id=draft_id,
+                    )
+                target_item = target_items.get((
+                    old_item.source_index, old_item.source_track_id,
+                ))
+                if target_item is None:
+                    raise SpotifyPlaylistReviewRequired(
+                        "Publishing Transfer source evidence differs from the Preview",
+                        draft_id=draft_id,
+                    )
+                if old_item_id in draft.decisions and (
+                    old_item.spotify_uri,
+                    old_item.spotify_name,
+                    old_item.spotify_artist,
+                    old_item.spotify_release,
+                    old_item.spotify_duration,
+                    old_item.score,
+                    old_item.match_type,
+                    old_item.score_reasons,
+                    old_item.authority_status,
+                    old_item.attention_reasons,
+                    old_item.availability_status,
+                    old_item.availability_reason,
+                    old_item.availability_checked_at,
+                    old_item.availability_source,
+                ) != (
+                    target_item.spotify_uri,
+                    target_item.spotify_name,
+                    target_item.spotify_artist,
+                    target_item.spotify_release,
+                    target_item.spotify_duration,
+                    target_item.score,
+                    target_item.match_type,
+                    target_item.score_reasons,
+                    target_item.authority_status,
+                    target_item.attention_reasons,
+                    target_item.availability_status,
+                    target_item.availability_reason,
+                    target_item.availability_checked_at,
+                    target_item.availability_source,
+                ):
+                    raise SpotifyPlaylistReviewRequired(
+                        "A reviewed Spotify proposal changed before linking",
+                        draft_id=draft_id,
+                    )
+                mapped_ids[old_item_id] = target_item.item_id
+
+            selected_target_ids = [
+                item.item_id for item in target_items.values()
+                if draft.include_all or item.attention_reasons
+            ]
+            old_transfer_id = draft.transfer_id
+            draft.transfer_id = target_id
+            draft.batch_id = target_batch_id
+            draft.playlist_id = target_state.spotify_playlist_id
+            draft.playlist_head = self._retry_policy.run(
+                lambda: self._spotify.playlist_head(
+                    target_state.spotify_playlist_id  # type: ignore[arg-type]
+                )
+            ).snapshot_id
+            draft.manifest_digest = self._publication_digest(target_manifest)
+            draft.selection_digest = target_selection_digest
+            draft.item_ids = list(dict.fromkeys([
+                *(mapped_ids[item_id] for item_id in draft.item_ids),
+                *selected_target_ids,
+            ]))
+            draft.decisions = {
+                mapped_ids[item_id]: decision
+                for item_id, decision in draft.decisions.items()
+            }
+            draft.audition_statuses = {}
+            if self._local_audition is not None and hasattr(
+                self._local_audition, "invalidate_transfer"
+            ):
+                self._local_audition.invalidate_transfer(old_transfer_id)
+            self._preflight_qualification_audition(draft, target_state)
+            linked_view = self._qualification_view(draft, target_state)
+            draft.status = (
+                QualificationStatus.READY
+                if linked_view.complete else QualificationStatus.DRAFT
+            )
+            draft.updated_at = datetime.now().isoformat()
+            self._transfer_storage.save_qualification(draft_id, draft)
+            return self._qualification_view(draft, target_state)
 
     def _qualification_transfer(
         self, request: QualificationRequest,
@@ -2488,10 +3133,25 @@ class Transfer:
 
     @classmethod
     def _qualification_selection_digest(cls, selection: dict) -> str:
+        track_defaults = {
+            "track_id": "",
+            "name": "",
+            "artist": "",
+            "album": "",
+            "remixer": "",
+            "label": "",
+            "genre": "",
+            "date_added": "",
+            "duration": 0,
+            "version": "",
+        }
         private_safe = {
             "reference": selection.get("reference"),
             "tracks": [
-                {key: value for key, value in track.items() if key != "location"}
+                {
+                    key: track.get(key, default)
+                    for key, default in track_defaults.items()
+                }
                 for track in selection.get("tracks", ())
             ],
         }
@@ -2499,15 +3159,60 @@ class Transfer:
             private_safe, sort_keys=True, separators=(",", ":"),
         ).encode()).hexdigest()
 
-    @staticmethod
-    def _qualification_manifest_digest(state: TransferState) -> str:
-        evidence = state.publication_manifest or {
-            "preview_items": state.publication_items,
-            "playlist_id": state.spotify_playlist_id,
-        }
+    @classmethod
+    def _qualification_audition_digest(cls, selection: SourceSelection) -> str:
+        """Bind audition to exact selected locations without retaining them."""
+        return cls._selection_token(selection, include_locations=True)
+
+    @classmethod
+    def _qualification_manifest_digest(cls, state: TransferState) -> str:
+        if state.publication_manifest is not None:
+            evidence = cls._stored_publication(
+                cls._publication_from_stored(state.publication_manifest)
+            )
+        else:
+            evidence = {
+                "preview_items": [
+                    asdict(PublicationItem(**item))
+                    for item in state.publication_items
+                ],
+                "playlist_id": state.spotify_playlist_id,
+            }
         return hashlib.sha256(json.dumps(
             evidence, sort_keys=True, separators=(",", ":"),
         ).encode()).hexdigest()
+
+    @staticmethod
+    def _availability_facts(result: dict, *, source: str) -> dict:
+        """Normalize truthful availability without treating omission as proof."""
+        retained_status = result.get("availability_status")
+        if retained_status in {"available", "unavailable", "unknown"}:
+            return {
+                "availability_status": retained_status,
+                "availability_reason": result.get("availability_reason"),
+                "availability_checked_at": result.get(
+                    "availability_checked_at"
+                ),
+                "availability_source": result.get(
+                    "availability_source", source,
+                ),
+            }
+        playable = result.get("is_playable")
+        if playable is True:
+            status, reason = "available", None
+        elif playable is False:
+            status, reason = "unavailable", "spotify_unavailable"
+        else:
+            status, reason = "unknown", "not_checked"
+        return {
+            "availability_status": status,
+            "availability_reason": reason,
+            "availability_checked_at": (
+                datetime.now().isoformat()
+                if isinstance(playable, bool) else None
+            ),
+            "availability_source": source,
+        }
 
     def _qualification_items(
         self,
@@ -2540,38 +3245,7 @@ class Transfer:
             item_id = item.occurrence_id or hashlib.sha256(
                 f"{state.source}\0{source_index}\0{item.source_track_id}".encode()
             ).hexdigest()
-            reasons: list[str] = []
             authority_status = "approved" if item.authoritative else "proposal"
-            if not item.authoritative:
-                if item.spotify_uri:
-                    reasons.append("new_proposal")
-                else:
-                    reasons.append("unresolved")
-                if item.match_type in {"shorter_version", "fallback_version"}:
-                    reasons.append(item.match_type)
-                if (
-                    item.source_duration > 0
-                    and item.spotify_duration > 0
-                    and abs(item.source_duration - item.spotify_duration) > 30
-                ):
-                    reasons.append("duration_conflict")
-                if any(
-                    "version" in reason.casefold()
-                    and any(marker in reason.casefold() for marker in (
-                        "conflict", "differ", "fallback", "shorter", "mismatch",
-                    ))
-                    for reason in item.score_reasons
-                ):
-                    reasons.append("version_conflict")
-                if item.source_track_id in alternative_ids:
-                    reasons.append("alternatives")
-                if item.spotify_uri in collision_uris:
-                    reasons.append("match_collision")
-                conflict_checker = getattr(
-                    self._knowledge, "approval_conflict", None
-                )
-                if conflict_checker is not None and conflict_checker(item):
-                    reasons.append("approval_conflict")
             decision_data = (
                 draft.decisions.get(item_id, {}) if draft is not None else {}
             )
@@ -2580,10 +3254,120 @@ class Transfer:
                 QualificationDecision(decision_value)
                 if decision_value is not None else None
             )
+            rendered_item = item
+            if decision == QualificationDecision.CORRECTION:
+                rendered_item = replace(
+                    item,
+                    spotify_uri=str(decision_data["correction_uri"]),
+                    spotify_name=str(decision_data["spotify_name"]),
+                    spotify_artist=str(decision_data["spotify_artist"]),
+                    spotify_release=str(
+                        decision_data.get("spotify_release", "")
+                    ),
+                    spotify_duration=int(
+                        decision_data.get("spotify_duration", 0)
+                    ),
+                    score=100.0,
+                    match_type="correction",
+                    score_reasons=("explicit Qualification Correction",),
+                    authoritative=False,
+                    availability_status=str(
+                        decision_data.get("availability_status", "unknown")
+                    ),
+                    availability_reason=decision_data.get(
+                        "availability_reason"
+                    ),
+                    availability_checked_at=decision_data.get(
+                        "availability_checked_at"
+                    ),
+                    availability_source=decision_data.get(
+                        "availability_source"
+                    ),
+                )
+                authority_status = "proposal"
+            reasons: list[str] = []
+            if decision == QualificationDecision.CORRECTION:
+                reasons.append("staged_correction")
+            elif not rendered_item.authoritative:
+                if rendered_item.spotify_uri:
+                    reasons.append("new_proposal")
+                else:
+                    reasons.append("unresolved")
+                if rendered_item.match_type in {
+                    "shorter_version", "fallback_version",
+                }:
+                    reasons.append(rendered_item.match_type)
+                if (
+                    rendered_item.source_duration > 0
+                    and rendered_item.spotify_duration > 0
+                    and abs(
+                        rendered_item.source_duration
+                        - rendered_item.spotify_duration
+                    ) > 30
+                ):
+                    reasons.append("duration_conflict")
+                if any(
+                    "version" in reason.casefold()
+                    and any(marker in reason.casefold() for marker in (
+                        "conflict", "differ", "fallback", "shorter", "mismatch",
+                    ))
+                    for reason in rendered_item.score_reasons
+                ):
+                    reasons.append("version_conflict")
+                if rendered_item.source_track_id in alternative_ids:
+                    reasons.append("alternatives")
+                if rendered_item.spotify_uri in collision_uris:
+                    reasons.append("match_collision")
+            conflict_checker = getattr(
+                self._knowledge, "approval_conflict", None
+            )
+            if (
+                not rendered_item.authoritative
+                and conflict_checker is not None
+                and conflict_checker(rendered_item)
+            ):
+                reasons.append("approval_conflict")
             if decision == QualificationDecision.DEFERRED and not decision_data.get(
                 "excluded", False
             ):
                 reasons.append("deferred")
+            if rendered_item.availability_status == "unavailable":
+                reasons.append(
+                    rendered_item.availability_reason or "spotify_unavailable"
+                )
+            permitted_actions = (
+                ()
+                if draft is not None and draft.status in {
+                    QualificationStatus.APPLYING,
+                    QualificationStatus.PAUSED,
+                    QualificationStatus.APPLIED,
+                    QualificationStatus.DISCARDED,
+                }
+                or (
+                    draft is not None
+                    and draft.status == QualificationStatus.REVIEW_REQUIRED
+                    and draft.review_reason != "resolvable_conflict"
+                )
+                else (
+                    (
+                        QualificationDecision.KEEP_PROPOSAL,
+                        QualificationDecision.CORRECTION,
+                        QualificationDecision.DEFERRED,
+                        QualificationDecision.REJECT_PROPOSAL,
+                    )
+                    if (
+                        item.spotify_uri
+                        and item.availability_status != "unavailable"
+                    ) else (
+                        QualificationDecision.CORRECTION,
+                        QualificationDecision.DEFERRED,
+                        *(
+                            (QualificationDecision.REJECT_PROPOSAL,)
+                            if item.spotify_uri else ()
+                        ),
+                    )
+                )
+            )
             audition_fact = (
                 draft.audition_statuses.get(item_id, {})
                 if draft is not None else {}
@@ -2608,14 +3392,14 @@ class Transfer:
                 source_label=item.source_label,
                 source_version=item.source_version,
                 source_duration=item.source_duration,
-                spotify_uri=item.spotify_uri,
-                spotify_name=item.spotify_name,
-                spotify_artist=item.spotify_artist,
-                spotify_release=item.spotify_release,
-                spotify_duration=item.spotify_duration,
-                score=item.score,
-                match_type=item.match_type,
-                score_reasons=item.score_reasons,
+                spotify_uri=rendered_item.spotify_uri,
+                spotify_name=rendered_item.spotify_name,
+                spotify_artist=rendered_item.spotify_artist,
+                spotify_release=rendered_item.spotify_release,
+                spotify_duration=rendered_item.spotify_duration,
+                score=rendered_item.score,
+                match_type=rendered_item.match_type,
+                score_reasons=rendered_item.score_reasons,
                 authority_status=authority_status,
                 attention_reasons=tuple(dict.fromkeys(reasons)),
                 audition_status=audition_status,
@@ -2624,17 +3408,18 @@ class Transfer:
                 correction_uri=decision_data.get("correction_uri"),
                 deferred_reason=decision_data.get("reason"),
                 excluded=bool(decision_data.get("excluded", False)),
+                availability_status=rendered_item.availability_status,
+                availability_reason=rendered_item.availability_reason,
+                availability_checked_at=rendered_item.availability_checked_at,
+                availability_source=rendered_item.availability_source,
+                permitted_actions=permitted_actions,
             ))
         return rendered
 
     def _preflight_qualification_audition(
         self, draft: QualificationDraftState, state: TransferState,
     ) -> None:
-        if (
-            not state.request.get("local_audio_audition", False)
-            or self._local_audition is None
-            or not hasattr(self._local_audition, "preflight")
-        ):
+        if not state.request.get("local_audio_audition", False):
             return
         selection = self._source.consume(draft.source_reference)
         comparison = {
@@ -2648,6 +3433,28 @@ class Transfer:
             raise SpotifyPlaylistReviewRequired(
                 "Rekordbox source selection changed; audition blocked"
             )
+        expected_digest = state.audition_selection_digest
+        if draft.audition_selection_digest is None and expected_digest is not None:
+            draft.audition_selection_digest = expected_digest
+        if expected_digest is None:
+            for item_id in draft.item_ids:
+                draft.audition_statuses[item_id] = {
+                    "status": "unavailable",
+                    "reason": "selection_binding_unavailable",
+                }
+            return
+        if (
+            draft.audition_selection_digest != expected_digest
+            or self._qualification_audition_digest(selection) != expected_digest
+        ):
+            raise SpotifyPlaylistReviewRequired(
+                "Rekordbox source selection changed; audition blocked"
+            )
+        if (
+            self._local_audition is None
+            or not hasattr(self._local_audition, "preflight")
+        ):
+            return
         items = {
             item.item_id: item
             for item in self._qualification_items(state, draft)
@@ -2698,21 +3505,37 @@ class Transfer:
         draft_id: str,
         item_id: str,
         decision: QualificationDecision,
+        authorization: TransferAuthorization | None = None,
         *,
         spotify_reference: str | None = None,
         reason: str | None = None,
         exclude: bool = False,
     ) -> QualificationView:
         """Record or revise one draft outcome without creating authority."""
+        required = self.private_source_authorization_requirement(authorization)
+        if required:
+            raise PermissionError(required)
         if self._transfer_storage is None or not hasattr(
             self._transfer_storage, "load_qualification"
         ):
             raise ValueError("Qualification requires durable Transfer storage")
+        if hasattr(self._transfer_storage, "refresh"):
+            self._transfer_storage.refresh()
         draft = self._transfer_storage.load_qualification(draft_id)
         if draft is None:
             raise ValueError(f"Unknown Qualification Draft: {draft_id}")
-        if draft.status == QualificationStatus.APPLIED:
-            raise ValueError("An applied Qualification Draft cannot be revised")
+        if draft.status in {
+            QualificationStatus.APPLYING,
+            QualificationStatus.PAUSED,
+            QualificationStatus.APPLIED,
+            QualificationStatus.DISCARDED,
+        } or (
+            draft.status == QualificationStatus.REVIEW_REQUIRED
+            and draft.review_reason != "resolvable_conflict"
+        ):
+            raise ValueError(
+                "A Qualification Draft cannot be revised after application starts"
+            )
         if draft.account_id != self._spotify.account_id():
             raise ValueError(
                 "A Qualification Draft cannot be revised under another Spotify account"
@@ -2727,10 +3550,12 @@ class Transfer:
         if item_id not in draft.item_ids or item_id not in items:
             raise ValueError("Qualification item is outside the selected playlist")
         item = items[item_id]
+        if decision not in item.permitted_actions:
+            raise ValueError(
+                "Qualification outcome is unavailable for this proposal"
+            )
         if exclude and decision != QualificationDecision.DEFERRED:
             raise ValueError("Only a deferred item can be explicitly excluded")
-        if decision == QualificationDecision.KEEP_PROPOSAL and not item.spotify_uri:
-            raise ValueError("An unresolved source track has no proposal to keep")
         stored: dict[str, object] = {
             "decision": decision.value,
             "updated_at": datetime.now().isoformat(),
@@ -2739,11 +3564,25 @@ class Transfer:
             if spotify_reference is None:
                 raise ValueError("A staged Correction requires a Spotify track URL or URI")
             spotify_uri = self._spotify_uri(spotify_reference, 1)
+            if spotify_uri == item.spotify_uri:
+                raise ValueError(
+                    "A staged Correction must select a different Spotify track"
+                )
             spotify_track = self._retry_policy.run(
                 lambda: self._spotify.spotify_track(spotify_uri)
             )
             if spotify_track.get("uri") != spotify_uri:
                 raise ValueError("The staged Correction did not resolve to its Spotify track")
+            if (
+                spotify_track.get("is_playable") is False
+                or spotify_track.get("is_local") is True
+                or bool(spotify_track.get("restrictions"))
+                or spotify_track.get("linked_from") is not None
+                or spotify_track.get("linked_from_uri") is not None
+            ):
+                raise ValueError(
+                    "The staged Correction is not an available Spotify track"
+                )
             stored.update({
                 "correction_uri": spotify_uri,
                 "spotify_name": spotify_track["name"],
@@ -2752,6 +3591,9 @@ class Transfer:
                 "spotify_duration": int(
                     spotify_track.get("duration_ms", 0)
                 ) // 1000,
+                **self._availability_facts(
+                    spotify_track, source="spotify_track_lookup",
+                ),
             })
         elif decision == QualificationDecision.DEFERRED:
             stored.update({
@@ -2765,6 +3607,7 @@ class Transfer:
             QualificationStatus.READY if view.complete
             else QualificationStatus.DRAFT
         )
+        draft.review_reason = None
         self._transfer_storage.save_qualification(draft_id, draft)
         return self._qualification_view(draft, state)
 
@@ -2784,9 +3627,15 @@ class Transfer:
             self._transfer_storage, "load_qualification"
         ):
             raise ValueError("Qualification requires durable Transfer storage")
+        if hasattr(self._transfer_storage, "refresh"):
+            self._transfer_storage.refresh()
         draft = self._transfer_storage.load_qualification(draft_id)
         if draft is None:
             raise ValueError(f"Unknown Qualification Draft: {draft_id}")
+        if draft.status == QualificationStatus.DISCARDED:
+            raise ValueError(
+                "A discarded Qualification Draft cannot audition source media"
+            )
         if draft.account_id != self._spotify.account_id():
             raise ValueError(
                 "A Qualification Draft cannot be auditioned under another Spotify account"
@@ -2818,6 +3667,18 @@ class Transfer:
             raise SpotifyPlaylistReviewRequired(
                 "Rekordbox source selection changed; audition blocked"
             )
+        expected_digest = state.audition_selection_digest
+        if expected_digest is None:
+            return LocalAuditionResult.unavailable(
+                "selection_binding_unavailable"
+            )
+        if (
+            draft.audition_selection_digest != expected_digest
+            or self._qualification_audition_digest(selection) != expected_digest
+        ):
+            raise SpotifyPlaylistReviewRequired(
+                "Rekordbox source selection changed; audition blocked"
+            )
         if item.source_index >= len(selection.tracks):
             raise ValueError("Audition item is outside the selected source")
         selected_track = selection.tracks[item.source_index]
@@ -2832,6 +3693,195 @@ class Transfer:
         }
         self._transfer_storage.save_qualification(draft_id, draft)
         return result
+
+    def discard_qualification(
+        self,
+        draft_id: str,
+        authorization: TransferAuthorization,
+    ) -> QualificationView:
+        """Explicitly retire an unapplied draft without creating authority."""
+        required = self.private_source_authorization_requirement(authorization)
+        if required:
+            raise PermissionError(required)
+        if self._transfer_storage is None:
+            raise ValueError("Qualification requires durable Transfer storage")
+        if hasattr(self._transfer_storage, "refresh"):
+            self._transfer_storage.refresh()
+        draft = self._transfer_storage.load_qualification(draft_id)
+        if draft is None:
+            raise ValueError(f"Unknown Qualification Draft: {draft_id}")
+        if draft.account_id != self._spotify.account_id():
+            raise ValueError(
+                "A Qualification Draft cannot be discarded under another account"
+            )
+        if draft.status in {
+            QualificationStatus.APPLYING,
+            QualificationStatus.PAUSED,
+            QualificationStatus.APPLIED,
+        }:
+            raise ValueError(
+                "A Qualification Draft cannot be discarded after application starts"
+            )
+        state = self._transfer_storage.load_transfer(draft.transfer_id)
+        if state is None:
+            raise ValueError("Qualification Transfer evidence is unavailable")
+        draft.status = QualificationStatus.DISCARDED
+        draft.updated_at = datetime.now().isoformat()
+        self._transfer_storage.save_qualification(draft_id, draft)
+        if self._local_audition is not None and hasattr(
+            self._local_audition, "invalidate_transfer"
+        ):
+            self._local_audition.invalidate_transfer(draft.transfer_id)
+        return self._qualification_view(draft, state)
+
+    def supersede_qualification(
+        self,
+        draft_id: str,
+        authorization: TransferAuthorization,
+    ) -> QualificationView:
+        """Explicitly start fresh from one discarded draft's current evidence."""
+        required = self.private_source_authorization_requirement(authorization)
+        if required:
+            raise PermissionError(required)
+        if self._transfer_storage is None:
+            raise ValueError("Qualification requires durable Transfer storage")
+        if hasattr(self._transfer_storage, "refresh"):
+            self._transfer_storage.refresh()
+        old = self._transfer_storage.load_qualification(draft_id)
+        if old is None:
+            raise ValueError(f"Unknown Qualification Draft: {draft_id}")
+        if old.status != QualificationStatus.DISCARDED:
+            raise ValueError(
+                "Only an explicitly discarded Qualification Draft can be superseded"
+            )
+        if old.superseded_by is not None:
+            existing = self._transfer_storage.load_qualification(
+                old.superseded_by
+            )
+            if existing is None:
+                raise SpotifyPlaylistReviewRequired(
+                    "Qualification supersession is incomplete; review required",
+                    draft_id=draft_id,
+                )
+            state = self._transfer_storage.load_transfer(existing.transfer_id)
+            if state is None:
+                raise ValueError("Qualification Transfer evidence is unavailable")
+            return self._qualification_view(existing, state)
+        account_id = self._spotify.account_id()
+        if old.account_id != account_id:
+            raise ValueError(
+                "A Qualification Draft cannot be superseded under another account"
+            )
+        state = self._transfer_storage.load_transfer(old.transfer_id)
+        if state is None or state.status != TransferStatus.COMPLETED:
+            raise ValueError("Qualification Transfer evidence is unavailable")
+        current_selection = self._source.consume(old.source_reference)
+        current_public = {
+            "reference": current_selection.reference,
+            "tracks": [
+                self._stored_track(track, include_location=False)
+                for track in current_selection.tracks
+            ],
+        }
+        selection_digest = self._qualification_selection_digest(current_public)
+        if selection_digest != self._qualification_selection_digest(state.selection):
+            raise SpotifyPlaylistReviewRequired(
+                "Rekordbox source selection changed; execute a new bounded Transfer",
+                draft_id=draft_id,
+            )
+        audition_digest = state.audition_selection_digest
+        if (
+            audition_digest is not None
+            and self._qualification_audition_digest(current_selection)
+            != audition_digest
+        ):
+            raise SpotifyPlaylistReviewRequired(
+                "Rekordbox audition selection changed; execute a new bounded Transfer",
+                draft_id=draft_id,
+            )
+        manifest_digest = self._qualification_manifest_digest(state)
+        if old.playlist_id is not None:
+            if self._publication_storage is None:
+                raise ValueError(
+                    "Qualification requires durable publication state"
+                )
+            if hasattr(self._publication_storage, "load"):
+                self._publication_storage.load()
+            manifest = self._publication_storage.publication_for_playlist(
+                account_id, old.playlist_id,
+            )
+            if (
+                manifest is None
+                or self._publication_digest(manifest) != manifest_digest
+            ):
+                raise SpotifyPlaylistReviewRequired(
+                    "Publication evidence changed; execute a new bounded Transfer",
+                    draft_id=draft_id,
+                )
+        playlist_head = None
+        if old.playlist_id is not None and hasattr(self._spotify, "playlist_head"):
+            playlist_head = self._retry_policy.run(
+                lambda: self._spotify.playlist_head(old.playlist_id)
+            ).snapshot_id
+        items = self._qualification_items(state, None)
+        item_ids = [
+            item.item_id for item in items
+            if old.include_all or item.attention_reasons
+        ]
+        now = datetime.now().isoformat()
+        new_id = hashlib.sha256(
+            f"qualification\0{old.transfer_id}\0{old.source_reference}\0{uuid4().hex}".encode()
+        ).hexdigest()
+        fresh = QualificationDraftState(
+            draft_id=new_id,
+            transfer_id=old.transfer_id,
+            batch_id=old.batch_id,
+            source_reference=old.source_reference,
+            account_id=account_id,
+            playlist_id=old.playlist_id,
+            playlist_head=playlist_head,
+            manifest_digest=manifest_digest,
+            selection_digest=selection_digest,
+            include_all=old.include_all,
+            item_ids=item_ids,
+            decisions={},
+            status=QualificationStatus.DRAFT,
+            created_at=now,
+            updated_at=now,
+            audition_selection_digest=audition_digest,
+            supersedes=old.draft_id,
+        )
+        self._preflight_qualification_audition(fresh, state)
+        view = self._qualification_view(fresh, state)
+        fresh.status = (
+            QualificationStatus.READY if view.complete
+            else QualificationStatus.DRAFT
+        )
+        old.superseded_by = new_id
+        old.updated_at = now
+        if not hasattr(
+            self._transfer_storage, "save_qualification_successor"
+        ):
+            raise ValueError(
+                "Qualification supersession requires transactional storage"
+            )
+        self._transfer_storage.save_qualification_successor(old, fresh)
+        return self._qualification_view(fresh, state)
+
+    def approve_qualification(
+        self,
+        draft_id: str,
+        authorization: TransferAuthorization,
+    ) -> ApprovalOutcome:
+        """Approve an applied draft as a distinct playlist-scoped operation."""
+        required = self.private_source_authorization_requirement(authorization)
+        if required:
+            raise PermissionError(required)
+        if self._transfer_storage is None:
+            raise ValueError("Qualification requires durable Transfer storage")
+        return self._approve(
+            None, qualification_draft_id=draft_id,
+        )
 
     def apply_qualification(
         self,
@@ -2850,105 +3900,204 @@ class Transfer:
             raise ValueError("Qualification requires durable Transfer storage")
         if self._publication_storage is None:
             raise ValueError("Qualification application requires publication storage")
-        draft = self._transfer_storage.load_qualification(draft_id)
-        if draft is None:
-            raise ValueError(f"Unknown Qualification Draft: {draft_id}")
-        if draft.account_id != self._spotify.account_id():
-            raise ValueError(
-                "A Qualification Draft cannot be applied under another Spotify account"
-            )
-        if draft.playlist_id is None:
-            raise ValueError(
-                "A Preview Qualification Draft requires a Provisional Playlist before apply"
-            )
-        if draft.status == QualificationStatus.APPLIED:
-            applied_count = len(
-                (draft.applied_manifest or {}).get("managed_items", ())
-            )
-            return QualificationApplyOutcome(
-                draft_id, draft.playlist_id, QualificationStatus.APPLIED,
-                applied_count, ("approve",),
-            )
-        state = self._transfer_storage.load_transfer(draft.transfer_id)
-        if state is None:
-            raise ValueError("Qualification Transfer evidence is unavailable")
-        view = self._qualification_view(draft, state)
-        if not view.complete:
-            raise ValueError(
-                "Qualification Draft has pending or deferred items"
-            )
-        unresolved_conflicts = []
-        for item in view.items:
-            if not ({"match_collision", "approval_conflict"} & set(
-                item.attention_reasons
-            )):
-                continue
-            decision = draft.decisions.get(item.item_id, {})
-            choice = decision.get("decision")
-            resolved = choice in {
-                QualificationDecision.CORRECTION.value,
-                QualificationDecision.REJECT_PROPOSAL.value,
-            } or (
-                choice == QualificationDecision.DEFERRED.value
-                and bool(decision.get("excluded"))
-            )
-            if not resolved:
-                unresolved_conflicts.append(item.item_id)
-        if unresolved_conflicts:
-            draft.status = QualificationStatus.REVIEW_REQUIRED
-            self._transfer_storage.save_qualification(draft_id, draft)
-            raise SpotifyPlaylistReviewRequired(
-                "Qualification conflict remains unresolved"
-            )
-        current_selection = self._source.consume(draft.source_reference)
-        selection = {
-            "reference": current_selection.reference,
-            "tracks": [
-                self._stored_track(track, include_location=False)
-                for track in current_selection.tracks
-            ],
-        }
-        if self._qualification_selection_digest(selection) != draft.selection_digest:
-            draft.status = QualificationStatus.REVIEW_REQUIRED
-            self._transfer_storage.save_qualification(draft_id, draft)
-            raise SpotifyPlaylistReviewRequired(
-                "Rekordbox source selection changed; review required"
-            )
-        current_manifest = self._publication_storage.publication_for_playlist(
-            draft.account_id, draft.playlist_id,
-        )
-        if current_manifest is None:
-            raise SpotifyPlaylistReviewRequired(
-                "The linked Provisional Playlist manifest is unavailable"
-            )
-        if (
-            self._publication_digest(current_manifest)
-            != draft.manifest_digest
-        ):
-            draft.status = QualificationStatus.REVIEW_REQUIRED
-            self._transfer_storage.save_qualification(draft_id, draft)
-            raise SpotifyPlaylistReviewRequired(
-                "Publication manifest changed; review required"
-            )
         account_id = self._spotify.account_id()
         with self._publishing_guards.acquire(account_id):
+            if hasattr(self._transfer_storage, "refresh"):
+                self._transfer_storage.refresh()
+            draft = self._transfer_storage.load_qualification(draft_id)
+            if draft is None:
+                raise ValueError(f"Unknown Qualification Draft: {draft_id}")
+            if draft.account_id != account_id:
+                raise ValueError(
+                    "A Qualification Draft cannot be applied under another "
+                    "Spotify account"
+                )
+            if draft.status == QualificationStatus.DISCARDED:
+                raise ValueError("A discarded Qualification Draft cannot be applied")
+            if draft.status == QualificationStatus.APPLIED:
+                assert draft.playlist_id is not None
+                return QualificationApplyOutcome(
+                    draft_id, draft.playlist_id, QualificationStatus.APPLIED,
+                    len((draft.applied_manifest or {}).get("managed_items", ())),
+                    ("approve",),
+                )
+            if draft.playlist_id is None:
+                raise SpotifyPlaylistReviewRequired(
+                    "Preview Qualification Draft must be linked to a distinct "
+                    "Provisional Mirror before apply",
+                    draft_id=draft_id,
+                )
+            if hasattr(self._publication_storage, "load"):
+                self._publication_storage.load()
+            if hasattr(self._knowledge, "refresh"):
+                self._knowledge.refresh()
+            state = self._transfer_storage.load_transfer(draft.transfer_id)
+            if state is None:
+                raise ValueError("Qualification Transfer evidence is unavailable")
+            view = self._qualification_view(draft, state)
+            if not view.complete:
+                raise ValueError(
+                    "Qualification Draft has pending or deferred items"
+                )
+            unresolved_approval_conflicts = []
+            for item in view.items:
+                if "approval_conflict" not in item.attention_reasons:
+                    continue
+                decision = draft.decisions.get(item.item_id, {})
+                choice = decision.get("decision")
+                resolved = choice in {
+                    QualificationDecision.CORRECTION.value,
+                    QualificationDecision.REJECT_PROPOSAL.value,
+                } or (
+                    choice == QualificationDecision.DEFERRED.value
+                    and bool(decision.get("excluded"))
+                )
+                if not resolved:
+                    unresolved_approval_conflicts.append(item.item_id)
+            if unresolved_approval_conflicts:
+                draft.status = QualificationStatus.REVIEW_REQUIRED
+                draft.review_reason = "resolvable_conflict"
+                self._transfer_storage.save_qualification(draft_id, draft)
+                raise SpotifyPlaylistReviewRequired(
+                    "Qualification conflict remains unresolved",
+                    draft_id=draft_id,
+                )
+
+            try:
+                current_selection = self._source.consume(
+                    draft.source_reference
+                )
+            except Exception as exc:
+                draft.status = QualificationStatus.REVIEW_REQUIRED
+                draft.review_reason = "evidence_changed"
+                draft.updated_at = datetime.now().isoformat()
+                self._transfer_storage.save_qualification(draft_id, draft)
+                raise SpotifyPlaylistReviewRequired(
+                    "Rekordbox source evidence is unavailable; review required",
+                    draft_id=draft_id,
+                ) from exc
+            selection = {
+                "reference": current_selection.reference,
+                "tracks": [
+                    self._stored_track(track, include_location=False)
+                    for track in current_selection.tracks
+                ],
+            }
+            if (
+                self._qualification_selection_digest(selection)
+                != draft.selection_digest
+                or (
+                    draft.audition_selection_digest is not None
+                    and (
+                        state.audition_selection_digest
+                        != draft.audition_selection_digest
+                        or self._qualification_audition_digest(current_selection)
+                        != draft.audition_selection_digest
+                    )
+                )
+            ):
+                draft.status = QualificationStatus.REVIEW_REQUIRED
+                draft.review_reason = "evidence_changed"
+                self._transfer_storage.save_qualification(draft_id, draft)
+                raise SpotifyPlaylistReviewRequired(
+                    "Rekordbox source selection changed; review required",
+                    draft_id=draft_id,
+                )
+
+            intended_manifest = (
+                self._publication_from_stored(draft.applied_manifest)
+                if draft.applied_manifest is not None else None
+            )
+            current_manifest = (
+                self._publication_storage.publication_for_playlist(
+                    account_id, draft.playlist_id,
+                )
+                if draft.playlist_id is not None else None
+            )
             expected_head = (
                 draft.mutation_snapshots[-1]
                 if draft.mutation_snapshots else draft.playlist_head
             )
-            if expected_head is not None and hasattr(self._spotify, "playlist_head"):
+            if (
+                expected_head is not None
+                and hasattr(self._spotify, "playlist_head")
+            ):
                 current_head = self._retry_policy.run(
                     lambda: self._spotify.playlist_head(draft.playlist_id)
                 )
                 if current_head.snapshot_id != expected_head:
                     draft.status = QualificationStatus.REVIEW_REQUIRED
+                    draft.review_reason = "evidence_changed"
                     self._transfer_storage.save_qualification(draft_id, draft)
                     raise SpotifyPlaylistChanged(
                         "Spotify playlist changed before Qualification apply"
                     )
-            updated_manifest, desired_uris = self._qualification_application(
-                draft, state, current_manifest,
+            if current_manifest is not None:
+                current_digest = self._publication_digest(current_manifest)
+                if current_digest != draft.manifest_digest:
+                    if (
+                        intended_manifest is not None
+                        and draft.status in {
+                            QualificationStatus.APPLYING,
+                            QualificationStatus.PAUSED,
+                        }
+                        and current_digest
+                        == self._publication_digest(intended_manifest)
+                    ):
+                        state.publication_manifest = self._stored_publication(
+                            intended_manifest
+                        )
+                        state.status = TransferStatus.COMPLETED
+                        self._save_transfer(draft.transfer_id, state)
+                        draft.manifest_digest = current_digest
+                        draft.status = QualificationStatus.APPLIED
+                        if draft.mutation_snapshots:
+                            draft.playlist_head = draft.mutation_snapshots[-1]
+                        self._transfer_storage.save_qualification(draft_id, draft)
+                        return QualificationApplyOutcome(
+                            draft_id, draft.playlist_id,
+                            QualificationStatus.APPLIED,
+                            len(intended_manifest.managed_items), ("approve",),
+                        )
+                    draft.status = QualificationStatus.REVIEW_REQUIRED
+                    draft.review_reason = "evidence_changed"
+                    self._transfer_storage.save_qualification(draft_id, draft)
+                    raise SpotifyPlaylistReviewRequired(
+                        "Publication manifest changed; review required",
+                        draft_id=draft_id,
+                    )
+            else:
+                draft.status = QualificationStatus.REVIEW_REQUIRED
+                draft.review_reason = "evidence_changed"
+                self._transfer_storage.save_qualification(draft_id, draft)
+                raise SpotifyPlaylistReviewRequired(
+                    "The linked Provisional Playlist manifest is unavailable",
+                    draft_id=draft_id,
+                )
+            if intended_manifest is not None and draft.applied_uris:
+                updated_manifest = intended_manifest
+                desired_uris = list(draft.applied_uris)
+            else:
+                updated_manifest, desired_uris = self._qualification_application(
+                    draft, state, current_manifest,
+                )
+            conflict_checker = getattr(
+                self._knowledge, "approval_conflict", None,
             )
+            if (
+                conflict_checker is not None
+                and any(
+                    item.match_type == "correction" and conflict_checker(item)
+                    for item in updated_manifest.managed_items
+                )
+            ):
+                draft.status = QualificationStatus.REVIEW_REQUIRED
+                draft.review_reason = "resolvable_conflict"
+                self._transfer_storage.save_qualification(draft_id, draft)
+                raise SpotifyPlaylistReviewRequired(
+                    "Qualification Correction conflicts with an Approved Match",
+                    draft_id=draft_id,
+                )
             identities_by_uri: dict[str, set[tuple[str, str, int]]] = {}
             for item in updated_manifest.managed_items:
                 identities_by_uri.setdefault(item.spotify_uri, set()).add((
@@ -2961,25 +4110,26 @@ class Transfer:
                 for identities in identities_by_uri.values()
             ):
                 draft.status = QualificationStatus.REVIEW_REQUIRED
+                draft.review_reason = "resolvable_conflict"
                 self._transfer_storage.save_qualification(draft_id, draft)
                 raise SpotifyPlaylistReviewRequired(
-                    "Qualification conflict remains unresolved"
+                    "Qualification conflict remains unresolved",
+                    draft_id=draft_id,
                 )
-            preservation_manifest = current_manifest
-            if draft.completed_chunks and draft.applied_manifest is not None:
-                preservation_manifest = self._publication_from_stored(
-                    draft.applied_manifest
+            if not draft.applied_uris:
+                preservation_manifest = current_manifest
+                if draft.completed_chunks and intended_manifest is not None:
+                    preservation_manifest = intended_manifest
+                desired_uris = self._preserve_unmanaged_playlist_items(
+                    draft.playlist_id, preservation_manifest, desired_uris,
                 )
-            desired_uris = self._preserve_unmanaged_playlist_items(
-                draft.playlist_id, preservation_manifest, desired_uris,
-            )
             draft.applied_manifest = self._stored_publication(updated_manifest)
+            draft.applied_uris = list(desired_uris)
             draft.status = QualificationStatus.APPLYING
             draft.updated_at = datetime.now().isoformat()
             self._transfer_storage.save_qualification(draft_id, draft)
-            paused = self._apply_qualification_chunks(
-                draft, desired_uris,
-            )
+
+            paused = self._apply_qualification_chunks(draft, desired_uris)
             if paused:
                 return QualificationApplyOutcome(
                     draft_id, draft.playlist_id, QualificationStatus.PAUSED,
@@ -2987,7 +4137,11 @@ class Transfer:
                 )
             self._publication_storage.retain_publication(updated_manifest)
             state.publication_manifest = self._stored_publication(updated_manifest)
+            state.spotify_playlist_id = draft.playlist_id
+            state.spotify_playlist_name = updated_manifest.spotify_playlist_name
+            state.status = TransferStatus.COMPLETED
             self._save_transfer(draft.transfer_id, state)
+            draft.manifest_digest = self._publication_digest(updated_manifest)
             draft.status = QualificationStatus.APPLIED
             if draft.mutation_snapshots:
                 draft.playlist_head = draft.mutation_snapshots[-1]
@@ -3066,11 +4220,34 @@ class Transfer:
                         match_type="correction",
                         score_reasons=("explicit Qualification Correction",),
                         authoritative=False,
+                        availability_status=str(
+                            decision.get("availability_status", "unknown")
+                        ),
+                        availability_reason=decision.get(
+                            "availability_reason"
+                        ),
+                        availability_checked_at=decision.get(
+                            "availability_checked_at"
+                        ),
+                        availability_source=decision.get(
+                            "availability_source"
+                        ),
+                        qualification_outcome=choice.value,
                     )
                 elif choice == QualificationDecision.REJECT_PROPOSAL:
                     rejected = True
+                    resolved = replace(
+                        item, qualification_outcome=choice.value,
+                    )
                 elif choice == QualificationDecision.DEFERRED:
                     excluded = bool(decision.get("excluded"))
+                    resolved = replace(
+                        item, qualification_outcome=choice.value,
+                    )
+                else:
+                    resolved = replace(
+                        item, qualification_outcome=choice.value,
+                    )
             if resolved.spotify_uri and not rejected and not excluded:
                 desired_items.append(resolved)
             was_review_item = (
@@ -3078,7 +4255,11 @@ class Transfer:
             ) in original_review_ids
             if excluded:
                 continue
-            if was_review_item or resolved.match_type == "correction":
+            if (
+                was_review_item
+                or decision is not None
+                or resolved.match_type == "correction"
+            ):
                 review_items.append(resolved)
         updated = replace(
             manifest,
@@ -3097,9 +4278,16 @@ class Transfer:
             ordered = self._retry_policy.run(
                 lambda: self._spotify.ordered_playlist_items(playlist_id)
             )
-            if any(item.kind != SpotifyItemKind.TRACK for item in ordered.items):
+            if any(
+                item.kind != SpotifyItemKind.TRACK
+                or item.is_playable is False
+                or item.restrictions is not None
+                or item.linked_from_uri is not None
+                for item in ordered.items
+            ):
                 raise SpotifyPlaylistReviewRequired(
-                    "Spotify playlist contains unsupported items; review required"
+                    "Spotify playlist contains unavailable, unsupported, "
+                    "restricted, or relinked items; review required"
                 )
             current_uris = [item.uri for item in ordered.items if item.uri]
         else:
@@ -3192,30 +4380,160 @@ class Transfer:
         self, playlist_id: str, *, corrections: str | Path | None = None,
     ) -> ApprovalOutcome:
         """Review exactly one retained Provisional Playlist against Spotify."""
+        return self._approve(playlist_id, corrections=corrections)
+
+    def _approve(
+        self,
+        playlist_id: str | None,
+        *,
+        corrections: str | Path | None = None,
+        qualification_draft_id: str | None = None,
+    ) -> ApprovalOutcome:
+        """Perform Approval under one account guard and evidence snapshot."""
         if self._publication_storage is None:
             raise ValueError("Approval requires publication storage")
         account_id = self._spotify.account_id()
-        manifest = self._publication_storage.publication_for_playlist(
-            account_id, playlist_id,
-        )
-        if manifest is None:
-            raise ValueError(
-                f"No Provisional Playlist {playlist_id} belongs to this Spotify account"
-            )
-        if self._transfer_storage is not None and hasattr(
-            self._transfer_storage, "qualifications_for_playlist"
-        ):
-            unapplied = [
-                draft for draft in self._transfer_storage.qualifications_for_playlist(
-                    account_id, playlist_id,
-                )
-                if draft.status != QualificationStatus.APPLIED
-            ]
-            if unapplied:
-                raise SpotifyPlaylistReviewRequired(
-                    "Qualification Draft must be completed and applied before Approval"
-                )
         with self._publishing_guards.acquire(account_id):
+            if hasattr(self._publication_storage, "load"):
+                self._publication_storage.load()
+            if hasattr(self._knowledge, "refresh"):
+                self._knowledge.refresh()
+            if self._transfer_storage is not None and hasattr(
+                self._transfer_storage, "refresh"
+            ):
+                self._transfer_storage.refresh()
+            qualification_draft = None
+            if qualification_draft_id is not None:
+                if self._transfer_storage is None:
+                    raise ValueError(
+                        "Qualification Approval requires durable Transfer storage"
+                    )
+                qualification_draft = (
+                    self._transfer_storage.load_qualification(
+                        qualification_draft_id
+                    )
+                )
+                if (
+                    qualification_draft is None
+                    or qualification_draft.status
+                    != QualificationStatus.APPLIED
+                ):
+                    raise SpotifyPlaylistReviewRequired(
+                        "Qualification Draft must be applied before Approval"
+                    )
+                if qualification_draft.account_id != account_id:
+                    raise ValueError(
+                        "A Qualification Draft cannot be approved under "
+                        "another account"
+                    )
+                if qualification_draft.playlist_id is None:
+                    raise ValueError(
+                        "Applied Qualification playlist is unavailable"
+                    )
+                playlist_id = qualification_draft.playlist_id
+            if playlist_id is None:
+                raise ValueError("Approval requires a Provisional Playlist")
+            manifest = self._publication_storage.publication_for_playlist(
+                account_id, playlist_id,
+            )
+            if manifest is None:
+                raise ValueError(
+                    "No Provisional Playlist belongs to this Spotify account"
+                )
+            if self._transfer_storage is not None and hasattr(
+                self._transfer_storage, "qualifications_for_playlist"
+            ):
+                playlist_drafts = (
+                    self._transfer_storage.qualifications_for_playlist(
+                        account_id, playlist_id,
+                    )
+                )
+                applied_drafts = [
+                    draft for draft in playlist_drafts
+                    if draft.status == QualificationStatus.APPLIED
+                ]
+                unapplied = []
+                for draft in playlist_drafts:
+                    if draft.status == QualificationStatus.APPLIED:
+                        continue
+                    if (
+                        draft.status == QualificationStatus.DISCARDED
+                        and any(
+                            applied.updated_at >= draft.updated_at
+                            for applied in applied_drafts
+                        )
+                    ):
+                        continue
+                    unapplied.append(draft)
+                if unapplied:
+                    raise SpotifyPlaylistReviewRequired(
+                        "Qualification Draft must be completed and applied "
+                        "before Approval"
+                    )
+                if applied_drafts:
+                    applicable = max(
+                        applied_drafts,
+                        key=lambda draft: (draft.updated_at, draft.created_at),
+                    )
+                    if qualification_draft is None:
+                        raise SpotifyPlaylistReviewRequired(
+                            "Qualification Approval requires its applied Draft "
+                            "and explicit private-source authorization"
+                        )
+                    if applicable.draft_id != qualification_draft.draft_id:
+                        raise SpotifyPlaylistReviewRequired(
+                            "A newer applied Qualification Draft must be "
+                            "approved"
+                        )
+                    applied_manifest = (
+                        self._publication_from_stored(
+                            applicable.applied_manifest
+                        )
+                        if applicable.applied_manifest is not None else None
+                    )
+                    current_digest = self._publication_digest(manifest)
+                    if (
+                        applied_manifest is None
+                        or applicable.manifest_digest != current_digest
+                        or self._publication_digest(applied_manifest)
+                        != current_digest
+                    ):
+                        raise SpotifyPlaylistReviewRequired(
+                            "Publication manifest changed after Qualification; "
+                            "review required"
+                        )
+                    try:
+                        current_selection = self._source.consume(
+                            applicable.source_reference
+                        )
+                    except Exception as exc:
+                        raise SpotifyPlaylistReviewRequired(
+                            "Rekordbox source evidence is unavailable after "
+                            "Qualification; review required",
+                            draft_id=applicable.draft_id,
+                        ) from exc
+                    public_selection = {
+                        "reference": current_selection.reference,
+                        "tracks": [
+                            self._stored_track(track, include_location=False)
+                            for track in current_selection.tracks
+                        ],
+                    }
+                    if (
+                        self._qualification_selection_digest(public_selection)
+                        != applicable.selection_digest
+                        or (
+                            applicable.audition_selection_digest is not None
+                            and self._qualification_audition_digest(
+                                current_selection
+                            ) != applicable.audition_selection_digest
+                        )
+                    ):
+                        raise SpotifyPlaylistReviewRequired(
+                            "Rekordbox source selection changed after "
+                            "Qualification; review required",
+                            draft_id=applicable.draft_id,
+                        )
             corrected_items = self._read_corrections(corrections, manifest)
             if all(hasattr(self._spotify, method) for method in (
                 "playlist_head", "ordered_playlist_items",
@@ -3230,6 +4548,16 @@ class Transfer:
                     after = self._retry_policy.run(
                         lambda: self._spotify.playlist_head(playlist_id)
                     )
+                    if (
+                        qualification_draft is not None
+                        and qualification_draft.playlist_head is not None
+                        and before.snapshot_id
+                        != qualification_draft.playlist_head
+                    ):
+                        raise SpotifyPlaylistChanged(
+                            "Spotify playlist changed after Qualification; "
+                            "re-review required"
+                        )
                     if before.snapshot_id != after.snapshot_id:
                         raise SpotifyPlaylistChanged(
                             "Spotify playlist changed during Approval; "
@@ -3278,6 +4606,12 @@ class Transfer:
                         playlist_id, manifest, current_uris, corrected_items,
                     )
                 remaining = Counter(current_uris)
+                present_counts = Counter(current_uris)
+                expected_managed_counts = Counter(
+                    item.spotify_uri
+                    for item in (manifest.managed_items or manifest.items)
+                    if item.spotify_uri
+                )
                 approved: list[PublicationItem] = []
                 rejected: list[PublicationItem] = []
                 reviewed_items = tuple(
@@ -3303,11 +4637,17 @@ class Transfer:
                     for item in manifest.items
                     if item.spotify_uri in original_collision_uris
                     and item.source_track_id not in corrected_items
+                    and item.qualification_outcome is None
                 }
                 proposed_identities: dict[
                     str, set[tuple[str, str, int]]
                 ] = {}
-                for item in reviewed_items:
+                collision_candidates = tuple(
+                    item for item in reviewed_items
+                    if item.qualification_outcome
+                    != QualificationDecision.REJECT_PROPOSAL.value
+                )
+                for item in collision_candidates:
                     if item.spotify_uri:
                         proposed_identities.setdefault(item.spotify_uri, set()).add((
                             item.source_artist.casefold(),
@@ -3321,6 +4661,17 @@ class Transfer:
                 collisions: list[PublicationItem] = []
                 for item in reviewed_items:
                     if not item.spotify_uri:
+                        continue
+                    if item.qualification_outcome == (
+                        QualificationDecision.REJECT_PROPOSAL.value
+                    ):
+                        if (
+                            present_counts[item.spotify_uri]
+                            > expected_managed_counts[item.spotify_uri]
+                        ):
+                            collisions.append(item)
+                            continue
+                        rejected.append(item)
                         continue
                     if (
                         (item.occurrence_id or item.source_track_id)
@@ -3353,6 +4704,23 @@ class Transfer:
                 )
                 conflicts: list[ApprovalConflict] = []
                 for item in outcome.approved:
+                    local_conflict_checker = getattr(
+                        self._knowledge,
+                        "local_audio_approval_conflict",
+                        None,
+                    )
+                    local_preflight_conflict = (
+                        local_conflict_checker(item, account_id)
+                        if local_conflict_checker is not None else None
+                    )
+                    if local_preflight_conflict is not None:
+                        recorded_conflict = self._knowledge.approve_local_audio(
+                            item, account_id,
+                        )
+                        conflicts.append(
+                            recorded_conflict or local_preflight_conflict
+                        )
+                        continue
                     if (
                         item.source_track_id in corrected_items
                         or item.match_type == "correction"
@@ -3362,7 +4730,17 @@ class Transfer:
                         conflict = self._knowledge.approve(item)
                     if conflict is not None:
                         conflicts.append(conflict)
-                    if item.local_evidence_id is not None:
+                    if (
+                        conflict is None
+                        and item.match_type == "correction"
+                        and item.local_evidence_id is None
+                    ):
+                        revoke_local_audio = getattr(
+                            self._knowledge, "revoke_local_audio", None,
+                        )
+                        if revoke_local_audio is not None:
+                            revoke_local_audio(item, account_id)
+                    if conflict is None and item.local_evidence_id is not None:
                         local_conflict = self._knowledge.approve_local_audio(
                             item, account_id,
                         )
@@ -3370,6 +4748,11 @@ class Transfer:
                             conflicts.append(local_conflict)
                 for item in outcome.rejected:
                     self._knowledge.reject(item)
+                    revoke_local_audio = getattr(
+                        self._knowledge, "revoke_local_audio", None,
+                    )
+                    if revoke_local_audio is not None:
+                        revoke_local_audio(item, account_id)
                 if conflicts:
                     conflict_identities = {
                         (item.source_artist, item.source_title, item.source_duration)
@@ -3411,6 +4794,23 @@ class Transfer:
                         )
                     )
             self._publication_storage.retain_approval(outcome)
+            if (
+                outcome.status == ApprovalStatus.ABANDONED
+                and qualification_draft is not None
+            ):
+                qualification_draft.status = QualificationStatus.REVIEW_REQUIRED
+                qualification_draft.review_reason = "playlist_abandoned"
+                qualification_draft.updated_at = datetime.now().isoformat()
+                assert self._transfer_storage is not None
+                self._transfer_storage.save_qualification(
+                    qualification_draft.draft_id, qualification_draft,
+                )
+                if self._local_audition is not None and hasattr(
+                    self._local_audition, "invalidate_transfer"
+                ):
+                    self._local_audition.invalidate_transfer(
+                        qualification_draft.transfer_id
+                    )
             return outcome
 
     @staticmethod
@@ -3477,13 +4877,32 @@ class Transfer:
                     raise ValueError(
                         f"Correction row {row_number} did not resolve to its Spotify track"
                     )
+                if (
+                    spotify_track.get("is_playable") is False
+                    or spotify_track.get("is_local") is True
+                    or bool(spotify_track.get("restrictions"))
+                    or spotify_track.get("linked_from") is not None
+                    or spotify_track.get("linked_from_uri") is not None
+                ):
+                    raise ValueError(
+                        f"Correction row {row_number} is not an available Spotify track"
+                    )
                 corrected[source_track_id] = replace(
                     original,
                     spotify_uri=spotify_uri,
                     spotify_name=spotify_track["name"],
                     spotify_artist=spotify_track["artist"],
+                    spotify_release=spotify_track.get("album", ""),
+                    spotify_duration=int(
+                        spotify_track.get("duration_ms", 0)
+                    ) // 1000,
                     score=100.0,
                     match_type="correction",
+                    score_reasons=("explicit playlist Correction",),
+                    authoritative=False,
+                    **self._availability_facts(
+                        spotify_track, source="spotify_track_lookup",
+                    ),
                 )
         return corrected
 
@@ -3552,7 +4971,12 @@ class Transfer:
         with self._publishing_guards.acquire(account_id):
             return self._execute(request)
 
-    def _execute(self, request: TransferRequest) -> SyncReport:
+    def _execute(
+        self,
+        request: TransferRequest,
+        *,
+        expected_selection_token: str | None = None,
+    ) -> SyncReport:
         """Execute one Transfer and return its structured outcome.
 
         Beatport publication creates a distinct Provisional Snapshot after the
@@ -3672,6 +5096,18 @@ class Transfer:
                     prepared_state.outcome = str(exc)
                     self._save_transfer(transfer_id, prepared_state)
                 raise
+            if expected_selection_token:
+                actual_selection_token = self._selection_token(
+                    selection,
+                    include_locations=(
+                        request.local_audio_identity
+                        or request.local_audio_audition
+                    ),
+                )
+                if actual_selection_token != expected_selection_token:
+                    raise SpotifyPlaylistReviewRequired(
+                        "Rekordbox Batch selection changed before execution"
+                    )
             relinked_mirror = None
             if request.mirror_disposition == MirrorDisposition.RELINK:
                 if request.mode != TransferMode.MIRROR or not request.mirror_playlist_id:
@@ -3714,12 +5150,19 @@ class Transfer:
                 unmatched=[],
                 publication_items=[],
                 alternatives=[],
+                audition_selection_digest=(
+                    self._selection_token(
+                        selection, include_locations=True,
+                    )
+                    if request.local_audio_audition else None
+                ),
                 spotify_playlist_id=(
                     relinked_mirror.spotify_playlist_id if relinked_mirror else None
                 ),
                 spotify_playlist_name=(
                     relinked_mirror.spotify_playlist_name if relinked_mirror else None
                 ),
+                revision=(prepared_state.revision if prepared_state is not None else 0),
             )
             self._save_transfer(transfer_id, state)
         else:
@@ -3876,8 +5319,14 @@ class Transfer:
                         playlist.local_audio_unavailable += 1
                 if result is not None:
                     playlist.cache_hits += 1
-                    if result.get("authoritative") and not self._approved_available(
-                        result["uri"]
+                    if result.get("authoritative"):
+                        result = {
+                            **result,
+                            **self._approved_availability(result["uri"]),
+                        }
+                    if (
+                        result.get("authoritative")
+                        and result.get("availability_status") == "unavailable"
                     ):
                         playlist.unavailable_approved.append(
                             UnavailableApprovedMatch(
@@ -3909,6 +5358,9 @@ class Transfer:
                             source_duration=track.duration,
                             authoritative=True,
                             local_evidence_id=local_evidence_id,
+                            **self._availability_facts(
+                                result, source="spotify_track_lookup",
+                            ),
                         ))
                         result = None
                 elif self._knowledge.should_retry(
@@ -4003,6 +5455,9 @@ class Transfer:
                             source_duration=track.duration,
                             authoritative=bool(result.get("authoritative")),
                             local_evidence_id=local_evidence_id,
+                            **self._availability_facts(
+                                result, source="spotify_or_retained_result",
+                            ),
                         ))
 
                 state.next_track_index = index + 1
@@ -4513,13 +5968,20 @@ class Transfer:
             item.occurrence_id == occurrence_id for item in items
         )
 
-    def _approved_available(self, spotify_uri: str) -> bool:
+    def _approved_availability(self, spotify_uri: str) -> dict:
         try:
             track = self._retry_policy.run(
                 lambda: self._spotify.spotify_track(spotify_uri)
             )
         except spotipy.SpotifyException as exc:
             if exc.http_status == 404:
-                return False
+                return {
+                    "availability_status": "unavailable",
+                    "availability_reason": "spotify_unavailable",
+                    "availability_checked_at": datetime.now().isoformat(),
+                    "availability_source": "spotify_track_lookup",
+                }
             raise
-        return track.get("is_playable", True) is not False
+        return self._availability_facts(
+            track, source="spotify_track_lookup",
+        )

--- a/djsupport/transfer.py
+++ b/djsupport/transfer.py
@@ -33,6 +33,7 @@ else:
     import fcntl
 
 from djsupport.cache import MatchCache
+from djsupport.local_audition import LocalAuditionResult
 from djsupport.matcher import match_track_with_alternatives
 from djsupport.rekordbox import Track
 from djsupport.report import (
@@ -57,7 +58,7 @@ from djsupport.spotify import (
 
 
 PUBLICATION_MANIFEST_VERSION = 5
-TRANSFER_STATE_VERSION = 3
+TRANSFER_STATE_VERSION = 4
 EXPENSIVE_BATCH_LOOKUP_THRESHOLD = 100
 SPOTIFY_TRACK_URI = re.compile(r"^spotify:track:([A-Za-z0-9]{22})$")
 SPOTIFY_TRACK_URL = re.compile(
@@ -110,6 +111,7 @@ class TransferRequest:
     mirror_playlist_id: str | None = None
     retain_matching_knowledge: bool = True
     local_audio_identity: bool = False
+    local_audio_audition: bool = False
 
 
 @dataclass(frozen=True)
@@ -151,6 +153,7 @@ class BatchPlanRequest:
     retry_days: int = 7
     playlist_prefix: str | None = "djsupport"
     local_audio_identity: bool = False
+    local_audio_audition: bool = False
 
 
 @dataclass(frozen=True)
@@ -186,6 +189,7 @@ class BatchPlan:
     retry_days: int = 7
     playlist_prefix: str | None = "djsupport"
     local_audio_identity: bool = False
+    local_audio_audition: bool = False
 
     @property
     def ready(self) -> bool:
@@ -238,6 +242,7 @@ class BatchPlan:
             "retry_days": self.retry_days,
             "playlist_prefix": self.playlist_prefix,
             "local_audio_identity": self.local_audio_identity,
+            "local_audio_audition": self.local_audio_audition,
         }
         canonical = json.dumps(material, sort_keys=True, separators=(",", ":"))
         return hashlib.sha256(canonical.encode()).hexdigest()
@@ -262,6 +267,7 @@ class TransferProgress:
     error: str | None = None
     retain_matching_knowledge: bool = True
     local_audio_identity: bool = False
+    local_audio_audition: bool = False
 
 
 class BatchPhase(str, Enum):
@@ -318,6 +324,7 @@ class BatchState:
     retry_days: int = 7
     playlist_prefix: str | None = "djsupport"
     local_audio_identity: bool = False
+    local_audio_audition: bool = False
     plan_id: str = ""
 
     @classmethod
@@ -340,6 +347,148 @@ class BatchProgress:
     completed: int
     failed: int
     pending: int
+
+
+class QualificationDecision(str, Enum):
+    """One non-authoritative human outcome in a Qualification Draft."""
+
+    KEEP_PROPOSAL = "keep_proposal"
+    CORRECTION = "correction"
+    DEFERRED = "deferred"
+    REJECT_PROPOSAL = "reject_proposal"
+
+
+class QualificationStatus(str, Enum):
+    DRAFT = "draft"
+    READY = "ready"
+    APPLYING = "applying"
+    PAUSED = "paused"
+    APPLIED = "applied"
+    REVIEW_REQUIRED = "review_required"
+
+
+@dataclass(frozen=True)
+class QualificationRequest:
+    """Select one completed Rekordbox playlist Transfer for qualification."""
+
+    transfer_id: str
+    playlist_reference: str | None = None
+    include_all: bool = False
+
+
+@dataclass
+class QualificationDraftState:
+    """Private, durable, non-authoritative Qualification working state."""
+
+    draft_id: str
+    transfer_id: str
+    batch_id: str | None
+    source_reference: str
+    account_id: str
+    playlist_id: str | None
+    playlist_head: str | None
+    manifest_digest: str
+    selection_digest: str
+    include_all: bool
+    item_ids: list[str]
+    decisions: dict[str, dict]
+    status: QualificationStatus
+    created_at: str
+    updated_at: str
+    mutation_snapshots: list[str] = field(default_factory=list)
+    completed_chunks: list[str] = field(default_factory=list)
+    applied_manifest: dict | None = None
+    audition_statuses: dict[str, dict] = field(default_factory=dict)
+
+    @classmethod
+    def from_dict(cls, value: dict) -> QualificationDraftState:
+        return cls(**{
+            "mutation_snapshots": [],
+            "completed_chunks": [],
+            "applied_manifest": None,
+            "audition_statuses": {},
+            **value,
+            "status": QualificationStatus(
+                value.get("status", QualificationStatus.DRAFT.value)
+            ),
+        })
+
+
+@dataclass(frozen=True)
+class QualificationItem:
+    """Privacy-bounded comparison facts for one selected source occurrence."""
+
+    item_id: str
+    source_index: int
+    source_track_id: str
+    source_artist: str
+    source_title: str
+    source_release: str = ""
+    source_label: str = ""
+    source_version: str = ""
+    source_duration: int = 0
+    spotify_uri: str = ""
+    spotify_name: str = ""
+    spotify_artist: str = ""
+    spotify_release: str = ""
+    spotify_duration: int = 0
+    score: float = 0.0
+    match_type: str = "unmatched"
+    score_reasons: tuple[str, ...] = ()
+    authority_status: str = "proposal"
+    attention_reasons: tuple[str, ...] = ()
+    audition_status: str = "not_requested"
+    audition_reason: str | None = None
+    decision: QualificationDecision | None = None
+    correction_uri: str | None = None
+    deferred_reason: str | None = None
+    excluded: bool = False
+
+
+@dataclass(frozen=True)
+class QualificationView:
+    draft_id: str
+    transfer_id: str
+    source_reference: str
+    spotify_playlist_id: str | None
+    status: QualificationStatus
+    items: tuple[QualificationItem, ...]
+    include_all: bool = False
+
+    @property
+    def pending(self) -> int:
+        return sum(item.decision is None for item in self.items)
+
+    @property
+    def deferred(self) -> int:
+        return sum(
+            item.decision == QualificationDecision.DEFERRED and not item.excluded
+            for item in self.items
+        )
+
+    @property
+    def complete(self) -> bool:
+        return self.pending == 0 and self.deferred == 0
+
+    @property
+    def current_item(self) -> QualificationItem | None:
+        return next((
+            item for item in self.items
+            if item.decision is None
+            or (
+                item.decision == QualificationDecision.DEFERRED
+                and not item.excluded
+            )
+        ), self.items[0] if self.items else None)
+
+
+@dataclass(frozen=True)
+class QualificationApplyOutcome:
+    draft_id: str
+    spotify_playlist_id: str
+    status: QualificationStatus
+    applied_items: int
+    next_actions: tuple[str, ...]
 
 
 class ApprovalStatus(str, Enum):
@@ -545,9 +694,16 @@ class PublicationItem:
     source_name: str
     source_artist: str
     source_title: str
+    occurrence_id: str = ""
+    source_index: int = 0
+    source_release: str = ""
+    source_label: str = ""
+    source_version: str = ""
     spotify_uri: str = ""
     spotify_name: str = ""
     spotify_artist: str = ""
+    spotify_release: str = ""
+    spotify_duration: int = 0
     score: float = 0.0
     match_type: str = "unmatched"
     score_reasons: tuple[str, ...] = ()
@@ -860,6 +1016,18 @@ class TransferStorage(Protocol):
 
     def save_batch(self, transfer_id: str, state: BatchState) -> None: ...
 
+    def load_qualification(
+        self, draft_id: str,
+    ) -> QualificationDraftState | None: ...
+
+    def save_qualification(
+        self, draft_id: str, state: QualificationDraftState,
+    ) -> None: ...
+
+    def qualifications_for_playlist(
+        self, account_id: str, playlist_id: str,
+    ) -> list[QualificationDraftState]: ...
+
 
 class FileTransferStorage:
     """Atomically persisted, versioned state for resumable Transfers."""
@@ -868,6 +1036,7 @@ class FileTransferStorage:
         self.path = Path(path)
         self.transfers: dict[str, TransferState] = {}
         self.batches: dict[str, BatchState] = {}
+        self.qualifications: dict[str, QualificationDraftState] = {}
         self._load()
 
     def _load(self) -> None:
@@ -877,7 +1046,7 @@ class FileTransferStorage:
             data = json.loads(self.path.read_text())
         except (json.JSONDecodeError, OSError):
             return
-        if data.get("version") in (1, 2, TRANSFER_STATE_VERSION):
+        if data.get("version") in (1, 2, 3, TRANSFER_STATE_VERSION):
             for transfer_id, state in data.get("transfers", {}).items():
                 try:
                     self.transfers[transfer_id] = TransferState.from_dict(state)
@@ -886,6 +1055,13 @@ class FileTransferStorage:
             for transfer_id, state in data.get("batches", {}).items():
                 try:
                     self.batches[transfer_id] = BatchState.from_dict(state)
+                except (KeyError, TypeError, ValueError):
+                    continue
+            for draft_id, state in data.get("qualifications", {}).items():
+                try:
+                    self.qualifications[draft_id] = (
+                        QualificationDraftState.from_dict(state)
+                    )
                 except (KeyError, TypeError, ValueError):
                     continue
 
@@ -903,6 +1079,25 @@ class FileTransferStorage:
         self.batches = {**self.batches, transfer_id: state}
         self._save()
 
+    def load_qualification(
+        self, draft_id: str,
+    ) -> QualificationDraftState | None:
+        return self.qualifications.get(draft_id)
+
+    def save_qualification(
+        self, draft_id: str, state: QualificationDraftState,
+    ) -> None:
+        self.qualifications = {**self.qualifications, draft_id: state}
+        self._save()
+
+    def qualifications_for_playlist(
+        self, account_id: str, playlist_id: str,
+    ) -> list[QualificationDraftState]:
+        return [
+            draft for draft in self.qualifications.values()
+            if draft.account_id == account_id and draft.playlist_id == playlist_id
+        ]
+
     def _save(self) -> None:
         self.path.parent.mkdir(parents=True, exist_ok=True)
         temporary = self.path.with_suffix(f"{self.path.suffix}.tmp")
@@ -913,6 +1108,10 @@ class FileTransferStorage:
             },
             "batches": {
                 key: asdict(batch) for key, batch in self.batches.items()
+            },
+            "qualifications": {
+                key: asdict(draft)
+                for key, draft in self.qualifications.items()
             },
         }, indent=2))
         os.replace(temporary, self.path)
@@ -964,6 +1163,8 @@ class MatchingKnowledge(Protocol):
     def local_audio_observation(
         self, evidence_id: str,
     ) -> LocalAudioObservation | None: ...
+
+    def approval_conflict(self, item: PublicationItem) -> bool: ...
 
 
 class BeatportChartSource:
@@ -1276,6 +1477,9 @@ class SpotifyMatcher:
             "uri": track["uri"],
             "name": track["name"],
             "artist": ", ".join(artist["name"] for artist in track["artists"]),
+            "album": (track.get("album") or {}).get("name", ""),
+            "duration_ms": int(track.get("duration_ms", 0)),
+            "is_playable": track.get("is_playable", True),
         }
 
 
@@ -1297,6 +1501,8 @@ class MatchCacheKnowledge:
             "uri": entry.spotify_uri,
             "name": entry.spotify_name,
             "artist": entry.spotify_artist,
+            "album": entry.spotify_release,
+            "duration_ms": entry.spotify_duration * 1000,
             "score": entry.score,
             "match_type": entry.match_type or "exact",
             "score_reasons": list(entry.score_reasons),
@@ -1331,6 +1537,8 @@ class MatchCacheKnowledge:
                 "score": item.score,
                 "match_type": item.match_type,
                 "score_reasons": list(item.score_reasons),
+                "spotify_release": item.spotify_release,
+                "spotify_duration": item.spotify_duration,
             }, item.source_duration,
         )
         return ApprovalConflict(**conflict) if conflict else None
@@ -1345,6 +1553,8 @@ class MatchCacheKnowledge:
                 "score": item.score,
                 "match_type": item.match_type,
                 "score_reasons": list(item.score_reasons),
+                "spotify_release": item.spotify_release,
+                "spotify_duration": item.spotify_duration,
             }, item.source_duration,
         )
 
@@ -1421,6 +1631,8 @@ class MatchCacheKnowledge:
                 "score": item.score,
                 "match_type": item.match_type,
                 "score_reasons": list(item.score_reasons),
+                "spotify_release": item.spotify_release,
+                "spotify_duration": item.spotify_duration,
             },
         )
         return ApprovalConflict(**conflict) if conflict else None
@@ -1446,6 +1658,15 @@ class MatchCacheKnowledge:
             algorithm=item["algorithm"],
             algorithm_version=item["algorithm_version"],
             duration=item["audio_duration"],
+        )
+
+    def approval_conflict(self, item: PublicationItem) -> bool:
+        return any(
+            conflict.get("source_artist") == item.source_artist
+            and conflict.get("source_title") == item.source_title
+            and int(conflict.get("source_duration", 0)) == item.source_duration
+            and conflict.get("proposed_spotify_uri") == item.spotify_uri
+            for conflict in self._cache.approval_conflicts
         )
 
 
@@ -1510,6 +1731,9 @@ class EphemeralMatchingKnowledge:
     ) -> LocalAudioObservation | None:
         return None
 
+    def approval_conflict(self, item: PublicationItem) -> bool:
+        return False
+
 
 class Transfer:
     """Coordinate a Transfer through source, Spotify, and storage seams."""
@@ -1525,6 +1749,7 @@ class Transfer:
         transfer_storage: TransferStorage | None = None,
         retry_policy: RetryPolicy | None = None,
         local_audio=None,
+        local_audition=None,
     ) -> None:
         self._source = source
         self._spotify = spotify
@@ -1534,6 +1759,7 @@ class Transfer:
         self._transfer_storage = transfer_storage
         self._retry_policy = retry_policy or RetryPolicy()
         self._local_audio = local_audio
+        self._local_audition = local_audition
         self._pause_requested = False
 
     @staticmethod
@@ -1593,6 +1819,16 @@ class Transfer:
             )
         return self._local_audio.capability()
 
+    def local_audition_capability(self):
+        """Inspect audition support without opening source media."""
+        if self._local_audition is None:
+            from djsupport.local_audition import LocalAuditionCapability
+
+            return LocalAuditionCapability(
+                available=False, reason="not_configured",
+            )
+        return self._local_audition.capability()
+
     def prepare(self, request: TransferRequest) -> str:
         """Durably reserve a Transfer ID before potentially slow source intake."""
         if self._transfer_storage is None:
@@ -1647,6 +1883,7 @@ class Transfer:
                 "retain_matching_knowledge", True,
             ),
             local_audio_identity=state.request.get("local_audio_identity", False),
+            local_audio_audition=state.request.get("local_audio_audition", False),
         )
 
     def batch_progress(self, transfer_id: str) -> BatchProgress:
@@ -1700,6 +1937,7 @@ class Transfer:
             "mirror_playlist_id": request.mirror_playlist_id,
             "retain_matching_knowledge": request.retain_matching_knowledge,
             "local_audio_identity": request.local_audio_identity,
+            "local_audio_audition": request.local_audio_audition,
         }
 
     @staticmethod
@@ -1715,6 +1953,7 @@ class Transfer:
             "genre": track.genre,
             "date_added": track.date_added,
             "duration": track.duration,
+            "version": track.version,
         }
         if include_location:
             stored["location"] = track.location
@@ -1739,7 +1978,11 @@ class Transfer:
         for selection in selections:
             selection_material = [
                 self._stored_track(
-                    track, include_location=request.local_audio_identity,
+                    track,
+                    include_location=(
+                        request.local_audio_identity
+                        or request.local_audio_audition
+                    ),
                 )
                 for track in selection.tracks
             ]
@@ -1811,6 +2054,7 @@ class Transfer:
             retry_days=request.retry_days,
             playlist_prefix=request.playlist_prefix,
             local_audio_identity=request.local_audio_identity,
+            local_audio_audition=request.local_audio_audition,
         )
 
     def execute_batch(
@@ -1881,6 +2125,7 @@ class Transfer:
                 retry_days=plan.retry_days,
                 playlist_prefix=plan.playlist_prefix,
                 local_audio_identity=plan.local_audio_identity,
+                local_audio_audition=plan.local_audio_audition,
                 plan_id=plan.batch_id,
                 playlists=[
                     BatchPlaylistState(
@@ -1917,6 +2162,7 @@ class Transfer:
                     playlist_prefix=batch.playlist_prefix,
                     transfer_id=item.transfer_id,
                     local_audio_identity=batch.local_audio_identity,
+                    local_audio_audition=batch.local_audio_audition,
                 ))
             except Exception as exc:
                 if not self._is_shared_failure(exc) and not self._is_playlist_failure(exc):
@@ -2069,6 +2315,878 @@ class Transfer:
             raise ValueError("A Transfer cannot be abandoned under another Spotify account")
         state.status = TransferStatus.ABANDONED
         self._transfer_storage.save_transfer(transfer_id, state)
+        if self._local_audition is not None and hasattr(
+            self._local_audition, "invalidate_transfer"
+        ):
+            self._local_audition.invalidate_transfer(transfer_id)
+
+    def obtain_qualification(
+        self,
+        request: QualificationRequest,
+        authorization: TransferAuthorization,
+    ) -> QualificationView:
+        """Obtain or resume one non-authoritative Rekordbox draft."""
+        required = self.private_source_authorization_requirement(authorization)
+        if required:
+            raise PermissionError(required)
+        if self._source.source_label != "Rekordbox":
+            raise ValueError(
+                "Qualification is available only for Rekordbox Mirrors"
+            )
+        if self._transfer_storage is None or not all(
+            hasattr(self._transfer_storage, method)
+            for method in ("load_qualification", "save_qualification")
+        ):
+            raise ValueError("Qualification requires durable Transfer storage")
+        child_id, batch_id, state = self._qualification_transfer(request)
+        if state.status != TransferStatus.COMPLETED:
+            raise ValueError("Qualification requires a completed Transfer")
+        if state.request.get("mode") != TransferMode.MIRROR.value:
+            raise ValueError(
+                "Qualification is available only for Rekordbox Mirrors"
+            )
+        source_reference = state.selection.get("reference")
+        if not source_reference:
+            raise ValueError("Qualification source selection is unavailable")
+        selection_digest = self._qualification_selection_digest(state.selection)
+        manifest_digest = self._qualification_manifest_digest(state)
+        account_id = self._spotify.account_id()
+        if state.account_id != account_id:
+            raise ValueError(
+                "A Qualification Draft cannot resume under another Spotify account"
+            )
+        playlist_head = None
+        if state.spotify_playlist_id and hasattr(self._spotify, "playlist_head"):
+            playlist_head = self._retry_policy.run(
+                lambda: self._spotify.playlist_head(
+                    state.spotify_playlist_id  # type: ignore[arg-type]
+                ).snapshot_id
+            )
+        draft_id = hashlib.sha256(
+            f"qualification\0{child_id}\0{source_reference}".encode()
+        ).hexdigest()
+        draft = self._transfer_storage.load_qualification(draft_id)
+        items = self._qualification_items(state, None)
+        selected_ids = [
+            item.item_id for item in items
+            if request.include_all or item.attention_reasons
+        ]
+        now = datetime.now().isoformat()
+        if draft is None:
+            draft = QualificationDraftState(
+                draft_id=draft_id,
+                transfer_id=child_id,
+                batch_id=batch_id,
+                source_reference=source_reference,
+                account_id=account_id,
+                playlist_id=state.spotify_playlist_id,
+                playlist_head=playlist_head,
+                manifest_digest=manifest_digest,
+                selection_digest=selection_digest,
+                include_all=request.include_all,
+                item_ids=selected_ids,
+                decisions={},
+                status=QualificationStatus.DRAFT,
+                created_at=now,
+                updated_at=now,
+            )
+        else:
+            if draft.account_id != account_id:
+                raise ValueError(
+                    "A Qualification Draft cannot resume under another Spotify account"
+                )
+            if (
+                draft.transfer_id != child_id
+                or draft.source_reference != source_reference
+                or draft.selection_digest != selection_digest
+                or draft.manifest_digest != manifest_digest
+                or draft.playlist_id != state.spotify_playlist_id
+            ):
+                draft.status = QualificationStatus.REVIEW_REQUIRED
+                draft.updated_at = now
+                self._transfer_storage.save_qualification(draft_id, draft)
+                raise SpotifyPlaylistReviewRequired(
+                    "Qualification evidence changed; create a new bounded review"
+                )
+            if (
+                draft.playlist_head is not None
+                and playlist_head is not None
+                and draft.playlist_head != playlist_head
+                and draft.status not in {
+                    QualificationStatus.APPLYING,
+                    QualificationStatus.PAUSED,
+                    QualificationStatus.APPLIED,
+                }
+            ):
+                draft.status = QualificationStatus.REVIEW_REQUIRED
+                draft.updated_at = now
+                self._transfer_storage.save_qualification(draft_id, draft)
+                raise SpotifyPlaylistReviewRequired(
+                    "Spotify playlist changed; Qualification review required"
+                )
+            draft.include_all = request.include_all
+            draft.item_ids = selected_ids
+            draft.updated_at = now
+        self._preflight_qualification_audition(draft, state)
+        view = self._qualification_view(draft, state)
+        draft.status = (
+            QualificationStatus.READY if view.complete
+            else QualificationStatus.DRAFT
+        )
+        draft.updated_at = now
+        self._transfer_storage.save_qualification(draft_id, draft)
+        return self._qualification_view(draft, state)
+
+    def qualification(self, draft_id: str) -> QualificationView:
+        """Render one durable draft without inferring any outcome."""
+        if self._transfer_storage is None or not hasattr(
+            self._transfer_storage, "load_qualification"
+        ):
+            raise ValueError("Qualification requires durable Transfer storage")
+        draft = self._transfer_storage.load_qualification(draft_id)
+        if draft is None:
+            raise ValueError(f"Unknown Qualification Draft: {draft_id}")
+        if draft.account_id != self._spotify.account_id():
+            raise ValueError(
+                "A Qualification Draft cannot be viewed under another Spotify account"
+            )
+        state = self._transfer_storage.load_transfer(draft.transfer_id)
+        if state is None:
+            raise ValueError("Qualification Transfer evidence is unavailable")
+        return self._qualification_view(draft, state)
+
+    def _qualification_transfer(
+        self, request: QualificationRequest,
+    ) -> tuple[str, str | None, TransferState]:
+        assert self._transfer_storage is not None
+        batch = self._transfer_storage.load_batch(request.transfer_id)
+        batch_id = request.transfer_id if batch is not None else None
+        if batch is not None:
+            candidates = [
+                item for item in batch.playlists
+                if request.playlist_reference is not None
+                and item.reference == request.playlist_reference
+            ]
+            if not candidates:
+                raise ValueError(
+                    "Select one playlist from the completed Rekordbox Batch"
+                )
+            if len(candidates) != 1:
+                raise ValueError("Qualification playlist selection is ambiguous")
+            child_id = candidates[0].transfer_id
+        else:
+            child_id = request.transfer_id
+        state = self._transfer_storage.load_transfer(child_id)
+        if state is None:
+            raise ValueError(f"Unknown Transfer: {request.transfer_id}")
+        if (
+            request.playlist_reference is not None
+            and state.selection.get("reference") != request.playlist_reference
+        ):
+            raise ValueError("Qualification playlist is outside the selected Batch")
+        return child_id, batch_id, state
+
+    @classmethod
+    def _qualification_selection_digest(cls, selection: dict) -> str:
+        private_safe = {
+            "reference": selection.get("reference"),
+            "tracks": [
+                {key: value for key, value in track.items() if key != "location"}
+                for track in selection.get("tracks", ())
+            ],
+        }
+        return hashlib.sha256(json.dumps(
+            private_safe, sort_keys=True, separators=(",", ":"),
+        ).encode()).hexdigest()
+
+    @staticmethod
+    def _qualification_manifest_digest(state: TransferState) -> str:
+        evidence = state.publication_manifest or {
+            "preview_items": state.publication_items,
+            "playlist_id": state.spotify_playlist_id,
+        }
+        return hashlib.sha256(json.dumps(
+            evidence, sort_keys=True, separators=(",", ":"),
+        ).encode()).hexdigest()
+
+    def _qualification_items(
+        self,
+        state: TransferState,
+        draft: QualificationDraftState | None,
+    ) -> list[QualificationItem]:
+        publication_items = [
+            PublicationItem(**item) for item in state.publication_items
+        ]
+        source_identities_by_uri: dict[
+            str, set[tuple[str, str, int]]
+        ] = {}
+        for item in publication_items:
+            if item.spotify_uri:
+                source_identities_by_uri.setdefault(item.spotify_uri, set()).add((
+                    item.source_artist.casefold(),
+                    item.source_title.casefold(),
+                    item.source_duration,
+                ))
+        collision_uris = {
+            uri for uri, identities in source_identities_by_uri.items()
+            if len(identities) > 1
+        }
+        alternative_ids = {
+            item.get("source_track_id") for item in state.alternatives
+        }
+        rendered: list[QualificationItem] = []
+        for ordinal, item in enumerate(publication_items):
+            source_index = item.source_index if item.occurrence_id else ordinal
+            item_id = item.occurrence_id or hashlib.sha256(
+                f"{state.source}\0{source_index}\0{item.source_track_id}".encode()
+            ).hexdigest()
+            reasons: list[str] = []
+            authority_status = "approved" if item.authoritative else "proposal"
+            if not item.authoritative:
+                if item.spotify_uri:
+                    reasons.append("new_proposal")
+                else:
+                    reasons.append("unresolved")
+                if item.match_type in {"shorter_version", "fallback_version"}:
+                    reasons.append(item.match_type)
+                if (
+                    item.source_duration > 0
+                    and item.spotify_duration > 0
+                    and abs(item.source_duration - item.spotify_duration) > 30
+                ):
+                    reasons.append("duration_conflict")
+                if any(
+                    "version" in reason.casefold()
+                    and any(marker in reason.casefold() for marker in (
+                        "conflict", "differ", "fallback", "shorter", "mismatch",
+                    ))
+                    for reason in item.score_reasons
+                ):
+                    reasons.append("version_conflict")
+                if item.source_track_id in alternative_ids:
+                    reasons.append("alternatives")
+                if item.spotify_uri in collision_uris:
+                    reasons.append("match_collision")
+                conflict_checker = getattr(
+                    self._knowledge, "approval_conflict", None
+                )
+                if conflict_checker is not None and conflict_checker(item):
+                    reasons.append("approval_conflict")
+            decision_data = (
+                draft.decisions.get(item_id, {}) if draft is not None else {}
+            )
+            decision_value = decision_data.get("decision")
+            decision = (
+                QualificationDecision(decision_value)
+                if decision_value is not None else None
+            )
+            if decision == QualificationDecision.DEFERRED and not decision_data.get(
+                "excluded", False
+            ):
+                reasons.append("deferred")
+            audition_fact = (
+                draft.audition_statuses.get(item_id, {})
+                if draft is not None else {}
+            )
+            audition_status = (
+                str(audition_fact.get("status"))
+                if audition_fact.get("status")
+                else "available_on_request"
+                if state.request.get("local_audio_audition")
+                and self._local_audition is not None
+                else "not_configured"
+                if state.request.get("local_audio_audition")
+                else "not_requested"
+            )
+            rendered.append(QualificationItem(
+                item_id=item_id,
+                source_index=source_index,
+                source_track_id=item.source_track_id,
+                source_artist=item.source_artist,
+                source_title=item.source_title,
+                source_release=item.source_release,
+                source_label=item.source_label,
+                source_version=item.source_version,
+                source_duration=item.source_duration,
+                spotify_uri=item.spotify_uri,
+                spotify_name=item.spotify_name,
+                spotify_artist=item.spotify_artist,
+                spotify_release=item.spotify_release,
+                spotify_duration=item.spotify_duration,
+                score=item.score,
+                match_type=item.match_type,
+                score_reasons=item.score_reasons,
+                authority_status=authority_status,
+                attention_reasons=tuple(dict.fromkeys(reasons)),
+                audition_status=audition_status,
+                audition_reason=audition_fact.get("reason"),
+                decision=decision,
+                correction_uri=decision_data.get("correction_uri"),
+                deferred_reason=decision_data.get("reason"),
+                excluded=bool(decision_data.get("excluded", False)),
+            ))
+        return rendered
+
+    def _preflight_qualification_audition(
+        self, draft: QualificationDraftState, state: TransferState,
+    ) -> None:
+        if (
+            not state.request.get("local_audio_audition", False)
+            or self._local_audition is None
+            or not hasattr(self._local_audition, "preflight")
+        ):
+            return
+        selection = self._source.consume(draft.source_reference)
+        comparison = {
+            "reference": selection.reference,
+            "tracks": [
+                self._stored_track(track, include_location=False)
+                for track in selection.tracks
+            ],
+        }
+        if self._qualification_selection_digest(comparison) != draft.selection_digest:
+            raise SpotifyPlaylistReviewRequired(
+                "Rekordbox source selection changed; audition blocked"
+            )
+        items = {
+            item.item_id: item
+            for item in self._qualification_items(state, draft)
+            if item.item_id in draft.item_ids
+        }
+        for item_id, item in items.items():
+            if item.source_index >= len(selection.tracks):
+                draft.audition_statuses[item_id] = {
+                    "status": "unavailable", "reason": "unselected_source",
+                }
+                continue
+            track = selection.tracks[item.source_index]
+            if track.track_id != item.source_track_id:
+                draft.audition_statuses[item_id] = {
+                    "status": "unavailable", "reason": "unselected_source",
+                }
+                continue
+            result = self._local_audition.preflight(track)
+            draft.audition_statuses[item_id] = {
+                "status": result.status,
+                "reason": result.reason,
+            }
+
+    def _qualification_view(
+        self, draft: QualificationDraftState, state: TransferState,
+    ) -> QualificationView:
+        item_by_id = {
+            item.item_id: item
+            for item in self._qualification_items(state, draft)
+        }
+        items = tuple(
+            item_by_id[item_id]
+            for item_id in draft.item_ids
+            if item_id in item_by_id
+        )
+        return QualificationView(
+            draft_id=draft.draft_id,
+            transfer_id=draft.transfer_id,
+            source_reference=draft.source_reference,
+            spotify_playlist_id=draft.playlist_id,
+            status=draft.status,
+            items=items,
+            include_all=draft.include_all,
+        )
+
+    def record_qualification(
+        self,
+        draft_id: str,
+        item_id: str,
+        decision: QualificationDecision,
+        *,
+        spotify_reference: str | None = None,
+        reason: str | None = None,
+        exclude: bool = False,
+    ) -> QualificationView:
+        """Record or revise one draft outcome without creating authority."""
+        if self._transfer_storage is None or not hasattr(
+            self._transfer_storage, "load_qualification"
+        ):
+            raise ValueError("Qualification requires durable Transfer storage")
+        draft = self._transfer_storage.load_qualification(draft_id)
+        if draft is None:
+            raise ValueError(f"Unknown Qualification Draft: {draft_id}")
+        if draft.status == QualificationStatus.APPLIED:
+            raise ValueError("An applied Qualification Draft cannot be revised")
+        if draft.account_id != self._spotify.account_id():
+            raise ValueError(
+                "A Qualification Draft cannot be revised under another Spotify account"
+            )
+        state = self._transfer_storage.load_transfer(draft.transfer_id)
+        if state is None:
+            raise ValueError("Qualification Transfer evidence is unavailable")
+        items = {
+            item.item_id: item
+            for item in self._qualification_items(state, draft)
+        }
+        if item_id not in draft.item_ids or item_id not in items:
+            raise ValueError("Qualification item is outside the selected playlist")
+        item = items[item_id]
+        if exclude and decision != QualificationDecision.DEFERRED:
+            raise ValueError("Only a deferred item can be explicitly excluded")
+        if decision == QualificationDecision.KEEP_PROPOSAL and not item.spotify_uri:
+            raise ValueError("An unresolved source track has no proposal to keep")
+        stored: dict[str, object] = {
+            "decision": decision.value,
+            "updated_at": datetime.now().isoformat(),
+        }
+        if decision == QualificationDecision.CORRECTION:
+            if spotify_reference is None:
+                raise ValueError("A staged Correction requires a Spotify track URL or URI")
+            spotify_uri = self._spotify_uri(spotify_reference, 1)
+            spotify_track = self._retry_policy.run(
+                lambda: self._spotify.spotify_track(spotify_uri)
+            )
+            if spotify_track.get("uri") != spotify_uri:
+                raise ValueError("The staged Correction did not resolve to its Spotify track")
+            stored.update({
+                "correction_uri": spotify_uri,
+                "spotify_name": spotify_track["name"],
+                "spotify_artist": spotify_track["artist"],
+                "spotify_release": spotify_track.get("album", ""),
+                "spotify_duration": int(
+                    spotify_track.get("duration_ms", 0)
+                ) // 1000,
+            })
+        elif decision == QualificationDecision.DEFERRED:
+            stored.update({
+                "reason": reason.strip() if reason and reason.strip() else None,
+                "excluded": exclude,
+            })
+        draft.decisions[item_id] = stored
+        draft.updated_at = datetime.now().isoformat()
+        view = self._qualification_view(draft, state)
+        draft.status = (
+            QualificationStatus.READY if view.complete
+            else QualificationStatus.DRAFT
+        )
+        self._transfer_storage.save_qualification(draft_id, draft)
+        return self._qualification_view(draft, state)
+
+    def audition_qualification(
+        self,
+        draft_id: str,
+        item_id: str,
+        authorization: TransferAuthorization,
+    ) -> LocalAuditionResult:
+        """Open only one exact selected source occurrence after authorization."""
+        required = self.private_source_authorization_requirement(authorization)
+        if required:
+            raise PermissionError(required)
+        if self._local_audition is None:
+            return LocalAuditionResult.unavailable("not_configured")
+        if self._transfer_storage is None or not hasattr(
+            self._transfer_storage, "load_qualification"
+        ):
+            raise ValueError("Qualification requires durable Transfer storage")
+        draft = self._transfer_storage.load_qualification(draft_id)
+        if draft is None:
+            raise ValueError(f"Unknown Qualification Draft: {draft_id}")
+        if draft.account_id != self._spotify.account_id():
+            raise ValueError(
+                "A Qualification Draft cannot be auditioned under another Spotify account"
+            )
+        state = self._transfer_storage.load_transfer(draft.transfer_id)
+        if state is None:
+            raise ValueError("Qualification Transfer evidence is unavailable")
+        if not state.request.get("local_audio_audition", False):
+            return LocalAuditionResult.unavailable("not_requested")
+        view_items = {
+            item.item_id: item
+            for item in self._qualification_items(state, draft)
+            if item.item_id in draft.item_ids
+        }
+        if item_id not in view_items:
+            raise ValueError(
+                "Audition item is outside the selected Qualification playlist"
+            )
+        item = view_items[item_id]
+        selection = self._source.consume(draft.source_reference)
+        comparison = {
+            "reference": selection.reference,
+            "tracks": [
+                self._stored_track(track, include_location=False)
+                for track in selection.tracks
+            ],
+        }
+        if self._qualification_selection_digest(comparison) != draft.selection_digest:
+            raise SpotifyPlaylistReviewRequired(
+                "Rekordbox source selection changed; audition blocked"
+            )
+        if item.source_index >= len(selection.tracks):
+            raise ValueError("Audition item is outside the selected source")
+        selected_track = selection.tracks[item.source_index]
+        if selected_track.track_id != item.source_track_id:
+            raise ValueError("Audition item is outside the selected source")
+        result = self._local_audition.open(
+            draft.transfer_id, item_id, selected_track,
+        )
+        draft.audition_statuses[item_id] = {
+            "status": result.status,
+            "reason": result.reason,
+        }
+        self._transfer_storage.save_qualification(draft_id, draft)
+        return result
+
+    def apply_qualification(
+        self,
+        draft_id: str,
+        authorization: TransferAuthorization,
+    ) -> QualificationApplyOutcome:
+        """Apply a complete draft to its Provisional Playlist, never Approval."""
+        required = self.private_source_authorization_requirement(authorization)
+        if required:
+            raise PermissionError(required)
+        if not authorization.spotify_write:
+            raise PermissionError("spotify_write")
+        if self._transfer_storage is None or not hasattr(
+            self._transfer_storage, "load_qualification"
+        ):
+            raise ValueError("Qualification requires durable Transfer storage")
+        if self._publication_storage is None:
+            raise ValueError("Qualification application requires publication storage")
+        draft = self._transfer_storage.load_qualification(draft_id)
+        if draft is None:
+            raise ValueError(f"Unknown Qualification Draft: {draft_id}")
+        if draft.account_id != self._spotify.account_id():
+            raise ValueError(
+                "A Qualification Draft cannot be applied under another Spotify account"
+            )
+        if draft.playlist_id is None:
+            raise ValueError(
+                "A Preview Qualification Draft requires a Provisional Playlist before apply"
+            )
+        if draft.status == QualificationStatus.APPLIED:
+            applied_count = len(
+                (draft.applied_manifest or {}).get("managed_items", ())
+            )
+            return QualificationApplyOutcome(
+                draft_id, draft.playlist_id, QualificationStatus.APPLIED,
+                applied_count, ("approve",),
+            )
+        state = self._transfer_storage.load_transfer(draft.transfer_id)
+        if state is None:
+            raise ValueError("Qualification Transfer evidence is unavailable")
+        view = self._qualification_view(draft, state)
+        if not view.complete:
+            raise ValueError(
+                "Qualification Draft has pending or deferred items"
+            )
+        unresolved_conflicts = []
+        for item in view.items:
+            if not ({"match_collision", "approval_conflict"} & set(
+                item.attention_reasons
+            )):
+                continue
+            decision = draft.decisions.get(item.item_id, {})
+            choice = decision.get("decision")
+            resolved = choice in {
+                QualificationDecision.CORRECTION.value,
+                QualificationDecision.REJECT_PROPOSAL.value,
+            } or (
+                choice == QualificationDecision.DEFERRED.value
+                and bool(decision.get("excluded"))
+            )
+            if not resolved:
+                unresolved_conflicts.append(item.item_id)
+        if unresolved_conflicts:
+            draft.status = QualificationStatus.REVIEW_REQUIRED
+            self._transfer_storage.save_qualification(draft_id, draft)
+            raise SpotifyPlaylistReviewRequired(
+                "Qualification conflict remains unresolved"
+            )
+        current_selection = self._source.consume(draft.source_reference)
+        selection = {
+            "reference": current_selection.reference,
+            "tracks": [
+                self._stored_track(track, include_location=False)
+                for track in current_selection.tracks
+            ],
+        }
+        if self._qualification_selection_digest(selection) != draft.selection_digest:
+            draft.status = QualificationStatus.REVIEW_REQUIRED
+            self._transfer_storage.save_qualification(draft_id, draft)
+            raise SpotifyPlaylistReviewRequired(
+                "Rekordbox source selection changed; review required"
+            )
+        current_manifest = self._publication_storage.publication_for_playlist(
+            draft.account_id, draft.playlist_id,
+        )
+        if current_manifest is None:
+            raise SpotifyPlaylistReviewRequired(
+                "The linked Provisional Playlist manifest is unavailable"
+            )
+        if (
+            self._publication_digest(current_manifest)
+            != draft.manifest_digest
+        ):
+            draft.status = QualificationStatus.REVIEW_REQUIRED
+            self._transfer_storage.save_qualification(draft_id, draft)
+            raise SpotifyPlaylistReviewRequired(
+                "Publication manifest changed; review required"
+            )
+        account_id = self._spotify.account_id()
+        with self._publishing_guards.acquire(account_id):
+            expected_head = (
+                draft.mutation_snapshots[-1]
+                if draft.mutation_snapshots else draft.playlist_head
+            )
+            if expected_head is not None and hasattr(self._spotify, "playlist_head"):
+                current_head = self._retry_policy.run(
+                    lambda: self._spotify.playlist_head(draft.playlist_id)
+                )
+                if current_head.snapshot_id != expected_head:
+                    draft.status = QualificationStatus.REVIEW_REQUIRED
+                    self._transfer_storage.save_qualification(draft_id, draft)
+                    raise SpotifyPlaylistChanged(
+                        "Spotify playlist changed before Qualification apply"
+                    )
+            updated_manifest, desired_uris = self._qualification_application(
+                draft, state, current_manifest,
+            )
+            identities_by_uri: dict[str, set[tuple[str, str, int]]] = {}
+            for item in updated_manifest.managed_items:
+                identities_by_uri.setdefault(item.spotify_uri, set()).add((
+                    item.source_artist.casefold(),
+                    item.source_title.casefold(),
+                    item.source_duration,
+                ))
+            if any(
+                len(identities) > 1
+                for identities in identities_by_uri.values()
+            ):
+                draft.status = QualificationStatus.REVIEW_REQUIRED
+                self._transfer_storage.save_qualification(draft_id, draft)
+                raise SpotifyPlaylistReviewRequired(
+                    "Qualification conflict remains unresolved"
+                )
+            preservation_manifest = current_manifest
+            if draft.completed_chunks and draft.applied_manifest is not None:
+                preservation_manifest = self._publication_from_stored(
+                    draft.applied_manifest
+                )
+            desired_uris = self._preserve_unmanaged_playlist_items(
+                draft.playlist_id, preservation_manifest, desired_uris,
+            )
+            draft.applied_manifest = self._stored_publication(updated_manifest)
+            draft.status = QualificationStatus.APPLYING
+            draft.updated_at = datetime.now().isoformat()
+            self._transfer_storage.save_qualification(draft_id, draft)
+            paused = self._apply_qualification_chunks(
+                draft, desired_uris,
+            )
+            if paused:
+                return QualificationApplyOutcome(
+                    draft_id, draft.playlist_id, QualificationStatus.PAUSED,
+                    len(updated_manifest.managed_items), ("resume",),
+                )
+            self._publication_storage.retain_publication(updated_manifest)
+            state.publication_manifest = self._stored_publication(updated_manifest)
+            self._save_transfer(draft.transfer_id, state)
+            draft.status = QualificationStatus.APPLIED
+            if draft.mutation_snapshots:
+                draft.playlist_head = draft.mutation_snapshots[-1]
+            draft.updated_at = datetime.now().isoformat()
+            self._transfer_storage.save_qualification(draft_id, draft)
+            return QualificationApplyOutcome(
+                draft_id, draft.playlist_id, QualificationStatus.APPLIED,
+                len(updated_manifest.managed_items), ("approve",),
+            )
+
+    @staticmethod
+    def _stored_publication(manifest: PublicationManifest) -> dict:
+        stored = asdict(manifest)
+        stored["created_at"] = manifest.created_at.isoformat()
+        return stored
+
+    @staticmethod
+    def _publication_from_stored(stored: dict) -> PublicationManifest:
+        return PublicationManifest(**{
+            **stored,
+            "mode": TransferMode(
+                stored.get("mode", TransferMode.SNAPSHOT.value)
+            ),
+            "created_at": datetime.fromisoformat(stored["created_at"]),
+            "items": tuple(
+                PublicationItem(**item) for item in stored.get("items", ())
+            ),
+            "managed_items": tuple(
+                PublicationItem(**item)
+                for item in stored.get("managed_items", stored.get("items", ()))
+            ),
+        })
+
+    @classmethod
+    def _publication_digest(cls, manifest: PublicationManifest) -> str:
+        return hashlib.sha256(json.dumps(
+            cls._stored_publication(manifest),
+            sort_keys=True,
+            separators=(",", ":"),
+        ).encode()).hexdigest()
+
+    def _qualification_application(
+        self,
+        draft: QualificationDraftState,
+        state: TransferState,
+        manifest: PublicationManifest,
+    ) -> tuple[PublicationManifest, list[str]]:
+        all_items = [PublicationItem(**item) for item in state.publication_items]
+        decision_by_id = draft.decisions
+        desired_items: list[PublicationItem] = []
+        review_items: list[PublicationItem] = []
+        original_review_ids = {
+            item.occurrence_id or item.source_track_id for item in manifest.items
+        }
+        for ordinal, item in enumerate(all_items):
+            item_id = item.occurrence_id or hashlib.sha256(
+                f"{state.source}\0{ordinal}\0{item.source_track_id}".encode()
+            ).hexdigest()
+            decision = decision_by_id.get(item_id)
+            resolved = item
+            excluded = False
+            rejected = False
+            if decision is not None:
+                choice = QualificationDecision(decision["decision"])
+                if choice == QualificationDecision.CORRECTION:
+                    resolved = replace(
+                        item,
+                        spotify_uri=str(decision["correction_uri"]),
+                        spotify_name=str(decision["spotify_name"]),
+                        spotify_artist=str(decision["spotify_artist"]),
+                        spotify_release=str(decision.get("spotify_release", "")),
+                        spotify_duration=int(
+                            decision.get("spotify_duration", 0)
+                        ),
+                        score=100.0,
+                        match_type="correction",
+                        score_reasons=("explicit Qualification Correction",),
+                        authoritative=False,
+                    )
+                elif choice == QualificationDecision.REJECT_PROPOSAL:
+                    rejected = True
+                elif choice == QualificationDecision.DEFERRED:
+                    excluded = bool(decision.get("excluded"))
+            if resolved.spotify_uri and not rejected and not excluded:
+                desired_items.append(resolved)
+            was_review_item = (
+                item.occurrence_id or item.source_track_id
+            ) in original_review_ids
+            if excluded:
+                continue
+            if was_review_item or resolved.match_type == "correction":
+                review_items.append(resolved)
+        updated = replace(
+            manifest,
+            items=tuple(review_items),
+            managed_items=tuple(desired_items),
+        )
+        return updated, [item.spotify_uri for item in desired_items]
+
+    def _preserve_unmanaged_playlist_items(
+        self,
+        playlist_id: str,
+        manifest: PublicationManifest,
+        desired_uris: list[str],
+    ) -> list[str]:
+        if hasattr(self._spotify, "ordered_playlist_items"):
+            ordered = self._retry_policy.run(
+                lambda: self._spotify.ordered_playlist_items(playlist_id)
+            )
+            if any(item.kind != SpotifyItemKind.TRACK for item in ordered.items):
+                raise SpotifyPlaylistReviewRequired(
+                    "Spotify playlist contains unsupported items; review required"
+                )
+            current_uris = [item.uri for item in ordered.items if item.uri]
+        else:
+            current_uris = self._retry_policy.run(
+                lambda: self._spotify.provisional_playlist_track_uris(playlist_id)
+            ) or []
+        managed = Counter(
+            item.spotify_uri for item in (manifest.managed_items or manifest.items)
+            if item.spotify_uri
+        )
+        manual_by_boundary: dict[int, list[str]] = {}
+        managed_seen = 0
+        for uri in current_uris:
+            if managed[uri] > 0:
+                managed[uri] -= 1
+                managed_seen += 1
+                continue
+            boundary = min(managed_seen, len(desired_uris))
+            manual_by_boundary.setdefault(boundary, []).append(uri)
+        repaired: list[str] = []
+        for boundary in range(len(desired_uris) + 1):
+            repaired.extend(manual_by_boundary.get(boundary, ()))
+            if boundary < len(desired_uris):
+                repaired.append(desired_uris[boundary])
+        return repaired
+
+    def _apply_qualification_chunks(
+        self, draft: QualificationDraftState, uris: list[str],
+    ) -> bool:
+        assert self._transfer_storage is not None
+        assert draft.playlist_id is not None
+        chunks = [uris[:100]] + [
+            uris[offset:offset + 100] for offset in range(100, len(uris), 100)
+        ]
+        for index, chunk in enumerate(chunks):
+            chunk_id = hashlib.sha256(json.dumps(
+                [index, chunk], separators=(",", ":"),
+            ).encode()).hexdigest()
+            if chunk_id in draft.completed_chunks:
+                continue
+            expected_head = (
+                draft.mutation_snapshots[-1]
+                if draft.mutation_snapshots else draft.playlist_head
+            )
+            if expected_head is not None and hasattr(self._spotify, "playlist_head"):
+                current = self._retry_policy.run(
+                    lambda: self._spotify.playlist_head(draft.playlist_id)
+                )
+                if current.snapshot_id != expected_head:
+                    raise SpotifyPlaylistChanged(
+                        "Spotify playlist changed during Qualification apply"
+                    )
+            if all(hasattr(self._spotify, method) for method in (
+                "replace_items", "add_items",
+            )):
+                result = self._retry_policy.run(
+                    lambda: (
+                        self._spotify.replace_items(draft.playlist_id, chunk)
+                        if index == 0 else self._spotify.add_items(
+                            draft.playlist_id, chunk,
+                        )
+                    )
+                )
+                snapshot_id = result.snapshot_id
+            else:
+                if index > 0:
+                    raise ValueError(
+                        "Qualification application requires checkpointed playlist writes"
+                    )
+                self._retry_policy.run(
+                    lambda: self._spotify.replace_provisional_playlist_tracks(
+                        draft.playlist_id, chunk,
+                    )
+                )
+                snapshot_id = (
+                    self._spotify.playlist_head(draft.playlist_id).snapshot_id
+                    if hasattr(self._spotify, "playlist_head") else ""
+                )
+            draft.mutation_snapshots.append(snapshot_id)
+            draft.completed_chunks.append(chunk_id)
+            self._transfer_storage.save_qualification(draft.draft_id, draft)
+            if self._pause_requested:
+                self._pause_requested = False
+                draft.status = QualificationStatus.PAUSED
+                self._transfer_storage.save_qualification(draft.draft_id, draft)
+                return True
+        return False
 
     def approve(
         self, playlist_id: str, *, corrections: str | Path | None = None,
@@ -2084,6 +3202,19 @@ class Transfer:
             raise ValueError(
                 f"No Provisional Playlist {playlist_id} belongs to this Spotify account"
             )
+        if self._transfer_storage is not None and hasattr(
+            self._transfer_storage, "qualifications_for_playlist"
+        ):
+            unapplied = [
+                draft for draft in self._transfer_storage.qualifications_for_playlist(
+                    account_id, playlist_id,
+                )
+                if draft.status != QualificationStatus.APPLIED
+            ]
+            if unapplied:
+                raise SpotifyPlaylistReviewRequired(
+                    "Qualification Draft must be completed and applied before Approval"
+                )
         with self._publishing_guards.acquire(account_id):
             corrected_items = self._read_corrections(corrections, manifest)
             if all(hasattr(self._spotify, method) for method in (
@@ -2153,25 +3284,47 @@ class Transfer:
                     corrected_items.get(item.source_track_id, item)
                     for item in manifest.items
                 )
-                original_proposal_counts = Counter(
-                    item.spotify_uri for item in manifest.items
-                    if item.spotify_uri
-                )
+                original_identities: dict[
+                    str, set[tuple[str, str, int]]
+                ] = {}
+                for item in manifest.items:
+                    if item.spotify_uri:
+                        original_identities.setdefault(item.spotify_uri, set()).add((
+                            item.source_artist.casefold(),
+                            item.source_title.casefold(),
+                            item.source_duration,
+                        ))
+                original_collision_uris = {
+                    uri for uri, identities in original_identities.items()
+                    if len(identities) > 1
+                }
                 unresolved_collision_ids = {
-                    item.source_track_id for item in manifest.items
-                    if original_proposal_counts[item.spotify_uri] > 1
+                    item.occurrence_id or item.source_track_id
+                    for item in manifest.items
+                    if item.spotify_uri in original_collision_uris
                     and item.source_track_id not in corrected_items
                 }
-                proposed_counts = Counter(item.spotify_uri for item in reviewed_items)
+                proposed_identities: dict[
+                    str, set[tuple[str, str, int]]
+                ] = {}
+                for item in reviewed_items:
+                    if item.spotify_uri:
+                        proposed_identities.setdefault(item.spotify_uri, set()).add((
+                            item.source_artist.casefold(),
+                            item.source_title.casefold(),
+                            item.source_duration,
+                        ))
                 collision_uris = {
-                    uri for uri, count in proposed_counts.items() if count > 1
+                    uri for uri, identities in proposed_identities.items()
+                    if len(identities) > 1
                 }
                 collisions: list[PublicationItem] = []
                 for item in reviewed_items:
                     if not item.spotify_uri:
                         continue
                     if (
-                        item.source_track_id in unresolved_collision_ids
+                        (item.occurrence_id or item.source_track_id)
+                        in unresolved_collision_ids
                         or item.spotify_uri in collision_uris
                     ):
                         collisions.append(item)
@@ -2195,11 +3348,15 @@ class Transfer:
                     corrections=tuple(
                         item for item in approved
                         if item.source_track_id in corrected_items
+                        or item.match_type == "correction"
                     ),
                 )
                 conflicts: list[ApprovalConflict] = []
                 for item in outcome.approved:
-                    if item.source_track_id in corrected_items:
+                    if (
+                        item.source_track_id in corrected_items
+                        or item.match_type == "correction"
+                    ):
                         conflict = self._knowledge.correct(item)
                     else:
                         conflict = self._knowledge.approve(item)
@@ -2683,6 +3840,7 @@ class Transfer:
         try:
             for index in range(state.next_track_index, len(selection.tracks)):
                 track = selection.tracks[index]
+                occurrence_id = self._occurrence_id(transfer_id, index, track)
                 result = self._knowledge.lookup(track, request.threshold)
                 local_evidence_id = None
                 if (
@@ -2733,9 +3891,18 @@ class Transfer:
                             source_name=track.display,
                             source_artist=track.artist,
                             source_title=track.name,
+                            occurrence_id=occurrence_id,
+                            source_index=index,
+                            source_release=track.album,
+                            source_label=track.label,
+                            source_version=track.version,
                             spotify_uri=result["uri"],
                             spotify_name=result["name"],
                             spotify_artist=result["artist"],
+                            spotify_release=result.get("album", ""),
+                            spotify_duration=(
+                                int(result.get("duration_ms", 0)) // 1000
+                            ),
                             score=result["score"],
                             match_type=result.get("match_type", "exact"),
                             score_reasons=tuple(result.get("score_reasons", ())),
@@ -2761,12 +3928,19 @@ class Transfer:
 
                 if result is None or "alternatives" in result:
                     playlist.unmatched.append(track.display)
-                    if self._is_new_reviewable_source(track, publication_items):
+                    if self._is_new_reviewable_occurrence(
+                        occurrence_id, publication_items,
+                    ):
                         publication_items.append(PublicationItem(
                             source_track_id=track.track_id,
                             source_name=track.display,
                             source_artist=track.artist,
                             source_title=track.name,
+                            occurrence_id=occurrence_id,
+                            source_index=index,
+                            source_release=track.album,
+                            source_label=track.label,
+                            source_version=track.version,
                             source_duration=track.duration,
                             local_evidence_id=local_evidence_id,
                         ))
@@ -2803,15 +3977,26 @@ class Transfer:
                         spotify_uri=result["uri"],
                     )
                     playlist.matched.append(matched_track)
-                    if self._is_new_reviewable_source(track, publication_items):
+                    if self._is_new_reviewable_occurrence(
+                        occurrence_id, publication_items,
+                    ):
                         publication_items.append(PublicationItem(
                             source_track_id=track.track_id,
                             source_name=track.display,
                             source_artist=track.artist,
                             source_title=track.name,
+                            occurrence_id=occurrence_id,
+                            source_index=index,
+                            source_release=track.album,
+                            source_label=track.label,
+                            source_version=track.version,
                             spotify_uri=result["uri"],
                             spotify_name=matched_track.spotify_name,
                             spotify_artist=matched_track.spotify_artist,
+                            spotify_release=result.get("album", ""),
+                            spotify_duration=(
+                                int(result.get("duration_ms", 0)) // 1000
+                            ),
                             score=matched_track.score,
                             match_type=matched_track.match_type,
                             score_reasons=matched_track.score_reasons,
@@ -2843,7 +4028,9 @@ class Transfer:
                     return report
                 self._save_transfer(transfer_id, state)
 
-            source_ids_by_uri: dict[str, set[tuple[str, str, int]]] = {}
+            source_ids_by_uri: dict[
+                str, set[tuple[str, str, int]]
+            ] = {}
             for item in publication_items:
                 if not item.spotify_uri:
                     continue
@@ -3294,29 +4481,36 @@ class Transfer:
                 source_name=item.source_name,
                 source_artist=item.source_artist,
                 source_title=item.source_title,
+                source_release=item.source_release,
+                source_label=item.source_label,
+                source_version=item.source_version,
                 source_duration=item.source_duration,
                 spotify_uri=item.spotify_uri,
                 spotify_name=item.spotify_name,
                 spotify_artist=item.spotify_artist,
+                spotify_release=item.spotify_release,
+                spotify_duration=item.spotify_duration,
                 score=item.score,
                 match_type=item.match_type,
                 score_reasons=item.score_reasons,
+                authority_status=(
+                    "approved" if item.authoritative else "proposal"
+                ),
             )
             for item in items
         ]
 
     @staticmethod
-    def _is_new_reviewable_source(
-        track: Track, items: list[PublicationItem],
+    def _occurrence_id(transfer_id: str, index: int, track: Track) -> str:
+        material = f"{transfer_id}\0{index}\0{track.track_id}"
+        return hashlib.sha256(material.encode()).hexdigest()
+
+    @staticmethod
+    def _is_new_reviewable_occurrence(
+        occurrence_id: str, items: list[PublicationItem],
     ) -> bool:
-        if not track.track_id:
-            return False
-        return not any(
-            item.source_track_id == track.track_id
-            and item.source_artist == track.artist
-            and item.source_title == track.name
-            and item.source_duration == track.duration
-            for item in items
+        return bool(occurrence_id) and not any(
+            item.occurrence_id == occurrence_id for item in items
         )
 
     def _approved_available(self, spotify_uri: str) -> bool:

--- a/djsupport/web.py
+++ b/djsupport/web.py
@@ -13,7 +13,7 @@ from typing import Any, Callable
 from urllib.parse import urlparse
 from uuid import uuid4
 
-from fastapi import FastAPI, HTTPException
+from fastapi import FastAPI, HTTPException, Request as FastAPIRequest
 from fastapi.responses import (
     HTMLResponse,
     JSONResponse,
@@ -26,6 +26,11 @@ from spotipy.oauth2 import SpotifyOAuth
 
 from djsupport.report import SyncReport
 from djsupport.spotify import SCOPES
+from djsupport.local_audition import (
+    AuditionHandleUnavailable,
+    AuditionRangeNotSatisfiable,
+    LocalSourceAudition,
+)
 from djsupport.transfer import (
     AccountPublishingGuards,
     BatchPlanRequest,
@@ -35,7 +40,11 @@ from djsupport.transfer import (
     FilePublicationStorage,
     FileTransferStorage,
     MatchCacheKnowledge,
+    QualificationDecision,
+    QualificationRequest,
+    QualificationView,
     RekordboxPlaylistSource,
+    SpotifyPlaylistReviewRequired,
     SpotifyMatcher,
     Transfer,
     TransferAuthorization,
@@ -79,7 +88,47 @@ class RekordboxBatchRequest(BaseModel):
     prefix: str | None = "djsupport"
     no_cache: bool = False
     local_audio_identity: bool = False
+    local_audio_audition: bool = False
     confirm_expensive: bool = False
+    authorize_private_source: bool = False
+    authorize_spotify_write: bool = False
+
+
+class QualificationDraftRequest(BaseModel):
+    """One explicit Rekordbox playlist selected for local qualification."""
+
+    xml_path: str
+    transfer_id: str
+    playlist_reference: str | None = None
+    include_all: bool = False
+    no_cache: bool = False
+    local_audio_identity: bool = False
+    local_audio_audition: bool = False
+    authorize_private_source: bool = False
+
+    def transfer_request(self) -> RekordboxBatchRequest:
+        return RekordboxBatchRequest(
+            xml_path=self.xml_path,
+            playlists=(
+                [self.playlist_reference] if self.playlist_reference else []
+            ),
+            no_cache=self.no_cache,
+            local_audio_identity=self.local_audio_identity,
+            local_audio_audition=self.local_audio_audition,
+            authorize_private_source=self.authorize_private_source,
+        )
+
+
+class QualificationDecisionRequest(BaseModel):
+    item_id: str
+    decision: QualificationDecision
+    spotify_reference: str | None = None
+    reason: str | None = None
+    exclude: bool = False
+    authorize_private_source: bool = False
+
+
+class QualificationAuthorizationRequest(BaseModel):
     authorize_private_source: bool = False
     authorize_spotify_write: bool = False
 
@@ -134,6 +183,7 @@ def _default_transfer_factory(url_type: str, request: SyncRequest) -> Transfer:
 
 def _default_rekordbox_transfer_factory(
     request: RekordboxBatchRequest, execute_authorized: bool,
+    *, local_audition: LocalSourceAudition | None = None,
 ) -> Transfer:
     from djsupport.cache import MatchCache
     from djsupport.local_audio import ChromaprintLocalAudio
@@ -148,7 +198,9 @@ def _default_rekordbox_transfer_factory(
     return Transfer(
         source=RekordboxPlaylistSource(
             request.xml_path,
-            include_locations=request.local_audio_identity,
+            include_locations=(
+                request.local_audio_identity or request.local_audio_audition
+            ),
         ),
         spotify=(
             SpotifyMatcher(get_client()) if execute_authorized else object()
@@ -167,6 +219,9 @@ def _default_rekordbox_transfer_factory(
         local_audio=(
             ChromaprintLocalAudio() if request.local_audio_identity else None
         ),
+        local_audition=(
+            local_audition if request.local_audio_audition else None
+        ),
     )
 
 
@@ -182,15 +237,23 @@ def create_app(
     ] | None = None,
     auth_manager: Callable[[], SpotifyOAuth] | None = None,
     background_runner: Callable[[Callable, tuple], None] | None = None,
+    local_audition: LocalSourceAudition | None = None,
 ) -> FastAPI:
     """Create the web adapter with replaceable external-boundary wiring."""
     web_app = FastAPI(title="djsupport", lifespan=lifespan)
     web_app.mount("/static", StaticFiles(directory=str(STATIC_DIR)), name="static")
     make_transfer = transfer_factory or _default_transfer_factory
-    make_rekordbox_transfer = (
-        rekordbox_transfer_factory or _default_rekordbox_transfer_factory
-    )
+    audition = local_audition or LocalSourceAudition()
+    uses_default_rekordbox_wiring = rekordbox_transfer_factory is None
+    if rekordbox_transfer_factory is None:
+        def make_rekordbox_transfer(request, execute_authorized):
+            return _default_rekordbox_transfer_factory(
+                request, execute_authorized, local_audition=audition,
+            )
+    else:
+        make_rekordbox_transfer = rekordbox_transfer_factory
     run_background = background_runner or _thread_runner
+    qualification_contexts: dict[str, QualificationDraftRequest] = {}
 
     def oauth_manager():
         return auth_manager() if auth_manager is not None else _auth_manager()
@@ -224,7 +287,9 @@ def create_app(
         from djsupport.agent import capability_document
         from djsupport.local_audio import ChromaprintLocalAudio
 
-        return capability_document(ChromaprintLocalAudio().capability())
+        return capability_document(
+            ChromaprintLocalAudio().capability(), audition.capability(),
+        )
 
     @web_app.get("/auth/status")
     def auth_status():
@@ -294,6 +359,7 @@ def create_app(
             retry_days=request.retry_days,
             playlist_prefix=request.prefix,
             local_audio_identity=request.local_audio_identity,
+            local_audio_audition=request.local_audio_audition,
             confirm_expensive=request.confirm_expensive,
         ), TransferAuthorization(
             private_source=request.authorize_private_source,
@@ -355,6 +421,230 @@ def create_app(
     def execute_rekordbox_batch(request: RekordboxBatchRequest):
         return rekordbox_contract(request, execute=True)
 
+    def recover_qualification_context(
+        draft_id: str,
+    ) -> QualificationDraftRequest | None:
+        if not uses_default_rekordbox_wiring:
+            return None
+        from djsupport.config import ConfigManager
+
+        publication_path = default_publication_manifest_path()
+        storage = FileTransferStorage(
+            publication_path.with_suffix(".transfers.json")
+        )
+        draft = storage.load_qualification(draft_id)
+        if draft is None:
+            return None
+        state = storage.load_transfer(draft.transfer_id)
+        if state is None:
+            return None
+        config = ConfigManager()
+        config.load()
+        xml_path = config.get_rekordbox_xml_path()
+        if not xml_path or not Path(xml_path).is_file():
+            return None
+        return QualificationDraftRequest(
+            xml_path=xml_path,
+            transfer_id=draft.batch_id or draft.transfer_id,
+            playlist_reference=draft.source_reference,
+            no_cache=not state.request.get("retain_matching_knowledge", True),
+            local_audio_identity=state.request.get(
+                "local_audio_identity", False,
+            ),
+            local_audio_audition=state.request.get(
+                "local_audio_audition", False,
+            ),
+            authorize_private_source=True,
+        )
+
+    def qualification_transfer(draft_id: str) -> Transfer:
+        context = qualification_contexts.get(draft_id)
+        if context is None:
+            context = recover_qualification_context(draft_id)
+            if context is not None:
+                qualification_contexts[draft_id] = context
+        if context is None:
+            raise HTTPException(
+                status_code=404, detail="Qualification Draft is unavailable",
+            )
+        return make_rekordbox_transfer(context.transfer_request(), True)
+
+    @web_app.post("/rekordbox/qualification/drafts")
+    def create_qualification_draft(request: QualificationDraftRequest):
+        if not request.authorize_private_source:
+            raise HTTPException(
+                status_code=403, detail="Private source authorization required",
+            )
+        require_authenticated()
+        transfer = make_rekordbox_transfer(request.transfer_request(), True)
+        try:
+            view = transfer.obtain_qualification(
+                QualificationRequest(
+                    transfer_id=request.transfer_id,
+                    playlist_reference=request.playlist_reference,
+                    include_all=request.include_all,
+                ),
+                TransferAuthorization(private_source=True),
+            )
+        except SpotifyPlaylistReviewRequired as exc:
+            raise HTTPException(
+                status_code=409, detail="Qualification review required",
+            ) from exc
+        except (PermissionError, ValueError) as exc:
+            raise HTTPException(
+                status_code=400, detail="Qualification Draft is unavailable",
+            ) from exc
+        qualification_contexts[view.draft_id] = request
+        return _qualification_to_dict(view)
+
+    @web_app.get("/rekordbox/qualification/drafts/{draft_id}")
+    def get_qualification_draft(
+        draft_id: str, authorize_private_source: bool = False,
+    ):
+        if not authorize_private_source:
+            raise HTTPException(
+                status_code=403, detail="Private source authorization required",
+            )
+        require_authenticated()
+        try:
+            return _qualification_to_dict(
+                qualification_transfer(draft_id).qualification(draft_id)
+            )
+        except ValueError as exc:
+            raise HTTPException(
+                status_code=404, detail="Qualification Draft is unavailable",
+            ) from exc
+
+    @web_app.post("/rekordbox/qualification/drafts/{draft_id}/decisions")
+    def decide_qualification_item(
+        draft_id: str, request: QualificationDecisionRequest,
+    ):
+        if not request.authorize_private_source:
+            raise HTTPException(
+                status_code=403, detail="Private source authorization required",
+            )
+        require_authenticated()
+        try:
+            view = qualification_transfer(draft_id).record_qualification(
+                draft_id,
+                request.item_id,
+                request.decision,
+                spotify_reference=request.spotify_reference,
+                reason=request.reason,
+                exclude=request.exclude,
+            )
+        except ValueError as exc:
+            raise HTTPException(
+                status_code=400, detail="Qualification decision is invalid",
+            ) from exc
+        return _qualification_to_dict(view)
+
+    @web_app.post(
+        "/rekordbox/qualification/drafts/{draft_id}/audition/{item_id}"
+    )
+    def audition_qualification_item(
+        draft_id: str,
+        item_id: str,
+        request: QualificationAuthorizationRequest,
+    ):
+        if not request.authorize_private_source:
+            raise HTTPException(
+                status_code=403, detail="Private source authorization required",
+            )
+        require_authenticated()
+        try:
+            result = qualification_transfer(draft_id).audition_qualification(
+                draft_id,
+                item_id,
+                TransferAuthorization(private_source=True),
+            )
+        except (PermissionError, ValueError) as exc:
+            raise HTTPException(
+                status_code=400, detail="Local audition is unavailable",
+            ) from exc
+        response = {
+            "status": result.status,
+            "media_type": result.media_type,
+            "content_length": result.content_length,
+            "expires_in": result.expires_in,
+        }
+        if result.status == "available" and result.handle:
+            response["media_url"] = (
+                f"/rekordbox/qualification/media/{result.handle}"
+            )
+        elif result.reason:
+            response["reason"] = result.reason
+        return response
+
+    @web_app.post("/rekordbox/qualification/drafts/{draft_id}/apply")
+    def apply_qualification_draft(
+        draft_id: str, request: QualificationAuthorizationRequest,
+    ):
+        if not request.authorize_private_source:
+            raise HTTPException(
+                status_code=403, detail="Private source authorization required",
+            )
+        if not request.authorize_spotify_write:
+            raise HTTPException(
+                status_code=403, detail="Spotify write authorization required",
+            )
+        require_authenticated()
+        try:
+            outcome = qualification_transfer(draft_id).apply_qualification(
+                draft_id,
+                TransferAuthorization(private_source=True, spotify_write=True),
+            )
+        except SpotifyPlaylistReviewRequired as exc:
+            raise HTTPException(
+                status_code=409, detail="Qualification review required",
+            ) from exc
+        except (PermissionError, ValueError) as exc:
+            raise HTTPException(
+                status_code=400, detail="Qualification Draft cannot be applied",
+            ) from exc
+        return {
+            "draft_id": outcome.draft_id,
+            "status": outcome.status.value,
+            "applied_items": outcome.applied_items,
+            "authority": "none",
+            "next_actions": list(outcome.next_actions),
+        }
+
+    @web_app.get("/rekordbox/qualification/media/{handle}")
+    def qualification_media(handle: str, request: FastAPIRequest):
+        client_host = request.client.host if request.client else ""
+        if client_host not in {"127.0.0.1", "::1", "localhost", "testclient"}:
+            raise HTTPException(status_code=403, detail="Local media only")
+        try:
+            stream = audition.stream(handle, request.headers.get("range"))
+        except AuditionHandleUnavailable as exc:
+            raise HTTPException(
+                status_code=404, detail="Local audition is unavailable",
+            ) from exc
+        except AuditionRangeNotSatisfiable as exc:
+            raise HTTPException(
+                status_code=416,
+                detail="Audition byte range is not satisfiable",
+                headers={"Content-Range": f"bytes */{exc.total_size}"},
+            ) from exc
+        headers = {
+            "Accept-Ranges": "bytes",
+            "Content-Length": str(stream.content_length),
+            "Cache-Control": "private, no-store",
+            "Content-Security-Policy": "default-src 'none'; media-src 'self'",
+            "Cross-Origin-Resource-Policy": "same-origin",
+            "Referrer-Policy": "no-referrer",
+            "X-Content-Type-Options": "nosniff",
+        }
+        if stream.content_range is not None:
+            headers["Content-Range"] = stream.content_range
+        return StreamingResponse(
+            stream.body,
+            status_code=stream.status_code,
+            media_type=stream.media_type,
+            headers=headers,
+        )
+
     @web_app.get("/sync/{transfer_id}/progress")
     async def sync_progress(transfer_id: str):
         async def event_stream():
@@ -409,6 +699,11 @@ def create_app(
     def index():
         return HTMLResponse((STATIC_DIR / "index.html").read_text())
 
+    @web_app.get("/qualification/{draft_id}")
+    def qualification_workspace(draft_id: str):
+        del draft_id
+        return HTMLResponse((STATIC_DIR / "index.html").read_text())
+
     return web_app
 
 
@@ -417,6 +712,70 @@ def _run_transfer(transfer: Transfer, request: TransferRequest) -> None:
         transfer.execute(request)
     except Exception:
         logger.exception("Transfer failed")
+
+
+def _qualification_to_dict(view: QualificationView) -> dict[str, Any]:
+    """Render only review facts; filesystem references stay behind Transfer."""
+    items = []
+    for item in view.items:
+        spotify_id = None
+        prefix = "spotify:track:"
+        if item.spotify_uri.startswith(prefix):
+            candidate = item.spotify_uri[len(prefix):]
+            if len(candidate) == 22 and candidate.isalnum():
+                spotify_id = candidate
+        items.append({
+            "item_id": item.item_id,
+            "source": {
+                "artist": item.source_artist,
+                "title": item.source_title,
+                "release": item.source_release,
+                "label": item.source_label,
+                "version": item.source_version,
+                "duration": item.source_duration,
+            },
+            "spotify": {
+                "uri": item.spotify_uri,
+                "name": item.spotify_name,
+                "artist": item.spotify_artist,
+                "release": item.spotify_release,
+                "duration": item.spotify_duration,
+                "embed_url": (
+                    f"https://open.spotify.com/embed/track/{spotify_id}"
+                    if spotify_id else None
+                ),
+                "open_url": (
+                    f"https://open.spotify.com/track/{spotify_id}"
+                    if spotify_id else None
+                ),
+            },
+            "proposal": {
+                "score": item.score,
+                "match_type": item.match_type,
+                "score_reasons": list(item.score_reasons),
+                "authority_status": item.authority_status,
+                "attention_reasons": list(item.attention_reasons),
+            },
+            "audition_status": item.audition_status,
+            "audition_reason": item.audition_reason,
+            "decision": item.decision.value if item.decision else None,
+            "correction_uri": item.correction_uri,
+            "deferred_reason": item.deferred_reason,
+            "excluded": item.excluded,
+        })
+    return {
+        "draft_id": view.draft_id,
+        "transfer_id": view.transfer_id,
+        "status": view.status.value,
+        "authority": "none",
+        "include_all": view.include_all,
+        "counts": {
+            "items": len(view.items),
+            "pending": view.pending,
+            "deferred": view.deferred,
+        },
+        "items": items,
+    }
 
 
 def _report_to_dict(report: SyncReport) -> dict[str, Any]:

--- a/djsupport/web.py
+++ b/djsupport/web.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import ipaddress
 import json
 import logging
 import threading
@@ -44,6 +45,7 @@ from djsupport.transfer import (
     QualificationRequest,
     QualificationView,
     RekordboxPlaylistSource,
+    SpotifyPlaylistChanged,
     SpotifyPlaylistReviewRequired,
     SpotifyMatcher,
     Transfer,
@@ -131,6 +133,26 @@ class QualificationDecisionRequest(BaseModel):
 class QualificationAuthorizationRequest(BaseModel):
     authorize_private_source: bool = False
     authorize_spotify_write: bool = False
+
+
+class QualificationLinkRequest(BaseModel):
+    publishing_transfer_id: str
+    authorize_private_source: bool = False
+
+
+QUALIFICATION_PRIVACY_HEADERS = {
+    "Cache-Control": "private, no-store",
+    "Content-Security-Policy": (
+        "default-src 'self'; script-src 'self' 'unsafe-inline'; "
+        "style-src 'self' 'unsafe-inline'; connect-src 'self'; "
+        "img-src 'self' data:; media-src 'self'; "
+        "frame-src https://open.spotify.com"
+    ),
+    "Cross-Origin-Resource-Policy": "same-origin",
+    "Referrer-Policy": "no-referrer",
+    "X-Content-Type-Options": "nosniff",
+    "X-Frame-Options": "DENY",
+}
 
 
 def _auth_manager() -> SpotifyOAuth:
@@ -255,6 +277,35 @@ def create_app(
     run_background = background_runner or _thread_runner
     qualification_contexts: dict[str, QualificationDraftRequest] = {}
 
+    @web_app.middleware("http")
+    async def qualification_privacy(request: FastAPIRequest, call_next):
+        qualification_route = (
+            request.url.path.startswith("/rekordbox/qualification/")
+            or request.url.path.startswith("/qualification/")
+        )
+        if qualification_route:
+            try:
+                require_qualification_loopback(request)
+            except HTTPException as exc:
+                response = JSONResponse(
+                    status_code=exc.status_code,
+                    content={"detail": exc.detail},
+                )
+            else:
+                response = await call_next(request)
+            privacy_headers = dict(QUALIFICATION_PRIVACY_HEADERS)
+            if request.url.path.startswith(
+                "/rekordbox/qualification/media/"
+            ):
+                privacy_headers["Content-Security-Policy"] = (
+                    "default-src 'none'; media-src 'self'"
+                )
+            for name, value in privacy_headers.items():
+                response.headers[name] = value
+        else:
+            response = await call_next(request)
+        return response
+
     def oauth_manager():
         return auth_manager() if auth_manager is not None else _auth_manager()
 
@@ -263,6 +314,48 @@ def create_app(
         token = mgr.get_cached_token()
         if not token or mgr.is_token_expired(token):
             raise HTTPException(status_code=401, detail="Not authenticated with Spotify")
+
+    def require_qualification_loopback(request: FastAPIRequest) -> None:
+        peer = request.client.host if request.client else ""
+
+        def is_loopback(value: str, *, allow_test: bool = False) -> bool:
+            if value == "localhost" or (allow_test and value == "testserver"):
+                return True
+            try:
+                return ipaddress.ip_address(value).is_loopback
+            except ValueError:
+                return False
+
+        peer_is_test = peer == "testclient"
+        if not (peer_is_test or is_loopback(peer)):
+            raise HTTPException(
+                status_code=403,
+                detail="Qualification Workspace is available only on loopback",
+            )
+        host_header = request.headers.get("host", "")
+        try:
+            request_host = urlparse(f"//{host_header}").hostname or ""
+        except ValueError:
+            request_host = ""
+        if not is_loopback(request_host, allow_test=peer_is_test):
+            raise HTTPException(
+                status_code=403,
+                detail="Qualification Workspace requires a loopback Host",
+            )
+        if request.method not in {"GET", "HEAD", "OPTIONS"}:
+            origin = request.headers.get("origin")
+            if origin:
+                try:
+                    origin_host = urlparse(origin).hostname or ""
+                except ValueError:
+                    origin_host = ""
+                if not is_loopback(origin_host, allow_test=peer_is_test):
+                    raise HTTPException(
+                        status_code=403,
+                        detail=(
+                            "Qualification Workspace requires a loopback Origin"
+                        ),
+                    )
 
     def transfer_for(transfer_id: str, request: SyncRequest | None = None):
         probe_request = request or SyncRequest(
@@ -457,32 +550,86 @@ def create_app(
             authorize_private_source=True,
         )
 
+    def durable_qualification_context(
+        request: QualificationDraftRequest,
+    ) -> QualificationDraftRequest:
+        """Derive adapter wiring from durable Transfer intent, not web input."""
+        if not uses_default_rekordbox_wiring:
+            return request
+        publication_path = default_publication_manifest_path()
+        storage = FileTransferStorage(
+            publication_path.with_suffix(".transfers.json")
+        )
+        batch = storage.load_batch(request.transfer_id)
+        transfer_id = request.transfer_id
+        if batch is not None:
+            selected = [
+                item for item in batch.playlists
+                if item.reference == request.playlist_reference
+            ]
+            if len(selected) != 1:
+                return request
+            transfer_id = selected[0].transfer_id
+        state = storage.load_transfer(transfer_id)
+        if state is None:
+            return request
+        return request.copy(update={
+            "no_cache": not state.request.get(
+                "retain_matching_knowledge", True,
+            ),
+            "local_audio_identity": state.request.get(
+                "local_audio_identity", False,
+            ),
+            "local_audio_audition": state.request.get(
+                "local_audio_audition", False,
+            ),
+        })
+
     def qualification_transfer(draft_id: str) -> Transfer:
-        context = qualification_contexts.get(draft_id)
-        if context is None:
+        context = None
+        if uses_default_rekordbox_wiring:
             context = recover_qualification_context(draft_id)
             if context is not None:
                 qualification_contexts[draft_id] = context
+        else:
+            context = qualification_contexts.get(draft_id)
         if context is None:
+            if uses_default_rekordbox_wiring:
+                publication_path = default_publication_manifest_path()
+                storage = FileTransferStorage(
+                    publication_path.with_suffix(".transfers.json")
+                )
+                if storage.load_qualification(draft_id) is not None:
+                    raise HTTPException(
+                        status_code=409,
+                        detail=(
+                            "Qualification source evidence is unavailable; "
+                            "review required"
+                        ),
+                    )
             raise HTTPException(
                 status_code=404, detail="Qualification Draft is unavailable",
             )
         return make_rekordbox_transfer(context.transfer_request(), True)
 
     @web_app.post("/rekordbox/qualification/drafts")
-    def create_qualification_draft(request: QualificationDraftRequest):
-        if not request.authorize_private_source:
+    def create_qualification_draft(
+        request: FastAPIRequest, payload: QualificationDraftRequest,
+    ):
+        require_qualification_loopback(request)
+        if not payload.authorize_private_source:
             raise HTTPException(
                 status_code=403, detail="Private source authorization required",
             )
         require_authenticated()
-        transfer = make_rekordbox_transfer(request.transfer_request(), True)
+        context = durable_qualification_context(payload)
+        transfer = make_rekordbox_transfer(context.transfer_request(), True)
         try:
             view = transfer.obtain_qualification(
                 QualificationRequest(
-                    transfer_id=request.transfer_id,
-                    playlist_reference=request.playlist_reference,
-                    include_all=request.include_all,
+                    transfer_id=payload.transfer_id,
+                    playlist_reference=payload.playlist_reference,
+                    include_all=payload.include_all,
                 ),
                 TransferAuthorization(private_source=True),
             )
@@ -494,13 +641,16 @@ def create_app(
             raise HTTPException(
                 status_code=400, detail="Qualification Draft is unavailable",
             ) from exc
-        qualification_contexts[view.draft_id] = request
+        qualification_contexts[view.draft_id] = context
         return _qualification_to_dict(view)
 
     @web_app.get("/rekordbox/qualification/drafts/{draft_id}")
     def get_qualification_draft(
-        draft_id: str, authorize_private_source: bool = False,
+        draft_id: str,
+        request: FastAPIRequest,
+        authorize_private_source: bool = False,
     ):
+        require_qualification_loopback(request)
         if not authorize_private_source:
             raise HTTPException(
                 status_code=403, detail="Private source authorization required",
@@ -508,7 +658,9 @@ def create_app(
         require_authenticated()
         try:
             return _qualification_to_dict(
-                qualification_transfer(draft_id).qualification(draft_id)
+                qualification_transfer(draft_id).qualification(
+                    draft_id, TransferAuthorization(private_source=True),
+                )
             )
         except ValueError as exc:
             raise HTTPException(
@@ -517,9 +669,12 @@ def create_app(
 
     @web_app.post("/rekordbox/qualification/drafts/{draft_id}/decisions")
     def decide_qualification_item(
-        draft_id: str, request: QualificationDecisionRequest,
+        draft_id: str,
+        request: FastAPIRequest,
+        payload: QualificationDecisionRequest,
     ):
-        if not request.authorize_private_source:
+        require_qualification_loopback(request)
+        if not payload.authorize_private_source:
             raise HTTPException(
                 status_code=403, detail="Private source authorization required",
             )
@@ -527,11 +682,12 @@ def create_app(
         try:
             view = qualification_transfer(draft_id).record_qualification(
                 draft_id,
-                request.item_id,
-                request.decision,
-                spotify_reference=request.spotify_reference,
-                reason=request.reason,
-                exclude=request.exclude,
+                payload.item_id,
+                payload.decision,
+                TransferAuthorization(private_source=True),
+                spotify_reference=payload.spotify_reference,
+                reason=payload.reason,
+                exclude=payload.exclude,
             )
         except ValueError as exc:
             raise HTTPException(
@@ -540,14 +696,53 @@ def create_app(
         return _qualification_to_dict(view)
 
     @web_app.post(
+        "/rekordbox/qualification/drafts/{draft_id}/include-all"
+    )
+    def include_all_qualification_items(
+        draft_id: str,
+        request: FastAPIRequest,
+        payload: QualificationAuthorizationRequest,
+    ):
+        require_qualification_loopback(request)
+        if not payload.authorize_private_source:
+            raise HTTPException(
+                status_code=403, detail="Private source authorization required",
+            )
+        require_authenticated()
+        transfer = qualification_transfer(draft_id)
+        context = qualification_contexts[draft_id]
+        try:
+            view = transfer.obtain_qualification(
+                QualificationRequest(
+                    transfer_id=context.transfer_id,
+                    playlist_reference=context.playlist_reference,
+                    include_all=True,
+                ),
+                TransferAuthorization(private_source=True),
+            )
+        except SpotifyPlaylistReviewRequired as exc:
+            raise HTTPException(
+                status_code=409, detail="Qualification review required",
+            ) from exc
+        except (PermissionError, ValueError) as exc:
+            raise HTTPException(
+                status_code=400,
+                detail="Qualification Draft cannot include all proposals",
+            ) from exc
+        qualification_contexts[view.draft_id] = context
+        return _qualification_to_dict(view)
+
+    @web_app.post(
         "/rekordbox/qualification/drafts/{draft_id}/audition/{item_id}"
     )
     def audition_qualification_item(
         draft_id: str,
         item_id: str,
-        request: QualificationAuthorizationRequest,
+        request: FastAPIRequest,
+        payload: QualificationAuthorizationRequest,
     ):
-        if not request.authorize_private_source:
+        require_qualification_loopback(request)
+        if not payload.authorize_private_source:
             raise HTTPException(
                 status_code=403, detail="Private source authorization required",
             )
@@ -558,6 +753,10 @@ def create_app(
                 item_id,
                 TransferAuthorization(private_source=True),
             )
+        except (SpotifyPlaylistChanged, SpotifyPlaylistReviewRequired) as exc:
+            raise HTTPException(
+                status_code=409, detail="Qualification review required",
+            ) from exc
         except (PermissionError, ValueError) as exc:
             raise HTTPException(
                 status_code=400, detail="Local audition is unavailable",
@@ -578,13 +777,16 @@ def create_app(
 
     @web_app.post("/rekordbox/qualification/drafts/{draft_id}/apply")
     def apply_qualification_draft(
-        draft_id: str, request: QualificationAuthorizationRequest,
+        draft_id: str,
+        request: FastAPIRequest,
+        payload: QualificationAuthorizationRequest,
     ):
-        if not request.authorize_private_source:
+        require_qualification_loopback(request)
+        if not payload.authorize_private_source:
             raise HTTPException(
                 status_code=403, detail="Private source authorization required",
             )
-        if not request.authorize_spotify_write:
+        if not payload.authorize_spotify_write:
             raise HTTPException(
                 status_code=403, detail="Spotify write authorization required",
             )
@@ -594,7 +796,7 @@ def create_app(
                 draft_id,
                 TransferAuthorization(private_source=True, spotify_write=True),
             )
-        except SpotifyPlaylistReviewRequired as exc:
+        except (SpotifyPlaylistChanged, SpotifyPlaylistReviewRequired) as exc:
             raise HTTPException(
                 status_code=409, detail="Qualification review required",
             ) from exc
@@ -610,31 +812,150 @@ def create_app(
             "next_actions": list(outcome.next_actions),
         }
 
+    @web_app.post("/rekordbox/qualification/drafts/{draft_id}/link")
+    def link_qualification_draft(
+        draft_id: str,
+        request: FastAPIRequest,
+        payload: QualificationLinkRequest,
+    ):
+        require_qualification_loopback(request)
+        if not payload.authorize_private_source:
+            raise HTTPException(
+                status_code=403, detail="Private source authorization required",
+            )
+        require_authenticated()
+        try:
+            view = qualification_transfer(draft_id).link_qualification(
+                draft_id,
+                payload.publishing_transfer_id,
+                TransferAuthorization(private_source=True),
+            )
+        except (SpotifyPlaylistChanged, SpotifyPlaylistReviewRequired) as exc:
+            raise HTTPException(
+                status_code=409, detail="Qualification review required",
+            ) from exc
+        except (PermissionError, ValueError) as exc:
+            raise HTTPException(
+                status_code=400, detail="Qualification Draft cannot be linked",
+            ) from exc
+        return _qualification_to_dict(view)
+
+    @web_app.post("/rekordbox/qualification/drafts/{draft_id}/discard")
+    def discard_qualification_draft(
+        draft_id: str,
+        request: FastAPIRequest,
+        payload: QualificationAuthorizationRequest,
+    ):
+        require_qualification_loopback(request)
+        if not payload.authorize_private_source:
+            raise HTTPException(
+                status_code=403, detail="Private source authorization required",
+            )
+        require_authenticated()
+        try:
+            view = qualification_transfer(draft_id).discard_qualification(
+                draft_id, TransferAuthorization(private_source=True),
+            )
+        except (PermissionError, ValueError) as exc:
+            raise HTTPException(
+                status_code=400, detail="Qualification Draft cannot be discarded",
+            ) from exc
+        return _qualification_to_dict(view)
+
+    @web_app.post("/rekordbox/qualification/drafts/{draft_id}/supersede")
+    def supersede_qualification_draft(
+        draft_id: str,
+        request: FastAPIRequest,
+        payload: QualificationAuthorizationRequest,
+    ):
+        require_qualification_loopback(request)
+        if not payload.authorize_private_source:
+            raise HTTPException(
+                status_code=403, detail="Private source authorization required",
+            )
+        require_authenticated()
+        try:
+            view = qualification_transfer(draft_id).supersede_qualification(
+                draft_id, TransferAuthorization(private_source=True),
+            )
+        except SpotifyPlaylistReviewRequired as exc:
+            raise HTTPException(
+                status_code=409, detail="Qualification review required",
+            ) from exc
+        except (PermissionError, ValueError) as exc:
+            raise HTTPException(
+                status_code=400, detail="Qualification Draft cannot be superseded",
+            ) from exc
+        qualification_contexts[view.draft_id] = qualification_contexts[draft_id]
+        return _qualification_to_dict(view)
+
+    @web_app.post("/rekordbox/qualification/drafts/{draft_id}/approve")
+    def approve_qualification_draft(
+        draft_id: str,
+        request: FastAPIRequest,
+        payload: QualificationAuthorizationRequest,
+    ):
+        require_qualification_loopback(request)
+        if not payload.authorize_private_source:
+            raise HTTPException(
+                status_code=403, detail="Private source authorization required",
+            )
+        require_authenticated()
+        try:
+            outcome = qualification_transfer(draft_id).approve_qualification(
+                draft_id,
+                TransferAuthorization(private_source=True),
+            )
+        except (SpotifyPlaylistChanged, SpotifyPlaylistReviewRequired) as exc:
+            raise HTTPException(
+                status_code=409, detail="Qualification review required",
+            ) from exc
+        except (PermissionError, ValueError) as exc:
+            raise HTTPException(
+                status_code=400, detail="Qualification Draft cannot be approved",
+            ) from exc
+        return {
+            "draft_id": draft_id,
+            "status": outcome.status.value.replace(" ", "_"),
+            "authority": (
+                "playlist_approval"
+                if outcome.status.value == "approved" else "none"
+            ),
+            "counts": {
+                "approved": len(outcome.approved),
+                "rejected": len(outcome.rejected),
+                "collisions": len(outcome.collisions),
+                "corrections": len(outcome.corrections),
+            },
+            "next_actions": (
+                ["review"] if outcome.status.value == "needs review" else []
+            ),
+        }
+
     @web_app.get("/rekordbox/qualification/media/{handle}")
     def qualification_media(handle: str, request: FastAPIRequest):
-        client_host = request.client.host if request.client else ""
-        if client_host not in {"127.0.0.1", "::1", "localhost", "testclient"}:
-            raise HTTPException(status_code=403, detail="Local media only")
+        require_qualification_loopback(request)
+        privacy_headers = QUALIFICATION_PRIVACY_HEADERS
         try:
             stream = audition.stream(handle, request.headers.get("range"))
         except AuditionHandleUnavailable as exc:
             raise HTTPException(
                 status_code=404, detail="Local audition is unavailable",
+                headers=privacy_headers,
             ) from exc
         except AuditionRangeNotSatisfiable as exc:
             raise HTTPException(
                 status_code=416,
                 detail="Audition byte range is not satisfiable",
-                headers={"Content-Range": f"bytes */{exc.total_size}"},
+                headers={
+                    **privacy_headers,
+                    "Content-Range": f"bytes */{exc.total_size}",
+                },
             ) from exc
         headers = {
+            **privacy_headers,
             "Accept-Ranges": "bytes",
             "Content-Length": str(stream.content_length),
-            "Cache-Control": "private, no-store",
-            "Content-Security-Policy": "default-src 'none'; media-src 'self'",
-            "Cross-Origin-Resource-Policy": "same-origin",
-            "Referrer-Policy": "no-referrer",
-            "X-Content-Type-Options": "nosniff",
         }
         if stream.content_range is not None:
             headers["Content-Range"] = stream.content_range
@@ -700,7 +1021,8 @@ def create_app(
         return HTMLResponse((STATIC_DIR / "index.html").read_text())
 
     @web_app.get("/qualification/{draft_id}")
-    def qualification_workspace(draft_id: str):
+    def qualification_workspace(draft_id: str, request: FastAPIRequest):
+        require_qualification_loopback(request)
         del draft_id
         return HTMLResponse((STATIC_DIR / "index.html").read_text())
 
@@ -755,7 +1077,14 @@ def _qualification_to_dict(view: QualificationView) -> dict[str, Any]:
                 "score_reasons": list(item.score_reasons),
                 "authority_status": item.authority_status,
                 "attention_reasons": list(item.attention_reasons),
+                "availability_status": item.availability_status,
+                "availability_reason": item.availability_reason,
+                "availability_checked_at": item.availability_checked_at,
+                "availability_source": item.availability_source,
             },
+            "permitted_actions": [
+                action.value for action in item.permitted_actions
+            ],
             "audition_status": item.audition_status,
             "audition_reason": item.audition_reason,
             "decision": item.decision.value if item.decision else None,
@@ -768,12 +1097,16 @@ def _qualification_to_dict(view: QualificationView) -> dict[str, Any]:
         "transfer_id": view.transfer_id,
         "status": view.status.value,
         "authority": "none",
+        "next_actions": list(view.next_actions),
         "include_all": view.include_all,
         "counts": {
             "items": len(view.items),
             "pending": view.pending,
             "deferred": view.deferred,
         },
+        "current_item_id": (
+            view.current_item.item_id if view.current_item is not None else None
+        ),
         "items": items,
     }
 

--- a/docs/backup-and-restore.md
+++ b/docs/backup-and-restore.md
@@ -5,9 +5,11 @@ It includes matching knowledge, Transfer and publication state, migration
 records, and privacy-screened reports. Credentials and unrelated files are not
 included.
 
-Matching-knowledge schema 2 includes private local-audio observations and
-account-scoped Approved Match associations. Transfer-state schema 4 includes
-the opt-in, completed evidence checkpoints, and private Qualification Drafts.
+Matching-knowledge schema 3 includes private local-audio observations,
+account-scoped Approved Match associations, and retained Spotify review facts.
+Publication schema 6 retains the corresponding review and availability facts.
+Transfer-state schema 4 includes the opt-in, completed evidence checkpoints,
+and private Qualification Drafts.
 Both are backed up and restored as private application data. Audition handles,
 audio, paths, filenames, and fingerprints are never part of a Qualification
 Draft. A differing copy of the same draft requires an explicit restore choice;

--- a/docs/backup-and-restore.md
+++ b/docs/backup-and-restore.md
@@ -6,9 +6,12 @@ records, and privacy-screened reports. Credentials and unrelated files are not
 included.
 
 Matching-knowledge schema 2 includes private local-audio observations and
-account-scoped Approved Match associations. Transfer-state schema 3 includes
-the opt-in and completed evidence checkpoint handles. Both are backed up and
-restored as private application data. Conflicting local-audio authority requires
+account-scoped Approved Match associations. Transfer-state schema 4 includes
+the opt-in, completed evidence checkpoints, and private Qualification Drafts.
+Both are backed up and restored as private application data. Audition handles,
+audio, paths, filenames, and fingerprints are never part of a Qualification
+Draft. A differing copy of the same draft requires an explicit restore choice;
+neither draft silently wins. Conflicting local-audio authority requires
 an explicit restore choice identified by a privacy-safe hashed label; reports
 and archive manifests do not print fingerprints or source paths.
 

--- a/docs/upgrading.md
+++ b/docs/upgrading.md
@@ -43,8 +43,11 @@ matching-knowledge schemas are rejected without rewriting the private file.
 
 ## To the Qualification Workspace release
 
-The next Transfer-state write upgrades retained state to schema 4 and adds a
-`qualifications` collection. Transfer schemas 1–3 remain readable. Qualification
+The next durable writes upgrade Transfer state to schema 4, matching knowledge
+to schema 3, and publication manifests to schema 6. Earlier supported schemas
+remain readable. Transfer schema 4 adds a `qualifications` collection; matching
+schema 3 and publication schema 6 retain rich Spotify release, duration, and
+truthful availability context for later Approved Match reuse. Qualification
 Drafts are additive private state: they do not become matching knowledge or
 Approval during upgrade. Backup/restore merges distinct drafts and requires an
 explicit current/archive choice when the same draft differs, so neither state

--- a/docs/upgrading.md
+++ b/docs/upgrading.md
@@ -41,6 +41,16 @@ cannot resume stale work. New fingerprint evidence remains in private
 application data and is never added to Git or generated reports. Unsupported
 matching-knowledge schemas are rejected without rewriting the private file.
 
+## To the Qualification Workspace release
+
+The next Transfer-state write upgrades retained state to schema 4 and adds a
+`qualifications` collection. Transfer schemas 1–3 remain readable. Qualification
+Drafts are additive private state: they do not become matching knowledge or
+Approval during upgrade. Backup/restore merges distinct drafts and requires an
+explicit current/archive choice when the same draft differs, so neither state
+wins silently. Audition handles, audio bytes, paths, filenames, and fingerprints
+are not stored in a draft.
+
 ## From 0.3.0
 
 DJ Support does not migrate working-directory data automatically. Keep the old

--- a/tests/test_agent_cli.py
+++ b/tests/test_agent_cli.py
@@ -14,7 +14,7 @@ def test_capabilities_json_does_not_require_xml_or_spotify(monkeypatch):
 
     assert result.exit_code == 0
     assert json.loads(result.output) == {
-        "contract_version": 1,
+        "contract_version": 2,
         "phase": "capability",
         "status": "ready",
         "capabilities": {
@@ -23,6 +23,17 @@ def test_capabilities_json_does_not_require_xml_or_spotify(monkeypatch):
                 "algorithm": "chromaprint",
                 "algorithm_version": None,
                 "reason": "binary_unavailable",
+                "default_enabled": False,
+                "authority": "approved_match_reuse_only",
+                "first_run_discovery": "none_until_explicit_approval",
+                "execution_order": "after_retained_knowledge_before_spotify_search",
+            },
+            "local_audio_audition": {
+                "available": True,
+                "default_enabled": False,
+                "authority": "none",
+                "requires_local_audio_identity": False,
+                "requires_durable_matching_knowledge": False,
             },
         },
         "next_actions": ["plan"],
@@ -45,7 +56,7 @@ def test_sync_json_requires_explicit_private_source_authorization(monkeypatch):
 
     assert result.exit_code == 2
     assert json.loads(result.output) == {
-        "contract_version": 1,
+        "contract_version": 2,
         "phase": "plan",
         "status": "authorization_required",
         "required_authorizations": ["private_source"],
@@ -87,7 +98,7 @@ def test_json_source_error_is_structured_and_does_not_echo_private_path(tmp_path
 
     assert result.exit_code == 2
     assert json.loads(result.output) == {
-        "contract_version": 1,
+        "contract_version": 2,
         "phase": "plan",
         "status": "error",
         "error": {"code": "private_source_unavailable"},
@@ -147,7 +158,7 @@ def test_authorized_sync_json_returns_only_structured_outcome(
 
     assert result.exit_code == 0, result.output
     outcome = json.loads(result.output)
-    assert outcome["contract_version"] == 1
+    assert outcome["contract_version"] == 2
     assert outcome["phase"] == "outcome"
     assert outcome["status"] == "completed"
     assert outcome["counts"] == {
@@ -162,3 +173,71 @@ def test_authorized_sync_json_returns_only_structured_outcome(
     }
     assert "My Playlists" not in result.output
     assert "Solomun" not in result.output
+
+
+def test_audition_intent_is_independent_and_compatible_with_no_cache(
+    monkeypatch, tmp_path,
+):
+    class Spotify:
+        def account_id(self):
+            return "spotify-account-one"
+
+        def match(self, track, threshold):
+            return {
+                "uri": f"spotify:track:{track.track_id}",
+                "name": "Synthetic Result", "artist": "Synthetic Artist",
+                "score": 95.0, "match_type": "exact",
+            }
+
+    monkeypatch.setattr("djsupport.cli.get_client", lambda: object())
+    monkeypatch.setattr(
+        "djsupport.transfer.SpotifyMatcher", lambda client: Spotify(),
+    )
+
+    result = CliRunner().invoke(cli, [
+        "sync", "tests/fixtures/library.xml",
+        "--playlist", "My Playlists/Peak Time",
+        "--json", "--authorize-private-source",
+        "--local-audio-audition", "--no-cache",
+        "--state-path", str(tmp_path / "publications.json"),
+    ])
+
+    assert result.exit_code == 2, result.output
+    document = json.loads(result.output)
+    assert document["requested_effects"] == [
+        "private_source", "local_audio_audition", "spotify_write",
+    ]
+    assert document["local_audio"]["identity_requested"] is False
+    assert document["local_audio"]["audition_requested"] is True
+
+
+def test_qualification_cli_denies_private_intake_through_versioned_contract(
+    tmp_path,
+):
+    private_path = tmp_path / "owner-library-name.xml"
+
+    result = CliRunner().invoke(cli, [
+        "qualification", "batch-opaque-1", str(private_path),
+        "--playlist", "Private/Selection", "--json",
+    ])
+
+    assert result.exit_code == 2
+    assert json.loads(result.output) == {
+        "contract_version": 2,
+        "phase": "qualification",
+        "status": "authorization_required",
+        "required_authorizations": ["private_source"],
+        "next_actions": ["authorize_private_source"],
+    }
+    assert "owner-library-name" not in result.output
+
+
+def test_qualification_cli_exposes_explicit_draft_and_apply_operations():
+    result = CliRunner().invoke(cli, ["qualification", "--help"])
+
+    assert result.exit_code == 0
+    assert "--item-id" in result.output
+    assert "--decision" in result.output
+    assert "--apply" in result.output
+    assert "--authorize-private-source" in result.output
+    assert "--authorize-spotify-write" in result.output

--- a/tests/test_agent_cli.py
+++ b/tests/test_agent_cli.py
@@ -211,6 +211,26 @@ def test_audition_intent_is_independent_and_compatible_with_no_cache(
     assert document["local_audio"]["audition_requested"] is True
 
 
+def test_human_audition_intent_requires_private_source_authorization_before_intake(
+    monkeypatch,
+):
+    monkeypatch.setattr(
+        "djsupport.cli._resolve_xml_path",
+        lambda path: (_ for _ in ()).throw(
+            AssertionError("private source intake must stay untouched")
+        ),
+    )
+
+    result = CliRunner().invoke(cli, [
+        "sync", "tests/fixtures/library.xml",
+        "--playlist", "My Playlists/Peak Time",
+        "--local-audio-audition",
+    ])
+
+    assert result.exit_code == 2
+    assert "--authorize-private-source" in result.output
+
+
 def test_qualification_cli_denies_private_intake_through_versioned_contract(
     tmp_path,
 ):
@@ -228,6 +248,35 @@ def test_qualification_cli_denies_private_intake_through_versioned_contract(
         "status": "authorization_required",
         "required_authorizations": ["private_source"],
         "next_actions": ["authorize_private_source"],
+    }
+    assert "owner-library-name" not in result.output
+
+
+def test_authorized_qualification_source_error_stays_structured_and_redacted(
+    monkeypatch, tmp_path,
+):
+    private_path = tmp_path / "owner-library-name.xml"
+    monkeypatch.setattr(
+        "djsupport.cli.get_client",
+        lambda: (_ for _ in ()).throw(
+            AssertionError("Spotify must stay untouched")
+        ),
+    )
+
+    result = CliRunner().invoke(cli, [
+        "qualification", "batch-opaque-1", str(private_path),
+        "--playlist", "Private/Selection", "--json",
+        "--authorize-private-source",
+        "--state-path", str(tmp_path / "publications.json"),
+    ])
+
+    assert result.exit_code == 2
+    assert json.loads(result.output) == {
+        "contract_version": 2,
+        "phase": "qualification",
+        "status": "error",
+        "error": {"code": "private_source_unavailable"},
+        "next_actions": ["inspect_private_source"],
     }
     assert "owner-library-name" not in result.output
 

--- a/tests/test_agent_contract.py
+++ b/tests/test_agent_contract.py
@@ -10,6 +10,7 @@ from djsupport.agent import (
     error_document,
 )
 from djsupport.local_audio import LocalAudioCapability
+from djsupport.local_audition import LocalAuditionCapability
 from djsupport.rekordbox import Track
 from djsupport.transfer import (
     AccountPublishingGuards,
@@ -69,6 +70,11 @@ class AvailableLocalAudio:
         )
 
 
+class AvailableAudition:
+    def capability(self):
+        return LocalAuditionCapability(available=True)
+
+
 def test_capability_inspection_is_versioned_and_side_effect_free(tmp_path):
     source = UntouchedSource()
     spotify = UntouchedSpotify()
@@ -78,12 +84,13 @@ def test_capability_inspection_is_versioned_and_side_effect_free(tmp_path):
         matching_knowledge=UntouchedKnowledge(),
         publishing_guards=AccountPublishingGuards(tmp_path / "locks"),
         local_audio=AvailableLocalAudio(),
+        local_audition=AvailableAudition(),
     ))
 
     result = contract.capabilities()
 
     assert result == {
-        "contract_version": 1,
+        "contract_version": 2,
         "phase": "capability",
         "status": "ready",
         "capabilities": {
@@ -91,6 +98,19 @@ def test_capability_inspection_is_versioned_and_side_effect_free(tmp_path):
                 "available": True,
                 "algorithm": "chromaprint",
                 "algorithm_version": "1.6.1",
+                "default_enabled": False,
+                "authority": "approved_match_reuse_only",
+                "first_run_discovery": "none_until_explicit_approval",
+                "execution_order": (
+                    "after_retained_knowledge_before_spotify_search"
+                ),
+            },
+            "local_audio_audition": {
+                "available": True,
+                "default_enabled": False,
+                "authority": "none",
+                "requires_local_audio_identity": False,
+                "requires_durable_matching_knowledge": False,
             },
         },
         "next_actions": ["plan"],
@@ -156,7 +176,7 @@ def test_batch_plan_requires_explicit_private_source_authorization(tmp_path):
     blocked = contract.plan_batch(request, AgentAuthorization())
 
     assert blocked == {
-        "contract_version": 1,
+        "contract_version": 2,
         "phase": "plan",
         "status": "authorization_required",
         "required_authorizations": ["private_source"],
@@ -180,7 +200,7 @@ def test_authorized_plan_is_stable_bounded_and_privacy_redacted(tmp_path):
     second = contract.plan_batch(request, authorization)
 
     assert first == second
-    assert first["contract_version"] == 1
+    assert first["contract_version"] == 2
     assert first["phase"] == "plan"
     assert first["status"] == "ready"
     assert len(first["batch_id"]) == 64
@@ -200,6 +220,16 @@ def test_authorized_plan_is_stable_bounded_and_privacy_redacted(tmp_path):
     rendered = json.dumps(first)
     assert "Private" not in rendered
     assert "Invented" not in rendered
+    assert first["local_audio"] == {
+        "identity_requested": False,
+        "audition_requested": False,
+        "identity_default_enabled": False,
+        "identity_first_run_discovery": "none_until_explicit_approval",
+        "identity_execution_order": (
+            "after_retained_knowledge_before_spotify_search"
+        ),
+        "audition_requires_identity": False,
+    }
 
 
 def test_expensive_confirmation_does_not_change_batch_identity(tmp_path):
@@ -255,7 +285,7 @@ def test_private_read_authorization_does_not_authorize_spotify_mutation(tmp_path
         request, AgentAuthorization(private_source=True),
     )
 
-    assert blocked["contract_version"] == 1
+    assert blocked["contract_version"] == 2
     assert blocked["phase"] == "execute"
     assert blocked["status"] == "authorization_required"
     assert blocked["required_authorizations"] == ["spotify_write"]
@@ -300,7 +330,7 @@ def test_authorized_preview_executes_non_interactively_and_is_idempotent(tmp_pat
     progress = contract.progress(first["transfer_id"], authorization)
 
     assert first == repeated
-    assert first["contract_version"] == 1
+    assert first["contract_version"] == 2
     assert first["phase"] == "outcome"
     assert first["status"] == "completed"
     assert first["transfer_id"] == first["batch_id"]
@@ -314,10 +344,10 @@ def test_authorized_preview_executes_non_interactively_and_is_idempotent(tmp_pat
         "local_audio_unavailable": 0,
         "local_audio_reused": 0,
     }
-    assert first["next_actions"] == ["review"]
+    assert first["next_actions"] == ["qualify"]
     assert spotify.searches == 1
     assert progress == {
-        "contract_version": 1,
+        "contract_version": 2,
         "phase": "progress",
         "status": "completed",
         "transfer_id": first["transfer_id"],
@@ -327,7 +357,7 @@ def test_authorized_preview_executes_non_interactively_and_is_idempotent(tmp_pat
             "failed": 0,
             "pending": 0,
         },
-        "next_actions": ["review"],
+        "next_actions": ["qualify"],
     }
     rendered = json.dumps(first)
     assert "Private" not in rendered

--- a/tests/test_agent_contract.py
+++ b/tests/test_agent_contract.py
@@ -1,6 +1,8 @@
 """Versioned, harness-neutral contract tests for AI agent clients."""
 
 import json
+from types import SimpleNamespace
+from unittest.mock import MagicMock
 
 import pytest
 
@@ -17,6 +19,7 @@ from djsupport.transfer import (
     BatchPlanRequest,
     FilePublicationStorage,
     FileTransferStorage,
+    QualificationRequest,
     SourceSelection,
     Transfer,
 )
@@ -46,6 +49,27 @@ def test_machine_error_next_actions_are_specific_to_the_failure():
     assert error_document(
         "execute", "spotify_authentication_required",
     )["next_actions"] == ["authenticate_spotify"]
+
+
+def test_qualification_approval_is_explicit_without_spotify_write_authority():
+    transfer = MagicMock()
+    transfer.private_source_authorization_requirement.side_effect = (
+        Transfer.private_source_authorization_requirement
+    )
+    transfer.approve_qualification.return_value = SimpleNamespace(
+        status=SimpleNamespace(value="approved"),
+        approved=(), rejected=(), collisions=(), corrections=(),
+    )
+    contract = AgentTransferContract(transfer)
+    authorization = AgentAuthorization(private_source=True)
+
+    document = contract.approve_qualification("opaque-draft", authorization)
+
+    assert document["status"] == "approved"
+    assert document["authority"] == "playlist_approval"
+    transfer.approve_qualification.assert_called_once_with(
+        "opaque-draft", authorization,
+    )
 
 
 class UntouchedSpotify:
@@ -183,6 +207,26 @@ def test_batch_plan_requires_explicit_private_source_authorization(tmp_path):
         "next_actions": ["authorize_private_source"],
     }
     assert source.calls == 0
+
+
+@pytest.mark.parametrize("origin", [
+    "https://review.example.test",
+    "http://127.0.0.1.example.test",
+    "http://user@127.0.0.1:8000",
+])
+def test_qualification_review_url_rejects_non_loopback_origins(origin):
+    transfer = MagicMock()
+    transfer.private_source_authorization_requirement.return_value = None
+    contract = AgentTransferContract(transfer)
+
+    with pytest.raises(ValueError, match="loopback"):
+        contract.qualification_draft(
+            QualificationRequest(transfer_id="opaque-transfer"),
+            AgentAuthorization(private_source=True),
+            review_origin=origin,
+        )
+
+    transfer.obtain_qualification.assert_not_called()
 
 
 def test_authorized_plan_is_stable_bounded_and_privacy_redacted(tmp_path):

--- a/tests/test_backup.py
+++ b/tests/test_backup.py
@@ -148,6 +148,29 @@ class TestRestorePreview:
         assert preview.valid is True
         assert preview.contents == ("publication-manifests.json",)
 
+    def test_accepts_version_four_transfer_state_with_qualification_drafts(
+        self, tmp_path,
+    ):
+        source = tmp_path / "source"
+        _write_json(source / "transfers.json", {
+            "version": 4,
+            "transfers": {},
+            "batches": {},
+            "qualifications": {
+                "draft-opaque": {
+                    "draft_id": "draft-opaque",
+                    "status": "draft",
+                    "decisions": {},
+                },
+            },
+        })
+        archive = LocalDataBackup(source).create(tmp_path / "backups")
+
+        preview = LocalDataBackup(tmp_path / "target").preview(archive)
+
+        assert preview.valid is True
+        assert preview.contents == ("transfers.json",)
+
     @pytest.mark.parametrize("damage", ["corrupt", "unsupported-backup", "unsupported-data"])
     def test_rejects_corrupt_or_unsupported_archive(self, tmp_path, damage):
         source = tmp_path / "source"
@@ -324,3 +347,61 @@ class TestRestore:
         assert preview.conflicts[0].kind == "report"
         assert result.restored is False
         assert (target / "reports" / "transfer.md").read_text() == "current report"
+
+    def test_merges_qualification_drafts_idempotently(self, tmp_path):
+        source = tmp_path / "source"
+        target = tmp_path / "target"
+        for root, draft in ((source, "incoming"), (target, "current")):
+            _write_json(root / "transfers.json", {
+                "version": 4,
+                "transfers": {},
+                "batches": {},
+                "qualifications": {
+                    draft: {
+                        "draft_id": draft,
+                        "status": "draft",
+                        "decisions": {},
+                    },
+                },
+            })
+        archive = LocalDataBackup(source).create(tmp_path / "backups")
+        service = LocalDataBackup(target)
+
+        first = service.restore(archive)
+        first_bytes = (target / "transfers.json").read_bytes()
+        second = service.restore(archive)
+
+        assert first.restored and second.restored
+        assert json.loads(first_bytes)["qualifications"].keys() == {
+            "current", "incoming",
+        }
+        assert (target / "transfers.json").read_bytes() == first_bytes
+
+    def test_changed_qualification_draft_requires_explicit_resolution(
+        self, tmp_path,
+    ):
+        source = tmp_path / "source"
+        target = tmp_path / "target"
+        for root, outcome in ((source, "deferred"), (target, "keep_proposal")):
+            _write_json(root / "transfers.json", {
+                "version": 4,
+                "transfers": {},
+                "batches": {},
+                "qualifications": {
+                    "draft-opaque": {
+                        "draft_id": "draft-opaque",
+                        "status": "draft",
+                        "decisions": {"item-opaque": {"decision": outcome}},
+                    },
+                },
+            })
+        archive = LocalDataBackup(source).create(tmp_path / "backups")
+        before = (target / "transfers.json").read_bytes()
+        service = LocalDataBackup(target)
+
+        preview = service.preview(archive)
+        result = service.restore(archive)
+
+        assert preview.conflicts[0].kind == "qualification-draft"
+        assert result.restored is False
+        assert (target / "transfers.json").read_bytes() == before

--- a/tests/test_local_audio_identity.py
+++ b/tests/test_local_audio_identity.py
@@ -91,8 +91,11 @@ class SpotifyBoundary:
             "uri": "spotify:track:approved",
             "name": "Known Recording",
             "artist": "Known Artist",
+            "album": "Known Spotify Release",
+            "duration_ms": 359_000,
             "score": 97.0,
             "match_type": "exact",
+            "score_reasons": ["original version evidence retained"],
         }
 
     def publish_provisional_snapshot(
@@ -173,6 +176,13 @@ def test_approved_local_identity_recovers_damaged_metadata_without_spotify(tmp_p
     assert later.total_matched == 1
     assert later.playlists[0].matched[0].spotify_uri == "spotify:track:approved"
     assert later.playlists[0].matched[0].match_type == "approved_local_audio"
+    reused_review = later.playlists[0].review_items[0]
+    assert reused_review.spotify_release == "Known Spotify Release"
+    assert reused_review.spotify_duration == 359
+    assert reused_review.score_reasons == (
+        "Approved Match reused from local audio identity",
+        "original version evidence retained",
+    )
 
 
 def test_local_identity_requires_durable_matching_knowledge_before_audio_access(
@@ -317,7 +327,7 @@ def test_completed_local_observation_is_not_recalculated_after_spotify_timeout(
 
     assert resumed.total_matched == 1
     assert local_audio.observed == ["rb-original"]
-    assert json.loads(state_path.read_text())["version"] == 3
+    assert json.loads(state_path.read_text())["version"] == 4
 
 
 def test_explicit_drift_revocation_removes_local_identity_authority(tmp_path):

--- a/tests/test_local_audition.py
+++ b/tests/test_local_audition.py
@@ -20,6 +20,7 @@ from djsupport.transfer import (
     LocalAuditionResult,
     QualificationRequest,
     SourceSelection,
+    SpotifyPlaylistReviewRequired,
     Transfer,
     TransferAuthorization,
     TransferMode,
@@ -144,6 +145,52 @@ def test_transfer_authorizes_only_the_selected_audition_occurrence(tmp_path):
     assert "fingerprint" not in persisted
 
 
+def test_audition_blocks_if_the_selected_occurrence_is_relinked_after_draft(
+    tmp_path,
+):
+    original = "file:///owner/private/original-selected.wav"
+    relinked = "file:///owner/private/different-selected.wav"
+    source = SelectedSource(_track(original))
+    audition = RecordingAudition()
+    storage_path = tmp_path / "transfers.json"
+    transfer = Transfer(
+        source=source,
+        spotify=PreviewSpotify(),
+        matching_knowledge=EphemeralMatchingKnowledge(),
+        publishing_guards=AccountPublishingGuards(tmp_path / "locks"),
+        transfer_storage=FileTransferStorage(storage_path),
+        local_audition=audition,
+    )
+    plan = transfer.plan_batch(BatchPlanRequest(
+        playlist_references=("Folder/Selected",),
+        preview=True,
+        local_audio_audition=True,
+    ))
+    report = transfer.execute_batch(plan, transfer_id=plan.batch_id)
+    draft = transfer.obtain_qualification(
+        QualificationRequest(
+            transfer_id=report.transfer_id,
+            playlist_reference="Folder/Selected",
+        ),
+        TransferAuthorization(private_source=True),
+    )
+    source.track = _track(relinked)
+
+    with pytest.raises(
+        SpotifyPlaylistReviewRequired, match="source selection changed"
+    ):
+        transfer.audition_qualification(
+            draft.draft_id,
+            draft.items[0].item_id,
+            TransferAuthorization(private_source=True),
+        )
+
+    assert audition.opened == []
+    persisted = storage_path.read_text()
+    assert "original-selected" not in persisted
+    assert "different-selected" not in persisted
+
+
 def test_local_audition_streams_full_and_bounded_ranges_without_path_disclosure(
     tmp_path,
 ):
@@ -220,6 +267,133 @@ def test_regenerated_handle_invalidates_prior_handle_and_transfer_scope(tmp_path
     adapter.invalidate_transfer("transfer-one")
     with pytest.raises(AuditionHandleUnavailable):
         adapter.stream(second.handle)
+
+
+def test_discarded_qualification_invalidates_handle_and_requires_fresh_authorization(
+    tmp_path,
+):
+    media = tmp_path / "selected-private-source.wav"
+    media.write_bytes(b"synthetic audition")
+    source = SelectedSource(_track(media.as_uri()))
+    audition = LocalSourceAudition()
+    transfer = Transfer(
+        source=source,
+        spotify=PreviewSpotify(),
+        matching_knowledge=EphemeralMatchingKnowledge(),
+        publishing_guards=AccountPublishingGuards(tmp_path / "locks"),
+        transfer_storage=FileTransferStorage(tmp_path / "transfers.json"),
+        local_audition=audition,
+    )
+    plan = transfer.plan_batch(BatchPlanRequest(
+        playlist_references=("Folder/Selected",),
+        preview=True,
+        local_audio_audition=True,
+    ))
+    report = transfer.execute_batch(plan, transfer_id=plan.batch_id)
+    draft = transfer.obtain_qualification(
+        QualificationRequest(
+            transfer_id=report.transfer_id,
+            playlist_reference="Folder/Selected",
+        ),
+        TransferAuthorization(private_source=True),
+    )
+    opened = transfer.audition_qualification(
+        draft.draft_id,
+        draft.items[0].item_id,
+        TransferAuthorization(private_source=True),
+    )
+
+    discarded = transfer.discard_qualification(
+        draft.draft_id, TransferAuthorization(private_source=True),
+    )
+
+    assert discarded.status.value == "discarded"
+    with pytest.raises(AuditionHandleUnavailable):
+        audition.stream(opened.handle)
+    with pytest.raises(ValueError, match="discarded"):
+        transfer.audition_qualification(
+            draft.draft_id,
+            draft.items[0].item_id,
+            TransferAuthorization(private_source=True),
+        )
+    resumed = transfer.obtain_qualification(
+        QualificationRequest(
+            transfer_id=report.transfer_id,
+            playlist_reference="Folder/Selected",
+        ),
+        TransferAuthorization(private_source=True),
+    )
+    assert resumed.status.value == "discarded"
+    fresh = transfer.supersede_qualification(
+        draft.draft_id, TransferAuthorization(private_source=True),
+    )
+    with pytest.raises(PermissionError, match="private_source"):
+        transfer.audition_qualification(
+            fresh.draft_id,
+            fresh.items[0].item_id,
+            TransferAuthorization(),
+        )
+    reopened = transfer.audition_qualification(
+        fresh.draft_id,
+        fresh.items[0].item_id,
+        TransferAuthorization(private_source=True),
+    )
+    assert reopened.handle != opened.handle
+    assert b"".join(audition.stream(reopened.handle).body) == b"synthetic audition"
+
+
+def test_stale_audition_reader_refreshes_before_opening_retired_draft(tmp_path):
+    private_location = "file:///invented/selected-source.wav"
+    source = SelectedSource(_track(private_location))
+    storage_path = tmp_path / "transfers.json"
+    primary = Transfer(
+        source=source,
+        spotify=PreviewSpotify(),
+        matching_knowledge=EphemeralMatchingKnowledge(),
+        publishing_guards=AccountPublishingGuards(tmp_path / "locks"),
+        transfer_storage=FileTransferStorage(storage_path),
+        local_audition=RecordingAudition(),
+    )
+    plan = primary.plan_batch(BatchPlanRequest(
+        playlist_references=("Folder/Selected",),
+        preview=True,
+        local_audio_audition=True,
+    ))
+    report = primary.execute_batch(plan, transfer_id=plan.batch_id)
+    draft = primary.obtain_qualification(
+        QualificationRequest(
+            transfer_id=report.transfer_id,
+            playlist_reference="Folder/Selected",
+        ),
+        TransferAuthorization(private_source=True),
+    )
+    stale_audition = RecordingAudition()
+    stale = Transfer(
+        source=source,
+        spotify=PreviewSpotify(),
+        matching_knowledge=EphemeralMatchingKnowledge(),
+        publishing_guards=AccountPublishingGuards(tmp_path / "locks"),
+        transfer_storage=FileTransferStorage(storage_path),
+        local_audition=stale_audition,
+    )
+    primary.discard_qualification(
+        draft.draft_id, TransferAuthorization(private_source=True),
+    )
+
+    with pytest.raises(ValueError, match="discarded"):
+        stale.audition_qualification(
+            draft.draft_id,
+            draft.items[0].item_id,
+            TransferAuthorization(private_source=True),
+        )
+
+    assert stale_audition.opened == []
+
+
+def test_windows_rekordbox_file_uri_uses_platform_path_conversion():
+    assert LocalSourceAudition._file_uri_path(
+        "/C:/Invented%20Library/Selected.wav", windows=True,
+    ) == "C:/Invented Library/Selected.wav"
 
 
 def test_empty_supported_media_has_truthful_zero_length_response(tmp_path):

--- a/tests/test_local_audition.py
+++ b/tests/test_local_audition.py
@@ -1,0 +1,288 @@
+"""Contract tests for private local-source audition media."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from djsupport.local_audition import (
+    AuditionHandleUnavailable,
+    AuditionRangeNotSatisfiable,
+    LocalSourceAudition,
+)
+from djsupport.rekordbox import Track
+from djsupport.transfer import (
+    AccountPublishingGuards,
+    BatchPlanRequest,
+    EphemeralMatchingKnowledge,
+    FileTransferStorage,
+    LocalAuditionResult,
+    QualificationRequest,
+    SourceSelection,
+    Transfer,
+    TransferAuthorization,
+    TransferMode,
+)
+
+
+def _track(location: str) -> Track:
+    return Track(
+        track_id="selected-occurrence",
+        name="Invented Source",
+        artist="Invented Artist",
+        album="Invented Release",
+        remixer="",
+        label="Invented Label",
+        genre="Synthetic",
+        date_added="2026-08-08",
+        duration=180,
+        location=location,
+    )
+
+
+class SelectedSource:
+    source_label = "Rekordbox"
+    default_mode = TransferMode.MIRROR
+
+    def __init__(self, track: Track) -> None:
+        self.track = track
+
+    def consume(self, reference):
+        return SourceSelection("Selected", reference, [self.track])
+
+    def consume_batch(self, references, whole_library):
+        return tuple(self.consume(reference) for reference in references)
+
+
+class PreviewSpotify:
+    def account_id(self):
+        return "spotify-account-one"
+
+    def match(self, track, threshold):
+        return {
+            "uri": "spotify:track:proposal000000000000",
+            "name": "Invented Proposal",
+            "artist": "Invented Spotify Artist",
+            "album": "Invented Spotify Release",
+            "duration_ms": 180_000,
+            "score": 96.0,
+            "match_type": "exact",
+        }
+
+
+class RecordingAudition:
+    def __init__(self) -> None:
+        self.opened = []
+
+    def open(self, transfer_id, item_id, track):
+        self.opened.append((transfer_id, item_id, track.track_id, track.location))
+        return LocalAuditionResult(
+            status="available",
+            handle="opaque-process-handle",
+            media_type="audio/wav",
+            content_length=16,
+        )
+
+
+class ForbiddenIdentity:
+    def observe(self, track):
+        raise AssertionError("audition must not calculate a fingerprint")
+
+
+def test_transfer_authorizes_only_the_selected_audition_occurrence(tmp_path):
+    private_location = "file:///owner/private/owner-only-name.wav"
+    audition = RecordingAudition()
+    storage_path = tmp_path / "transfers.json"
+    transfer = Transfer(
+        source=SelectedSource(_track(private_location)),
+        spotify=PreviewSpotify(),
+        matching_knowledge=EphemeralMatchingKnowledge(),
+        publishing_guards=AccountPublishingGuards(tmp_path / "locks"),
+        transfer_storage=FileTransferStorage(storage_path),
+        local_audio=ForbiddenIdentity(),
+        local_audition=audition,
+    )
+    plan = transfer.plan_batch(BatchPlanRequest(
+        playlist_references=("Folder/Selected",),
+        preview=True,
+        local_audio_audition=True,
+    ))
+    report = transfer.execute_batch(plan, transfer_id=plan.batch_id)
+    draft = transfer.obtain_qualification(
+        QualificationRequest(
+            transfer_id=report.transfer_id,
+            playlist_reference="Folder/Selected",
+        ),
+        TransferAuthorization(private_source=True),
+    )
+    item_id = draft.items[0].item_id
+
+    with pytest.raises(PermissionError, match="private_source"):
+        transfer.audition_qualification(
+            draft.draft_id, item_id, TransferAuthorization(),
+        )
+    with pytest.raises(ValueError, match="outside the selected"):
+        transfer.audition_qualification(
+            draft.draft_id, "unselected-item",
+            TransferAuthorization(private_source=True),
+        )
+    result = transfer.audition_qualification(
+        draft.draft_id,
+        item_id,
+        TransferAuthorization(private_source=True, spotify_write=False),
+    )
+
+    assert result.status == "available"
+    assert result.handle == "opaque-process-handle"
+    assert audition.opened == [(
+        draft.transfer_id, item_id, "selected-occurrence", private_location,
+    )]
+    persisted = storage_path.read_text()
+    assert "owner-only-name" not in persisted
+    assert "opaque-process-handle" not in persisted
+    assert "fingerprint" not in persisted
+
+
+def test_local_audition_streams_full_and_bounded_ranges_without_path_disclosure(
+    tmp_path,
+):
+    media = tmp_path / "owner-private-name.wav"
+    media.write_bytes(b"0123456789abcdef")
+    now = [100.0]
+    adapter = LocalSourceAudition(
+        ttl_seconds=10,
+        max_range_bytes=8,
+        clock=lambda: now[0],
+    )
+
+    opened = adapter.open("transfer-one", "item-one", _track(media.as_uri()))
+    full = adapter.stream(opened.handle)
+    partial = adapter.stream(opened.handle, "bytes=2-7")
+
+    assert opened.status == "available"
+    assert opened.media_type == "audio/wav"
+    assert opened.content_length == 16
+    assert "owner-private-name" not in repr(opened)
+    assert full.status_code == 200
+    assert full.content_length == 16
+    assert b"".join(full.body) == b"0123456789abcdef"
+    assert partial.status_code == 206
+    assert partial.content_range == "bytes 2-7/16"
+    assert partial.content_length == 6
+    assert b"".join(partial.body) == b"234567"
+
+    with pytest.raises(AuditionRangeNotSatisfiable) as excessive:
+        adapter.stream(opened.handle, "bytes=0-12")
+    assert excessive.value.total_size == 16
+    with pytest.raises(AuditionRangeNotSatisfiable):
+        adapter.stream(opened.handle, "bytes=99-100")
+    now[0] = 111.0
+    with pytest.raises(AuditionHandleUnavailable):
+        adapter.stream(opened.handle)
+
+
+@pytest.mark.parametrize(
+    ("location", "reason"),
+    [
+        ("", "missing_location"),
+        ("https://example.test/audio.wav", "unsupported_location"),
+        ("file://remote-host/private.wav", "unsupported_location"),
+        ("file:///private/*.wav", "unsafe_location"),
+        ("file:///private/missing.wav", "missing_file"),
+        ("file:///private/source.txt", "unsupported_format"),
+    ],
+)
+def test_local_audition_unavailability_is_path_free(tmp_path, location, reason):
+    adapter = LocalSourceAudition()
+
+    result = adapter.open("transfer-one", "item-one", _track(location))
+
+    assert result.status == "unavailable"
+    assert result.reason == reason
+    assert result.handle is None
+    if location:
+        assert location not in json.dumps(result.__dict__)
+
+
+def test_regenerated_handle_invalidates_prior_handle_and_transfer_scope(tmp_path):
+    media = tmp_path / "private-source.wav"
+    media.write_bytes(b"synthetic")
+    adapter = LocalSourceAudition()
+
+    first = adapter.open("transfer-one", "item-one", _track(media.as_uri()))
+    second = adapter.open("transfer-one", "item-one", _track(media.as_uri()))
+
+    assert first.handle != second.handle
+    with pytest.raises(AuditionHandleUnavailable):
+        adapter.stream(first.handle)
+    assert b"".join(adapter.stream(second.handle).body) == b"synthetic"
+    adapter.invalidate_transfer("transfer-one")
+    with pytest.raises(AuditionHandleUnavailable):
+        adapter.stream(second.handle)
+
+
+def test_empty_supported_media_has_truthful_zero_length_response(tmp_path):
+    media = tmp_path / "empty-source.wav"
+    media.write_bytes(b"")
+    adapter = LocalSourceAudition()
+    opened = adapter.open("transfer-one", "item-one", _track(media.as_uri()))
+
+    stream = adapter.stream(opened.handle)
+
+    assert stream.status_code == 200
+    assert stream.content_length == 0
+    assert b"".join(stream.body) == b""
+
+
+def test_unreadable_media_is_a_path_free_per_track_outcome(tmp_path, monkeypatch):
+    media = tmp_path / "owner-private-unreadable.wav"
+    media.write_bytes(b"synthetic")
+    real_open = type(media).open
+
+    def denied_open(path, *args, **kwargs):
+        if path == media:
+            raise PermissionError("synthetic denial")
+        return real_open(path, *args, **kwargs)
+
+    monkeypatch.setattr(type(media), "open", denied_open)
+
+    result = LocalSourceAudition().open(
+        "transfer-one", "item-one", _track(media.as_uri()),
+    )
+
+    assert result.status == "unavailable"
+    assert result.reason == "unreadable_media"
+    assert "owner-private-unreadable" not in repr(result)
+
+
+def test_qualification_fact_honestly_reports_missing_selected_media(tmp_path):
+    missing = tmp_path / "private-missing-source.wav"
+    transfer = Transfer(
+        source=SelectedSource(_track(missing.as_uri())),
+        spotify=PreviewSpotify(),
+        matching_knowledge=EphemeralMatchingKnowledge(),
+        publishing_guards=AccountPublishingGuards(tmp_path / "locks"),
+        transfer_storage=FileTransferStorage(tmp_path / "transfers.json"),
+        local_audition=LocalSourceAudition(),
+    )
+    plan = transfer.plan_batch(BatchPlanRequest(
+        playlist_references=("Folder/Selected",),
+        preview=True,
+        local_audio_audition=True,
+    ))
+    report = transfer.execute_batch(plan, transfer_id=plan.batch_id)
+
+    draft = transfer.obtain_qualification(
+        QualificationRequest(
+            transfer_id=report.transfer_id,
+            playlist_reference="Folder/Selected",
+        ),
+        TransferAuthorization(private_source=True),
+    )
+
+    assert draft.items[0].audition_status == "unavailable"
+    assert draft.items[0].audition_reason == "missing_file"
+    assert "private-missing-source" not in json.dumps(
+        draft.items[0].__dict__, default=str,
+    )

--- a/tests/test_matcher.py
+++ b/tests/test_matcher.py
@@ -24,7 +24,10 @@ from djsupport.cache import MatchCache
 from djsupport.rekordbox import Track
 
 
-def make_track(name="Test Track", artist="Test Artist", remixer="", duration=0):
+def make_track(
+    name="Test Track", artist="Test Artist", remixer="", duration=0,
+    version="",
+):
     return Track(
         track_id="1",
         name=name,
@@ -35,6 +38,7 @@ def make_track(name="Test Track", artist="Test Artist", remixer="", duration=0):
         genre="",
         date_added="",
         duration=duration,
+        version=version,
     )
 
 
@@ -211,6 +215,12 @@ class TestIsNamedVariant:
 
 
 class TestClassifyVersionMatch:
+    def test_rekordbox_mix_metadata_protects_plain_title_version_intent(self):
+        track = make_track("Track", version="Extended Mix")
+        result = make_result("Track")
+
+        assert _classify_version_match(track, result) == "fallback_version"
+
     def test_both_original_mix_is_exact(self):
         track = make_track("Vultora (Original Mix)")
         result = make_result("Vultora (Original Mix)")
@@ -284,6 +294,27 @@ class TestMatchTrack:
         assert result["uri"] == "spotify:track:abc"
         assert result["score"] >= 80
         assert result["match_type"] == "exact"
+
+    def test_rekordbox_mix_metadata_surfaces_fallback_version_evidence(self):
+        sp = self._mock_sp([
+            make_spotify_item(
+                "Synthetic Signal", "Synthetic Artist",
+                "spotify:track:default-version",
+            ),
+        ])
+
+        result = match_track(
+            sp,
+            make_track(
+                "Synthetic Signal", "Synthetic Artist",
+                version="Extended Mix",
+            ),
+            threshold=80,
+        )
+
+        assert result is not None
+        assert result["match_type"] == "fallback_version"
+        assert "fallback version" in result["score_reasons"]
 
     def test_materially_shorter_candidate_is_reviewable_not_exact(self):
         sp = self._mock_sp([

--- a/tests/test_migration.py
+++ b/tests/test_migration.py
@@ -175,7 +175,7 @@ class TestLegacyMigration:
 
         assert result.applied is True
         stored = json.loads((app_data / "matching-knowledge.json").read_text())
-        assert stored["version"] == 2
+        assert stored["version"] == 3
         assert stored["fingerprint_associations"] == [association]
         assert "new||track" in stored["entries"]
 

--- a/tests/test_migration.py
+++ b/tests/test_migration.py
@@ -480,16 +480,32 @@ def test_foundation_migration_is_backup_first_and_idempotent(tmp_path):
         "approvals": [],
         "mirrors": [{"spotify_user_id": "legacy-profile"}],
     })
+    _write_json(app_data / "transfers.json", {
+        "version": 4,
+        "transfers": {},
+        "batches": {},
+        "qualifications": {
+            "draft-opaque": {
+                "draft_id": "draft-opaque",
+                "account_id": "legacy-profile",
+                "decisions": {},
+            },
+        },
+    })
 
     migration = FoundationMigration(app_data)
     first = migration.apply("legacy-profile", "stable-account")
     second = migration.apply("legacy-profile", "stable-account")
 
     stored = json.loads((app_data / "publication-manifests.json").read_text())
-    assert first.applied and first.backup_created and first.changed_records == 2
+    transfer_state = json.loads((app_data / "transfers.json").read_text())
+    assert first.applied and first.backup_created and first.changed_records == 3
     assert not second.applied and not second.backup_created
     assert stored["manifests"][0]["account_id"] == "stable-account"
     assert stored["mirrors"][0]["account_id"] == "stable-account"
+    assert transfer_state["qualifications"]["draft-opaque"]["account_id"] == (
+        "stable-account"
+    )
     archive = next((app_data / "backups").glob("*.zip"))
     assert LocalDataBackup(app_data).preview(archive).valid
 

--- a/tests/test_qualification.py
+++ b/tests/test_qualification.py
@@ -2,11 +2,18 @@
 
 from __future__ import annotations
 
+import json
 from dataclasses import replace
+from datetime import datetime
 
 import pytest
 
 from djsupport.agent import AgentAuthorization, AgentTransferContract
+from djsupport.cache import MatchCache
+from djsupport.local_audition import (
+    AuditionHandleUnavailable,
+    LocalSourceAudition,
+)
 from djsupport.rekordbox import Track
 from djsupport.transfer import (
     AccountPublishingGuards,
@@ -14,9 +21,14 @@ from djsupport.transfer import (
     EphemeralMatchingKnowledge,
     FilePublicationStorage,
     FileTransferStorage,
+    MatchCacheKnowledge,
+    PublicationItem,
+    PublicationManifest,
     QualificationDecision,
     QualificationRequest,
+    QualificationStatus,
     SourceSelection,
+    SourceNotFound,
     SpotifyMutationResult,
     SpotifyPlaylistHead,
     SpotifyPlaylistItem,
@@ -279,6 +291,27 @@ def test_rekordbox_attention_queue_preserves_review_facts_and_authority(
     assert approved.authority_status == "approved"
     assert approved.attention_reasons == ()
 
+    transfer.record_qualification(
+        all_proposals.draft_id,
+        approved.item_id,
+        QualificationDecision.DEFERRED,
+        TransferAuthorization(private_source=True),
+        reason="Explicit spot check is still unresolved",
+    )
+    resumed = transfer.obtain_qualification(
+        QualificationRequest(
+            transfer_id=report.transfer_id,
+            playlist_reference="Folder/Selected",
+        ),
+        TransferAuthorization(private_source=True),
+    )
+
+    assert resumed.include_all is True
+    assert [item.source_track_id for item in resumed.items] == [
+        "new", "short", "approved",
+    ]
+    assert resumed.deferred == 1
+
 
 def test_completed_draft_applies_before_separate_playlist_approval(tmp_path):
     tracks = [
@@ -319,21 +352,25 @@ def test_completed_draft_applies_before_separate_playlist_approval(tmp_path):
 
     transfer.record_qualification(
         view.draft_id, item_ids["keep"], QualificationDecision.KEEP_PROPOSAL,
+        TransferAuthorization(private_source=True),
     )
     transfer.record_qualification(
         view.draft_id,
         item_ids["correct"],
         QualificationDecision.CORRECTION,
+        TransferAuthorization(private_source=True),
         spotify_reference="spotify:track:replacement00000000000",
     )
     deferred = transfer.record_qualification(
         view.draft_id,
         item_ids["defer"],
         QualificationDecision.DEFERRED,
+        TransferAuthorization(private_source=True),
         reason="Needs a different listening environment",
     )
     transfer.record_qualification(
         view.draft_id, item_ids["reject"], QualificationDecision.REJECT_PROPOSAL,
+        TransferAuthorization(private_source=True),
     )
 
     assert deferred.deferred == 1
@@ -359,6 +396,7 @@ def test_completed_draft_applies_before_separate_playlist_approval(tmp_path):
         view.draft_id,
         item_ids["defer"],
         QualificationDecision.DEFERRED,
+        TransferAuthorization(private_source=True),
         reason="Explicitly omitted from this bounded review",
         exclude=True,
     )
@@ -375,7 +413,24 @@ def test_completed_draft_applies_before_separate_playlist_approval(tmp_path):
     ]
     assert knowledge.approved == knowledge.corrected == knowledge.rejected == []
 
-    approval = transfer.approve(playlist_id)
+    resumed_applied = transfer.obtain_qualification(
+        QualificationRequest(
+            transfer_id=report.transfer_id,
+            playlist_reference="Folder/Selected",
+        ),
+        TransferAuthorization(private_source=True),
+    )
+
+    assert resumed_applied.status.value == "applied"
+    assert transfer.apply_qualification(
+        view.draft_id,
+        TransferAuthorization(private_source=True, spotify_write=True),
+    ).status.value == "applied"
+
+    approval = transfer.approve_qualification(
+        view.draft_id,
+        TransferAuthorization(private_source=True, spotify_write=True),
+    )
 
     assert approval.status.value == "approved"
     assert [item.source_track_id for item in knowledge.approved] == ["keep"]
@@ -415,12 +470,16 @@ def test_duplicate_source_occurrences_remain_ordered_facts_through_approval(
     for item in view.items:
         transfer.record_qualification(
             view.draft_id, item.item_id, QualificationDecision.KEEP_PROPOSAL,
+            TransferAuthorization(private_source=True),
         )
     transfer.apply_qualification(
         view.draft_id,
         TransferAuthorization(private_source=True, spotify_write=True),
     )
-    outcome = transfer.approve(report.playlists[0].spotify_playlist_id)
+    outcome = transfer.approve_qualification(
+        view.draft_id,
+        TransferAuthorization(private_source=True, spotify_write=True),
+    )
 
     assert outcome.status.value == "approved"
     assert outcome.collisions == ()
@@ -542,7 +601,58 @@ def test_unresolved_conflicts_block_draft_application_before_mutation(
     for item in view.items:
         transfer.record_qualification(
             view.draft_id, item.item_id, QualificationDecision.KEEP_PROPOSAL,
+            TransferAuthorization(private_source=True),
         )
+    writes_before = spotify.playlist_writes
+
+    with pytest.raises(SpotifyPlaylistReviewRequired, match="conflict"):
+        transfer.apply_qualification(
+            view.draft_id,
+            TransferAuthorization(private_source=True, spotify_write=True),
+        )
+
+    assert spotify.playlist_writes == writes_before
+
+
+def test_staged_correction_rechecks_approved_match_conflict_before_mutation(
+    tmp_path,
+):
+    replacement_uri = "spotify:track:replacement00000000000"
+
+    class CorrectedConflictKnowledge(AuthorityRecordingKnowledge):
+        def approval_conflict(self, item):
+            return item.spotify_uri == replacement_uri
+
+    track = _track("conflict", title="Correction Conflict", duration=181)
+    spotify = PlaylistSpotify({"conflict": _proposal("conflict")})
+    transfer = Transfer(
+        source=RekordboxSelection([track]),
+        spotify=spotify,
+        matching_knowledge=CorrectedConflictKnowledge(),
+        publishing_guards=AccountPublishingGuards(tmp_path / "locks"),
+        publication_storage=FilePublicationStorage(
+            tmp_path / "publications.json"
+        ),
+        transfer_storage=FileTransferStorage(tmp_path / "transfers.json"),
+    )
+    plan = transfer.plan_batch(BatchPlanRequest(
+        playlist_references=("Folder/Conflict",),
+    ))
+    report = transfer.execute_batch(plan, transfer_id=plan.batch_id)
+    view = transfer.obtain_qualification(
+        QualificationRequest(
+            transfer_id=report.transfer_id,
+            playlist_reference="Folder/Conflict",
+        ),
+        TransferAuthorization(private_source=True),
+    )
+    transfer.record_qualification(
+        view.draft_id,
+        view.items[0].item_id,
+        QualificationDecision.CORRECTION,
+        TransferAuthorization(private_source=True),
+        spotify_reference=replacement_uri,
+    )
     writes_before = spotify.playlist_writes
 
     with pytest.raises(SpotifyPlaylistReviewRequired, match="conflict"):
@@ -615,6 +725,7 @@ def test_changed_playlist_head_blocks_draft_application_before_mutation(tmp_path
     transfer.record_qualification(
         view.draft_id, view.items[0].item_id,
         QualificationDecision.KEEP_PROPOSAL,
+        TransferAuthorization(private_source=True),
     )
     playlist_id = report.playlists[0].spotify_playlist_id
     spotify._mutated(playlist_id, spotify.playlists[playlist_id])
@@ -627,6 +738,93 @@ def test_changed_playlist_head_blocks_draft_application_before_mutation(tmp_path
         )
 
     assert spotify.playlist_writes == writes_after_external_change
+
+
+@pytest.mark.parametrize("external_edit", [False, True])
+def test_draft_application_recovers_only_its_checkpointed_playlist_mutation(
+    tmp_path, external_edit,
+):
+    class CrashOncePublicationStorage(FilePublicationStorage):
+        crash_next = False
+
+        def retain_publication(self, manifest):
+            if self.crash_next:
+                self.crash_next = False
+                raise RuntimeError("synthetic retention crash")
+            super().retain_publication(manifest)
+
+    track = _track("crash", title="Crash Recovery", duration=181)
+    spotify = PlaylistSpotify({"crash": _proposal("crash")})
+    knowledge = AuthorityRecordingKnowledge()
+    publication_path = tmp_path / "publications.json"
+    transfer_path = tmp_path / "transfers.json"
+    publications = CrashOncePublicationStorage(publication_path)
+    transfer = Transfer(
+        source=RekordboxSelection([track]),
+        spotify=spotify,
+        matching_knowledge=knowledge,
+        publishing_guards=AccountPublishingGuards(tmp_path / "locks"),
+        publication_storage=publications,
+        transfer_storage=FileTransferStorage(transfer_path),
+    )
+    plan = transfer.plan_batch(BatchPlanRequest(
+        playlist_references=("Folder/Selected",),
+    ))
+    report = transfer.execute_batch(plan, transfer_id=plan.batch_id)
+    draft = transfer.obtain_qualification(
+        QualificationRequest(
+            transfer_id=report.transfer_id,
+            playlist_reference="Folder/Selected",
+        ),
+        TransferAuthorization(private_source=True),
+    )
+    transfer.record_qualification(
+        draft.draft_id,
+        draft.items[0].item_id,
+        QualificationDecision.KEEP_PROPOSAL,
+        TransferAuthorization(private_source=True),
+    )
+    writes_before = spotify.playlist_writes
+    publications.crash_next = True
+
+    with pytest.raises(RuntimeError, match="retention crash"):
+        transfer.apply_qualification(
+            draft.draft_id,
+            TransferAuthorization(private_source=True, spotify_write=True),
+        )
+
+    assert spotify.playlist_writes == writes_before + 1
+    if external_edit:
+        spotify._mutated(
+            report.playlists[0].spotify_playlist_id,
+            [_proposal("external-edit")["uri"]],
+        )
+    writes_before_resume = spotify.playlist_writes
+    restarted = Transfer(
+        source=RekordboxSelection([track]),
+        spotify=spotify,
+        matching_knowledge=knowledge,
+        publishing_guards=AccountPublishingGuards(tmp_path / "locks"),
+        publication_storage=FilePublicationStorage(publication_path),
+        transfer_storage=FileTransferStorage(transfer_path),
+    )
+    if external_edit:
+        with pytest.raises(SpotifyPlaylistChanged):
+            restarted.apply_qualification(
+                draft.draft_id,
+                TransferAuthorization(
+                    private_source=True, spotify_write=True,
+                ),
+            )
+    else:
+        outcome = restarted.apply_qualification(
+            draft.draft_id,
+            TransferAuthorization(private_source=True, spotify_write=True),
+        )
+        assert outcome.status == QualificationStatus.APPLIED
+
+    assert spotify.playlist_writes == writes_before_resume
+    assert knowledge.approved == knowledge.corrected == knowledge.rejected == []
 
 
 @pytest.mark.parametrize("changed_evidence", ["source", "manifest", "account"])
@@ -660,6 +858,7 @@ def test_changed_bound_evidence_blocks_application_without_mutation(
     transfer.record_qualification(
         view.draft_id, view.items[0].item_id,
         QualificationDecision.KEEP_PROPOSAL,
+        TransferAuthorization(private_source=True),
     )
     if changed_evidence == "source":
         source.tracks[0] = replace(track, duration=999)
@@ -716,6 +915,7 @@ def test_large_draft_application_resumes_from_checkpoints_and_is_idempotent(
     for item in view.items:
         transfer.record_qualification(
             view.draft_id, item.item_id, QualificationDecision.KEEP_PROPOSAL,
+            TransferAuthorization(private_source=True),
         )
     writes_before_apply = spotify.playlist_writes
     transfer.pause()
@@ -780,15 +980,18 @@ def test_agent_qualification_documents_are_first_class_and_privacy_redacted(
     assert document["review_url"].startswith(
         "http://127.0.0.1:8000/qualification/"
     )
-    assert document["next_actions"] == ["review"]
+    assert document["next_actions"] == ["review", "discard"]
     rendered = str(document)
     assert "Private/Agent" not in rendered
     assert "Private Agent Review" not in rendered
     assert _proposal("agent")["uri"] not in rendered
 
-    item_id = transfer.qualification(document["draft_id"]).items[0].item_id
+    item_id = transfer.qualification(
+        document["draft_id"], TransferAuthorization(private_source=True),
+    ).items[0].item_id
     transfer.record_qualification(
         document["draft_id"], item_id, QualificationDecision.KEEP_PROPOSAL,
+        TransferAuthorization(private_source=True),
     )
     ready = contract.qualification_progress(
         document["draft_id"], AgentAuthorization(private_source=True),
@@ -798,6 +1001,733 @@ def test_agent_qualification_documents_are_first_class_and_privacy_redacted(
     )
 
     assert ready["status"] == "ready"
-    assert ready["next_actions"] == ["apply"]
+    assert ready["next_actions"] == ["apply", "discard"]
     assert denied_apply["status"] == "authorization_required"
     assert denied_apply["required_authorizations"] == ["spotify_write"]
+
+
+def test_preview_draft_links_to_distinct_equivalent_provisional_mirror(
+    tmp_path,
+):
+    track = _track("preview-link", title="Preview Link", duration=181)
+    spotify = PlaylistSpotify({"preview-link": _proposal("preview-link")})
+    knowledge = AuthorityRecordingKnowledge()
+    publications = FilePublicationStorage(tmp_path / "publications.json")
+    storage = FileTransferStorage(tmp_path / "transfers.json")
+    transfer = Transfer(
+        source=RekordboxSelection([track]),
+        spotify=spotify,
+        matching_knowledge=knowledge,
+        publishing_guards=AccountPublishingGuards(tmp_path / "locks"),
+        publication_storage=publications,
+        transfer_storage=storage,
+    )
+    preview_plan = transfer.plan_batch(BatchPlanRequest(
+        playlist_references=("Folder/Selected",), preview=True,
+    ))
+    preview = transfer.execute_batch(
+        preview_plan, transfer_id=preview_plan.batch_id,
+    )
+    draft = transfer.obtain_qualification(
+        QualificationRequest(
+            transfer_id=preview.transfer_id,
+            playlist_reference="Folder/Selected",
+        ),
+        TransferAuthorization(private_source=True),
+    )
+    decided = transfer.record_qualification(
+        draft.draft_id,
+        draft.items[0].item_id,
+        QualificationDecision.KEEP_PROPOSAL,
+        TransferAuthorization(private_source=True),
+    )
+
+    assert decided.spotify_playlist_id is None
+    assert decided.next_actions == ("publish_and_link", "discard")
+    with pytest.raises(SpotifyPlaylistReviewRequired, match="linked"):
+        transfer.apply_qualification(
+            draft.draft_id,
+            TransferAuthorization(private_source=True, spotify_write=True),
+        )
+
+    publish_plan = transfer.plan_batch(BatchPlanRequest(
+        playlist_references=("Folder/Selected",),
+    ))
+    published = transfer.execute_batch(
+        publish_plan, transfer_id=publish_plan.batch_id,
+    )
+    writes_before_link = spotify.playlist_writes
+    linked = transfer.link_qualification(
+        draft.draft_id,
+        published.transfer_id,
+        TransferAuthorization(private_source=True),
+    )
+
+    assert linked.draft_id == draft.draft_id
+    assert linked.transfer_id != draft.transfer_id
+    assert linked.spotify_playlist_id == published.playlists[0].spotify_playlist_id
+    assert linked.items[0].decision == QualificationDecision.KEEP_PROPOSAL
+    assert linked.next_actions == ("apply", "discard")
+    assert spotify.playlist_writes == writes_before_link
+    assert knowledge.approved == knowledge.corrected == knowledge.rejected == []
+    restarted = Transfer(
+        source=RekordboxSelection([track]),
+        spotify=spotify,
+        matching_knowledge=knowledge,
+        publishing_guards=AccountPublishingGuards(tmp_path / "locks"),
+        publication_storage=FilePublicationStorage(
+            tmp_path / "publications.json"
+        ),
+        transfer_storage=FileTransferStorage(tmp_path / "transfers.json"),
+    )
+    resumed = restarted.obtain_qualification(
+        QualificationRequest(
+            transfer_id=published.transfer_id,
+            playlist_reference="Folder/Selected",
+        ),
+        TransferAuthorization(private_source=True),
+    )
+    assert resumed.draft_id == linked.draft_id
+    assert resumed.items[0].decision == QualificationDecision.KEEP_PROPOSAL
+    resumed_from_preview = restarted.obtain_qualification(
+        QualificationRequest(
+            transfer_id=preview.transfer_id,
+            playlist_reference="Folder/Selected",
+        ),
+        TransferAuthorization(private_source=True),
+    )
+    assert resumed_from_preview.draft_id == linked.draft_id
+
+    transfer.apply_qualification(
+        linked.draft_id,
+        TransferAuthorization(private_source=True, spotify_write=True),
+    )
+    approval = transfer.approve_qualification(
+        linked.draft_id,
+        TransferAuthorization(private_source=True, spotify_write=True),
+    )
+
+    assert approval.status.value == "approved"
+    assert [item.source_track_id for item in knowledge.approved] == [
+        "preview-link"
+    ]
+
+
+def test_preview_link_fails_closed_if_reviewed_preview_evidence_drifted(
+    tmp_path,
+):
+    track = _track("preview-drift", title="Preview Drift", duration=181)
+    spotify = PlaylistSpotify({"preview-drift": _proposal("preview-drift")})
+    storage = FileTransferStorage(tmp_path / "transfers.json")
+    transfer = Transfer(
+        source=RekordboxSelection([track]),
+        spotify=spotify,
+        matching_knowledge=AuthorityRecordingKnowledge(),
+        publishing_guards=AccountPublishingGuards(tmp_path / "locks"),
+        publication_storage=FilePublicationStorage(
+            tmp_path / "publications.json"
+        ),
+        transfer_storage=storage,
+    )
+    preview_plan = transfer.plan_batch(BatchPlanRequest(
+        playlist_references=("Folder/Selected",), preview=True,
+    ))
+    preview = transfer.execute_batch(
+        preview_plan, transfer_id=preview_plan.batch_id,
+    )
+    draft = transfer.obtain_qualification(
+        QualificationRequest(
+            transfer_id=preview.transfer_id,
+            playlist_reference="Folder/Selected",
+        ),
+        TransferAuthorization(private_source=True),
+    )
+    transfer.record_qualification(
+        draft.draft_id,
+        draft.items[0].item_id,
+        QualificationDecision.KEEP_PROPOSAL,
+        TransferAuthorization(private_source=True),
+    )
+    preview_child = storage.load_batch(preview.transfer_id).playlists[0].transfer_id
+    preview_state = storage.load_transfer(preview_child)
+    preview_state.publication_items[0]["spotify_name"] = "Drifted proposal"
+    storage.save_transfer(preview_child, preview_state)
+    publish_plan = transfer.plan_batch(BatchPlanRequest(
+        playlist_references=("Folder/Selected",),
+    ))
+    published = transfer.execute_batch(
+        publish_plan, transfer_id=publish_plan.batch_id,
+    )
+    writes_before = spotify.playlist_writes
+
+    with pytest.raises(SpotifyPlaylistReviewRequired, match="Preview"):
+        transfer.link_qualification(
+            draft.draft_id,
+            published.transfer_id,
+            TransferAuthorization(private_source=True),
+        )
+
+    assert spotify.playlist_writes == writes_before
+
+
+def test_qualification_storage_rejects_stale_concurrent_revision(tmp_path):
+    track = _track("concurrent", title="Concurrent", duration=181)
+    path = tmp_path / "transfers.json"
+    transfer = Transfer(
+        source=RekordboxSelection([track]),
+        spotify=PlaylistSpotify({"concurrent": _proposal("concurrent")}),
+        matching_knowledge=AuthorityRecordingKnowledge(),
+        publishing_guards=AccountPublishingGuards(tmp_path / "locks"),
+        publication_storage=FilePublicationStorage(
+            tmp_path / "publications.json"
+        ),
+        transfer_storage=FileTransferStorage(path),
+    )
+    plan = transfer.plan_batch(BatchPlanRequest(
+        playlist_references=("Folder/Selected",),
+    ))
+    report = transfer.execute_batch(plan, transfer_id=plan.batch_id)
+    draft = transfer.obtain_qualification(
+        QualificationRequest(
+            transfer_id=report.transfer_id,
+            playlist_reference="Folder/Selected",
+        ),
+        TransferAuthorization(private_source=True),
+    )
+    first = FileTransferStorage(path)
+    second = FileTransferStorage(path)
+    first_state = first.load_qualification(draft.draft_id)
+    stale_state = second.load_qualification(draft.draft_id)
+    first_state.include_all = True
+    first.save_qualification(draft.draft_id, first_state)
+    stale_state.include_all = False
+
+    with pytest.raises(ValueError, match="changed concurrently"):
+        second.save_qualification(draft.draft_id, stale_state)
+
+    assert FileTransferStorage(path).load_qualification(
+        draft.draft_id
+    ).include_all is True
+
+
+def test_qualification_storage_rejects_mismatched_embedded_draft_identity(
+    tmp_path,
+):
+    track = _track("identity", title="Identity", duration=181)
+    path = tmp_path / "transfers.json"
+    transfer = Transfer(
+        source=RekordboxSelection([track]),
+        spotify=PlaylistSpotify({"identity": _proposal("identity")}),
+        matching_knowledge=AuthorityRecordingKnowledge(),
+        publishing_guards=AccountPublishingGuards(tmp_path / "locks"),
+        publication_storage=FilePublicationStorage(
+            tmp_path / "publications.json"
+        ),
+        transfer_storage=FileTransferStorage(path),
+    )
+    plan = transfer.plan_batch(BatchPlanRequest(
+        playlist_references=("Folder/Selected",),
+    ))
+    report = transfer.execute_batch(plan, transfer_id=plan.batch_id)
+    draft = transfer.obtain_qualification(
+        QualificationRequest(
+            transfer_id=report.transfer_id,
+            playlist_reference="Folder/Selected",
+        ),
+        TransferAuthorization(private_source=True),
+    )
+    persisted = json.loads(path.read_text())
+    stored = persisted["qualifications"].pop(draft.draft_id)
+    persisted["qualifications"]["different-map-key"] = stored
+    path.write_text(json.dumps(persisted))
+
+    with pytest.raises(ValueError, match="Transfer state is malformed"):
+        FileTransferStorage(path)
+
+
+def test_schema_three_transfer_and_schema_five_manifest_apply_additively(
+    tmp_path,
+):
+    legacy_item_keys = {
+        "source_track_id", "source_name", "source_artist", "source_title",
+        "spotify_uri", "spotify_name", "spotify_artist", "score",
+        "match_type", "score_reasons", "source_duration", "authoritative",
+        "local_evidence_id",
+    }
+
+    def legacy_item(item):
+        return {key: value for key, value in item.items() if key in legacy_item_keys}
+
+    track = _track("legacy", title="Legacy", duration=181)
+    spotify = PlaylistSpotify({"legacy": _proposal("legacy")})
+    transfer_path = tmp_path / "transfers.json"
+    publication_path = tmp_path / "publications.json"
+    transfer = Transfer(
+        source=RekordboxSelection([track]),
+        spotify=spotify,
+        matching_knowledge=AuthorityRecordingKnowledge(),
+        publishing_guards=AccountPublishingGuards(tmp_path / "locks"),
+        publication_storage=FilePublicationStorage(publication_path),
+        transfer_storage=FileTransferStorage(transfer_path),
+    )
+    plan = transfer.plan_batch(BatchPlanRequest(
+        playlist_references=("Folder/Selected",),
+    ))
+    report = transfer.execute_batch(plan, transfer_id=plan.batch_id)
+
+    legacy_transfers = json.loads(transfer_path.read_text())
+    legacy_transfers["version"] = 3
+    for batch in legacy_transfers["batches"].values():
+        batch.pop("revision", None)
+    for state in legacy_transfers["transfers"].values():
+        state.pop("revision", None)
+        state.pop("audition_selection_digest", None)
+        for selected in state.get("selection", {}).get("tracks", []):
+            selected.pop("version", None)
+        state["publication_items"] = [
+            legacy_item(item) for item in state["publication_items"]
+        ]
+        if state.get("publication_manifest"):
+            state["publication_manifest"]["items"] = [
+                legacy_item(item)
+                for item in state["publication_manifest"]["items"]
+            ]
+            state["publication_manifest"]["managed_items"] = [
+                legacy_item(item)
+                for item in state["publication_manifest"]["managed_items"]
+            ]
+    transfer_path.write_text(json.dumps(legacy_transfers))
+    legacy_publications = json.loads(publication_path.read_text())
+    legacy_publications["version"] = 5
+    for manifest in legacy_publications["manifests"]:
+        manifest["items"] = [legacy_item(item) for item in manifest["items"]]
+        manifest["managed_items"] = [
+            legacy_item(item) for item in manifest["managed_items"]
+        ]
+    publication_path.write_text(json.dumps(legacy_publications))
+
+    resumed = Transfer(
+        source=RekordboxSelection([track]),
+        spotify=spotify,
+        matching_knowledge=AuthorityRecordingKnowledge(),
+        publishing_guards=AccountPublishingGuards(tmp_path / "locks"),
+        publication_storage=FilePublicationStorage(publication_path),
+        transfer_storage=FileTransferStorage(transfer_path),
+    )
+    draft = resumed.obtain_qualification(
+        QualificationRequest(
+            transfer_id=report.transfer_id,
+            playlist_reference="Folder/Selected",
+        ),
+        TransferAuthorization(private_source=True),
+    )
+    resumed.record_qualification(
+        draft.draft_id,
+        draft.items[0].item_id,
+        QualificationDecision.KEEP_PROPOSAL,
+        TransferAuthorization(private_source=True),
+    )
+    outcome = resumed.apply_qualification(
+        draft.draft_id,
+        TransferAuthorization(private_source=True, spotify_write=True),
+    )
+
+    assert outcome.status == QualificationStatus.APPLIED
+    assert json.loads(transfer_path.read_text())["version"] == 4
+    assert json.loads(publication_path.read_text())["version"] == 6
+
+
+def test_discard_blocks_approval_until_explicit_fresh_draft_is_applied(
+    tmp_path,
+):
+    track = _track("discard", title="Discard", duration=181)
+    spotify = PlaylistSpotify({"discard": _proposal("discard")})
+    knowledge = AuthorityRecordingKnowledge()
+    transfer = Transfer(
+        source=RekordboxSelection([track]),
+        spotify=spotify,
+        matching_knowledge=knowledge,
+        publishing_guards=AccountPublishingGuards(tmp_path / "locks"),
+        publication_storage=FilePublicationStorage(
+            tmp_path / "publications.json"
+        ),
+        transfer_storage=FileTransferStorage(tmp_path / "transfers.json"),
+    )
+    plan = transfer.plan_batch(BatchPlanRequest(
+        playlist_references=("Folder/Selected",),
+    ))
+    report = transfer.execute_batch(plan, transfer_id=plan.batch_id)
+    playlist_id = report.playlists[0].spotify_playlist_id
+    draft = transfer.obtain_qualification(
+        QualificationRequest(
+            transfer_id=report.transfer_id,
+            playlist_reference="Folder/Selected",
+        ),
+        TransferAuthorization(private_source=True),
+    )
+
+    discarded = transfer.discard_qualification(
+        draft.draft_id, TransferAuthorization(private_source=True),
+    )
+
+    assert discarded.status.value == "discarded"
+    assert transfer.obtain_qualification(
+        QualificationRequest(
+            transfer_id=report.transfer_id,
+            playlist_reference="Folder/Selected",
+        ),
+        TransferAuthorization(private_source=True),
+    ).status.value == "discarded"
+    with pytest.raises(SpotifyPlaylistReviewRequired, match="completed and applied"):
+        transfer.approve(playlist_id)
+    assert knowledge.approved == knowledge.rejected == []
+
+    fresh = transfer.supersede_qualification(
+        draft.draft_id, TransferAuthorization(private_source=True),
+    )
+    assert fresh.draft_id != draft.draft_id
+    assert fresh.pending == 1
+    assert transfer.obtain_qualification(
+        QualificationRequest(
+            transfer_id=report.transfer_id,
+            playlist_reference="Folder/Selected",
+        ),
+        TransferAuthorization(private_source=True),
+    ).draft_id == fresh.draft_id
+    ready = transfer.record_qualification(
+        fresh.draft_id,
+        fresh.items[0].item_id,
+        QualificationDecision.KEEP_PROPOSAL,
+        TransferAuthorization(private_source=True),
+    )
+    transfer.apply_qualification(
+        ready.draft_id,
+        TransferAuthorization(private_source=True, spotify_write=True),
+    )
+    approved = transfer.approve_qualification(
+        fresh.draft_id,
+        TransferAuthorization(private_source=True, spotify_write=True),
+    )
+
+    assert approved.status.value == "approved"
+    assert [item.source_track_id for item in knowledge.approved] == ["discard"]
+
+
+def test_changed_manifest_after_apply_blocks_approval_without_authority_writes(
+    tmp_path,
+):
+    track = _track("manifest", title="Manifest", duration=181)
+    spotify = PlaylistSpotify({"manifest": _proposal("manifest")})
+    knowledge = AuthorityRecordingKnowledge()
+    publications = FilePublicationStorage(tmp_path / "publications.json")
+    transfer = Transfer(
+        source=RekordboxSelection([track]),
+        spotify=spotify,
+        matching_knowledge=knowledge,
+        publishing_guards=AccountPublishingGuards(tmp_path / "locks"),
+        publication_storage=publications,
+        transfer_storage=FileTransferStorage(tmp_path / "transfers.json"),
+    )
+    plan = transfer.plan_batch(BatchPlanRequest(
+        playlist_references=("Folder/Selected",),
+    ))
+    report = transfer.execute_batch(plan, transfer_id=plan.batch_id)
+    playlist_id = report.playlists[0].spotify_playlist_id
+    draft = transfer.obtain_qualification(
+        QualificationRequest(
+            transfer_id=report.transfer_id,
+            playlist_reference="Folder/Selected",
+        ),
+        TransferAuthorization(private_source=True),
+    )
+    transfer.record_qualification(
+        draft.draft_id,
+        draft.items[0].item_id,
+        QualificationDecision.KEEP_PROPOSAL,
+        TransferAuthorization(private_source=True),
+    )
+    transfer.apply_qualification(
+        draft.draft_id,
+        TransferAuthorization(private_source=True, spotify_write=True),
+    )
+    retained = publications.publication_for_playlist(
+        "spotify-account-one", playlist_id,
+    )
+    assert retained is not None
+    publications.retain_publication(replace(
+        retained, spotify_playlist_name="Changed after Qualification",
+    ))
+
+    with pytest.raises(SpotifyPlaylistReviewRequired, match="changed after"):
+        transfer.approve_qualification(
+            draft.draft_id,
+            TransferAuthorization(private_source=True, spotify_write=True),
+        )
+
+    assert knowledge.approved == knowledge.corrected == knowledge.rejected == []
+
+
+@pytest.mark.parametrize("changed_evidence", ["source", "playlist_head"])
+def test_changed_evidence_after_apply_blocks_qualification_approval(
+    tmp_path, changed_evidence,
+):
+    track = _track("approve-stable", title="Approve Stable", duration=181)
+    source = RekordboxSelection([track])
+    spotify = PlaylistSpotify({"approve-stable": _proposal("approve-stable")})
+    knowledge = AuthorityRecordingKnowledge()
+    transfer = Transfer(
+        source=source,
+        spotify=spotify,
+        matching_knowledge=knowledge,
+        publishing_guards=AccountPublishingGuards(tmp_path / "locks"),
+        publication_storage=FilePublicationStorage(
+            tmp_path / "publications.json"
+        ),
+        transfer_storage=FileTransferStorage(tmp_path / "transfers.json"),
+    )
+    plan = transfer.plan_batch(BatchPlanRequest(
+        playlist_references=("Folder/Selected",),
+    ))
+    report = transfer.execute_batch(plan, transfer_id=plan.batch_id)
+    draft = transfer.obtain_qualification(
+        QualificationRequest(
+            transfer_id=report.transfer_id,
+            playlist_reference="Folder/Selected",
+        ),
+        TransferAuthorization(private_source=True),
+    )
+    transfer.record_qualification(
+        draft.draft_id,
+        draft.items[0].item_id,
+        QualificationDecision.KEEP_PROPOSAL,
+        TransferAuthorization(private_source=True),
+    )
+    transfer.apply_qualification(
+        draft.draft_id,
+        TransferAuthorization(private_source=True, spotify_write=True),
+    )
+    writes_before_approval = spotify.playlist_writes
+    if changed_evidence == "source":
+        source.tracks = [
+            replace(track, name="Changed after application"),
+        ]
+        expected = SpotifyPlaylistReviewRequired
+    else:
+        spotify._mutated(
+            report.playlists[0].spotify_playlist_id,
+            [_proposal("manual-edit")["uri"]],
+        )
+        expected = SpotifyPlaylistChanged
+        writes_before_approval = spotify.playlist_writes
+
+    with pytest.raises(expected):
+        transfer.approve_qualification(
+            draft.draft_id,
+            TransferAuthorization(private_source=True, spotify_write=True),
+        )
+
+    assert spotify.playlist_writes == writes_before_approval
+    assert knowledge.approved == knowledge.corrected == knowledge.rejected == []
+
+
+@pytest.mark.parametrize("phase", ["apply", "approval"])
+def test_agent_reports_missing_source_as_review_required_without_effects(
+    tmp_path, phase,
+):
+    track = _track("source-loss", title="Source Loss", duration=181)
+    source = RekordboxSelection([track])
+    spotify = PlaylistSpotify({"source-loss": _proposal("source-loss")})
+    knowledge = AuthorityRecordingKnowledge()
+    transfer = Transfer(
+        source=source,
+        spotify=spotify,
+        matching_knowledge=knowledge,
+        publishing_guards=AccountPublishingGuards(tmp_path / "locks"),
+        publication_storage=FilePublicationStorage(
+            tmp_path / "publications.json"
+        ),
+        transfer_storage=FileTransferStorage(tmp_path / "transfers.json"),
+    )
+    plan = transfer.plan_batch(BatchPlanRequest(
+        playlist_references=("Folder/Selected",),
+    ))
+    report = transfer.execute_batch(plan, transfer_id=plan.batch_id)
+    draft = transfer.obtain_qualification(
+        QualificationRequest(
+            transfer_id=report.transfer_id,
+            playlist_reference="Folder/Selected",
+        ),
+        TransferAuthorization(private_source=True),
+    )
+    transfer.record_qualification(
+        draft.draft_id,
+        draft.items[0].item_id,
+        QualificationDecision.KEEP_PROPOSAL,
+        TransferAuthorization(private_source=True),
+    )
+    if phase == "approval":
+        transfer.apply_qualification(
+            draft.draft_id,
+            TransferAuthorization(private_source=True, spotify_write=True),
+        )
+    writes_before = spotify.playlist_writes
+
+    def missing(reference):
+        raise SourceNotFound("synthetic selected source disappeared")
+
+    source.consume = missing
+    contract = AgentTransferContract(transfer)
+    if phase == "apply":
+        document = contract.apply_qualification(
+            draft.draft_id,
+            AgentAuthorization(private_source=True, spotify_write=True),
+        )
+    else:
+        document = contract.approve_qualification(
+            draft.draft_id,
+            AgentAuthorization(private_source=True),
+        )
+
+    assert document["status"] == "review_required"
+    assert document["draft_id"] == draft.draft_id
+    assert spotify.playlist_writes == writes_before
+    assert knowledge.approved == knowledge.corrected == knowledge.rejected == []
+
+
+def test_staged_correction_renders_replacement_facts_and_rejects_invalid_choices(
+    tmp_path,
+):
+    track = _track("correction", title="Correction", duration=360)
+    original = _proposal(
+        "correction", match_type="shorter_version", duration_ms=180_000,
+    )
+    spotify = PlaylistSpotify({"correction": original})
+    transfer = Transfer(
+        source=RekordboxSelection([track]),
+        spotify=spotify,
+        matching_knowledge=AuthorityRecordingKnowledge(),
+        publishing_guards=AccountPublishingGuards(tmp_path / "locks"),
+        publication_storage=FilePublicationStorage(
+            tmp_path / "publications.json"
+        ),
+        transfer_storage=FileTransferStorage(tmp_path / "transfers.json"),
+    )
+    plan = transfer.plan_batch(BatchPlanRequest(
+        playlist_references=("Folder/Selected",),
+    ))
+    report = transfer.execute_batch(plan, transfer_id=plan.batch_id)
+    draft = transfer.obtain_qualification(
+        QualificationRequest(
+            transfer_id=report.transfer_id,
+            playlist_reference="Folder/Selected",
+        ),
+        TransferAuthorization(private_source=True),
+    )
+    with pytest.raises(ValueError, match="different Spotify track"):
+        transfer.record_qualification(
+            draft.draft_id,
+            draft.items[0].item_id,
+            QualificationDecision.CORRECTION,
+            TransferAuthorization(private_source=True),
+            spotify_reference=original["uri"],
+        )
+    replacement = "spotify:track:replacement00000000000"
+    corrected = transfer.record_qualification(
+        draft.draft_id,
+        draft.items[0].item_id,
+        QualificationDecision.CORRECTION,
+        TransferAuthorization(private_source=True),
+        spotify_reference=replacement,
+    )
+    item = corrected.items[0]
+
+    assert item.spotify_uri == replacement
+    assert item.spotify_release == "Replacement Release"
+    assert item.spotify_duration == 222
+    assert item.match_type == "correction"
+    assert item.score_reasons == ("explicit Qualification Correction",)
+    assert item.attention_reasons == ("staged_correction",)
+    assert "shorter_version" not in item.attention_reasons
+    assert "duration_conflict" not in item.attention_reasons
+
+    spotify.spotify_track = lambda uri: {
+        "uri": uri,
+        "name": "Unavailable",
+        "artist": "Replacement Artist",
+        "album": "Replacement Release",
+        "duration_ms": 222_000,
+        "is_playable": False,
+    }
+    with pytest.raises(ValueError, match="not an available"):
+        transfer.record_qualification(
+            draft.draft_id,
+            item.item_id,
+            QualificationDecision.CORRECTION,
+            TransferAuthorization(private_source=True),
+            spotify_reference=_proposal("unavailable")["uri"],
+        )
+
+
+def test_abandoned_qualification_approval_retires_local_audition_handles(
+    tmp_path, monkeypatch,
+):
+    media = tmp_path / "selected-source.wav"
+    media.write_bytes(b"synthetic media")
+    track = _track(
+        "abandoned", title="Abandoned", duration=181,
+        location=media.as_uri(),
+    )
+    spotify = PlaylistSpotify({"abandoned": _proposal("abandoned")})
+    audition = LocalSourceAudition()
+    transfer = Transfer(
+        source=RekordboxSelection([track]),
+        spotify=spotify,
+        matching_knowledge=AuthorityRecordingKnowledge(),
+        publishing_guards=AccountPublishingGuards(tmp_path / "locks"),
+        publication_storage=FilePublicationStorage(
+            tmp_path / "publications.json"
+        ),
+        transfer_storage=FileTransferStorage(tmp_path / "transfers.json"),
+        local_audition=audition,
+    )
+    plan = transfer.plan_batch(BatchPlanRequest(
+        playlist_references=("Folder/Selected",),
+        local_audio_audition=True,
+    ))
+    report = transfer.execute_batch(plan, transfer_id=plan.batch_id)
+    draft = transfer.obtain_qualification(
+        QualificationRequest(
+            transfer_id=report.transfer_id,
+            playlist_reference="Folder/Selected",
+        ),
+        TransferAuthorization(private_source=True),
+    )
+    transfer.record_qualification(
+        draft.draft_id,
+        draft.items[0].item_id,
+        QualificationDecision.KEEP_PROPOSAL,
+        TransferAuthorization(private_source=True),
+    )
+    transfer.apply_qualification(
+        draft.draft_id,
+        TransferAuthorization(private_source=True, spotify_write=True),
+    )
+    opened = transfer.audition_qualification(
+        draft.draft_id,
+        draft.items[0].item_id,
+        TransferAuthorization(private_source=True),
+    )
+    monkeypatch.delattr(PlaylistSpotify, "ordered_playlist_items")
+    spotify.provisional_playlist_track_uris = lambda playlist_id: None
+
+    outcome = transfer.approve_qualification(
+        draft.draft_id,
+        TransferAuthorization(private_source=True, spotify_write=True),
+    )
+
+    assert outcome.status.value == "abandoned"
+    with pytest.raises(AuditionHandleUnavailable):
+        audition.stream(opened.handle)
+    assert transfer.qualification(
+        draft.draft_id, TransferAuthorization(private_source=True),
+    ).status == QualificationStatus.REVIEW_REQUIRED

--- a/tests/test_qualification.py
+++ b/tests/test_qualification.py
@@ -1,0 +1,803 @@
+"""Behavior tests for Rekordbox Qualification through the Transfer seam."""
+
+from __future__ import annotations
+
+from dataclasses import replace
+
+import pytest
+
+from djsupport.agent import AgentAuthorization, AgentTransferContract
+from djsupport.rekordbox import Track
+from djsupport.transfer import (
+    AccountPublishingGuards,
+    BatchPlanRequest,
+    EphemeralMatchingKnowledge,
+    FilePublicationStorage,
+    FileTransferStorage,
+    QualificationDecision,
+    QualificationRequest,
+    SourceSelection,
+    SpotifyMutationResult,
+    SpotifyPlaylistHead,
+    SpotifyPlaylistItem,
+    SpotifyPlaylistPage,
+    SpotifyItemKind,
+    SpotifyPlaylistChanged,
+    SpotifyPlaylistReviewRequired,
+    Transfer,
+    TransferAuthorization,
+    TransferMode,
+)
+
+
+def _track(
+    track_id: str,
+    *,
+    title: str,
+    duration: int,
+    album: str = "Invented Source Release",
+    label: str = "Invented Source Label",
+    version: str = "",
+    location: str = "",
+) -> Track:
+    return Track(
+        track_id=track_id,
+        name=title,
+        artist="Invented Source Artist",
+        album=album,
+        remixer="",
+        label=label,
+        genre="Synthetic",
+        date_added="2026-08-08",
+        duration=duration,
+        location=location,
+        version=version,
+    )
+
+
+class RekordboxSelection:
+    source_label = "Rekordbox"
+    default_mode = TransferMode.MIRROR
+
+    def __init__(self, tracks: list[Track]) -> None:
+        self.tracks = tracks
+        self.consumed = 0
+
+    def consume(self, reference: str) -> SourceSelection:
+        self.consumed += 1
+        return SourceSelection("Selected", reference, list(self.tracks))
+
+    def consume_batch(self, references, whole_library):
+        return tuple(self.consume(reference) for reference in references)
+
+
+class ProposalSpotify:
+    def __init__(self, proposals: dict[str, dict | None]) -> None:
+        self.proposals = proposals
+        self.searches: list[str] = []
+
+    def account_id(self):
+        return "spotify-account-one"
+
+    def match(self, track, threshold):
+        self.searches.append(track.track_id)
+        return self.proposals[track.track_id]
+
+    def spotify_track(self, uri):
+        return {"uri": uri, "is_playable": True}
+
+
+class PlaylistSpotify(ProposalSpotify):
+    def __init__(self, proposals: dict[str, dict | None]) -> None:
+        super().__init__(proposals)
+        self.playlists: dict[str, list[str]] = {}
+        self.heads: dict[str, str] = {}
+        self.playlist_writes = 0
+
+    def create_playlist(self, name, description):
+        self.playlists["provisional-one"] = []
+        self.heads["provisional-one"] = "head-0"
+        return "provisional-one"
+
+    def find_recovery_playlist(self, publication_key):
+        return None
+
+    def _mutated(self, playlist_id, uris):
+        self.playlist_writes += 1
+        self.playlists[playlist_id] = list(uris)
+        head = f"head-{self.playlist_writes}"
+        self.heads[playlist_id] = head
+        return SpotifyMutationResult(head)
+
+    def replace_items(self, playlist_id, uris):
+        return self._mutated(playlist_id, uris)
+
+    def add_items(self, playlist_id, uris):
+        return self._mutated(playlist_id, [*self.playlists[playlist_id], *uris])
+
+    def playlist_head(self, playlist_id):
+        return SpotifyPlaylistHead(self.heads[playlist_id])
+
+    def ordered_playlist_items(self, playlist_id):
+        return SpotifyPlaylistPage(tuple(
+            SpotifyPlaylistItem(index, SpotifyItemKind.TRACK, uri)
+            for index, uri in enumerate(self.playlists[playlist_id])
+        ))
+
+    def set_playlist_description(self, playlist_id, description):
+        pass
+
+    def provisional_playlist_track_uris(self, playlist_id):
+        return list(self.playlists[playlist_id])
+
+    def replace_provisional_playlist_tracks(self, playlist_id, uris):
+        self._mutated(playlist_id, uris)
+
+    def spotify_track(self, uri):
+        return {
+            "uri": uri,
+            "name": "Explicit Replacement",
+            "artist": "Replacement Artist",
+            "album": "Replacement Release",
+            "duration_ms": 222_000,
+            "is_playable": True,
+        }
+
+
+class RetainedKnowledge(EphemeralMatchingKnowledge):
+    persistent = True
+
+    def __init__(self, retained: dict[str, dict] | None = None) -> None:
+        self.retained = retained or {}
+
+    def lookup(self, track, threshold):
+        return self.retained.get(track.track_id)
+
+
+class AuthorityRecordingKnowledge(RetainedKnowledge):
+    def __init__(self) -> None:
+        super().__init__()
+        self.proposal_writes = 0
+        self.approved = []
+        self.corrected = []
+        self.rejected = []
+
+    def should_retry(self, track, threshold, retry_days, force):
+        return True
+
+    def retain(self, track, threshold, result):
+        self.proposal_writes += 1
+
+    def approve(self, item):
+        self.approved.append(item)
+
+    def correct(self, item):
+        self.corrected.append(item)
+
+    def reject(self, item):
+        self.rejected.append(item)
+
+    def approve_local_audio(self, item, account_id):
+        return None
+
+
+def _proposal(
+    suffix: str,
+    *,
+    match_type: str = "exact",
+    score: float = 96.0,
+    reasons: tuple[str, ...] = ("artist agrees", "duration agrees"),
+    duration_ms: int = 181_000,
+) -> dict:
+    return {
+        "uri": f"spotify:track:{suffix:0<22}",
+        "name": f"Invented Spotify {suffix}",
+        "artist": "Invented Spotify Artist",
+        "album": "Invented Spotify Release",
+        "duration_ms": duration_ms,
+        "score": score,
+        "match_type": match_type,
+        "score_reasons": list(reasons),
+    }
+
+
+def test_rekordbox_attention_queue_preserves_review_facts_and_authority(
+    tmp_path,
+):
+    tracks = [
+        _track("new", title="New Proposal", duration=181, version="Original Mix"),
+        _track("short", title="Shorter Proposal", duration=360),
+        _track("approved", title="Approved by Local Audio", duration=240),
+    ]
+    source = RekordboxSelection(tracks)
+    spotify = ProposalSpotify({
+        "new": _proposal("new"),
+        "short": _proposal(
+            "short", match_type="shorter_version", score=91.0,
+            reasons=("artist agrees", "Spotify proposal is meaningfully shorter"),
+            duration_ms=210_000,
+        ),
+        "approved": None,
+    })
+    knowledge = RetainedKnowledge({
+        "approved": {
+            **_proposal("approved", match_type="approved_local_audio"),
+            "authoritative": True,
+        },
+    })
+    storage = FileTransferStorage(tmp_path / "transfers.json")
+    transfer = Transfer(
+        source=source,
+        spotify=spotify,
+        matching_knowledge=knowledge,
+        publishing_guards=AccountPublishingGuards(tmp_path / "locks"),
+        transfer_storage=storage,
+    )
+    plan = transfer.plan_batch(BatchPlanRequest(
+        playlist_references=("Folder/Selected",),
+        preview=True,
+        local_audio_audition=True,
+    ))
+    report = transfer.execute_batch(plan, transfer_id=plan.batch_id)
+
+    attention = transfer.obtain_qualification(
+        QualificationRequest(
+            transfer_id=report.transfer_id,
+            playlist_reference="Folder/Selected",
+        ),
+        TransferAuthorization(private_source=True),
+    )
+
+    assert [item.source_track_id for item in attention.items] == ["new", "short"]
+    assert attention.items[0].attention_reasons == ("new_proposal",)
+    assert "shorter_version" in attention.items[1].attention_reasons
+    assert attention.items[0].source_release == "Invented Source Release"
+    assert attention.items[0].source_label == "Invented Source Label"
+    assert attention.items[0].source_version == "Original Mix"
+    assert attention.items[0].spotify_release == "Invented Spotify Release"
+    assert attention.items[0].spotify_duration == 181
+    assert attention.items[0].score_reasons == (
+        "artist agrees", "duration agrees",
+    )
+    assert attention.pending == 2
+    assert spotify.searches == ["new", "short"]
+
+    all_proposals = transfer.obtain_qualification(
+        QualificationRequest(
+            transfer_id=report.transfer_id,
+            playlist_reference="Folder/Selected",
+            include_all=True,
+        ),
+        TransferAuthorization(private_source=True),
+    )
+
+    assert [item.source_track_id for item in all_proposals.items] == [
+        "new", "short", "approved",
+    ]
+    approved = all_proposals.items[-1]
+    assert approved.match_type == "approved_local_audio"
+    assert approved.authority_status == "approved"
+    assert approved.attention_reasons == ()
+
+
+def test_completed_draft_applies_before_separate_playlist_approval(tmp_path):
+    tracks = [
+        _track("keep", title="Keep Proposal", duration=181),
+        _track("correct", title="Correct Proposal", duration=182),
+        _track("defer", title="Deferred Proposal", duration=183),
+        _track("reject", title="Rejected Proposal", duration=184),
+    ]
+    spotify = PlaylistSpotify({
+        track.track_id: _proposal(track.track_id, duration_ms=track.duration * 1000)
+        for track in tracks
+    })
+    knowledge = AuthorityRecordingKnowledge()
+    publications = FilePublicationStorage(tmp_path / "publications.json")
+    transfer = Transfer(
+        source=RekordboxSelection(tracks),
+        spotify=spotify,
+        matching_knowledge=knowledge,
+        publishing_guards=AccountPublishingGuards(tmp_path / "locks"),
+        publication_storage=publications,
+        transfer_storage=FileTransferStorage(tmp_path / "transfers.json"),
+    )
+    plan = transfer.plan_batch(BatchPlanRequest(
+        playlist_references=("Folder/Selected",),
+    ))
+    report = transfer.execute_batch(plan, transfer_id=plan.batch_id)
+    playlist_id = report.playlists[0].spotify_playlist_id
+    view = transfer.obtain_qualification(
+        QualificationRequest(
+            transfer_id=report.transfer_id,
+            playlist_reference="Folder/Selected",
+        ),
+        TransferAuthorization(private_source=True),
+    )
+    item_ids = {item.source_track_id: item.item_id for item in view.items}
+    writes_after_publication = spotify.playlist_writes
+    proposal_writes_after_matching = knowledge.proposal_writes
+
+    transfer.record_qualification(
+        view.draft_id, item_ids["keep"], QualificationDecision.KEEP_PROPOSAL,
+    )
+    transfer.record_qualification(
+        view.draft_id,
+        item_ids["correct"],
+        QualificationDecision.CORRECTION,
+        spotify_reference="spotify:track:replacement00000000000",
+    )
+    deferred = transfer.record_qualification(
+        view.draft_id,
+        item_ids["defer"],
+        QualificationDecision.DEFERRED,
+        reason="Needs a different listening environment",
+    )
+    transfer.record_qualification(
+        view.draft_id, item_ids["reject"], QualificationDecision.REJECT_PROPOSAL,
+    )
+
+    assert deferred.deferred == 1
+    assert spotify.playlist_writes == writes_after_publication
+    assert knowledge.proposal_writes == proposal_writes_after_matching
+    assert knowledge.approved == knowledge.corrected == knowledge.rejected == []
+    with pytest.raises(
+        SpotifyPlaylistReviewRequired, match="completed and applied"
+    ):
+        transfer.approve(playlist_id)
+    with pytest.raises(ValueError, match="pending or deferred"):
+        transfer.apply_qualification(
+            view.draft_id,
+            TransferAuthorization(private_source=True, spotify_write=True),
+        )
+    with pytest.raises(PermissionError, match="spotify_write"):
+        transfer.apply_qualification(
+            view.draft_id, TransferAuthorization(private_source=True),
+        )
+    assert spotify.playlist_writes == writes_after_publication
+
+    ready = transfer.record_qualification(
+        view.draft_id,
+        item_ids["defer"],
+        QualificationDecision.DEFERRED,
+        reason="Explicitly omitted from this bounded review",
+        exclude=True,
+    )
+    assert ready.complete is True
+    applied = transfer.apply_qualification(
+        view.draft_id,
+        TransferAuthorization(private_source=True, spotify_write=True),
+    )
+
+    assert applied.status.value == "applied"
+    assert spotify.playlists[playlist_id] == [
+        _proposal("keep")["uri"],
+        "spotify:track:replacement00000000000",
+    ]
+    assert knowledge.approved == knowledge.corrected == knowledge.rejected == []
+
+    approval = transfer.approve(playlist_id)
+
+    assert approval.status.value == "approved"
+    assert [item.source_track_id for item in knowledge.approved] == ["keep"]
+    assert [item.source_track_id for item in knowledge.corrected] == ["correct"]
+    assert [item.source_track_id for item in knowledge.rejected] == ["reject"]
+
+
+def test_duplicate_source_occurrences_remain_ordered_facts_through_approval(
+    tmp_path,
+):
+    repeated = _track("repeat", title="Repeated Source", duration=181)
+    spotify = PlaylistSpotify({"repeat": _proposal("repeat")})
+    knowledge = AuthorityRecordingKnowledge()
+    publications = FilePublicationStorage(tmp_path / "publications.json")
+    transfer = Transfer(
+        source=RekordboxSelection([repeated, repeated]),
+        spotify=spotify,
+        matching_knowledge=knowledge,
+        publishing_guards=AccountPublishingGuards(tmp_path / "locks"),
+        publication_storage=publications,
+        transfer_storage=FileTransferStorage(tmp_path / "transfers.json"),
+    )
+    plan = transfer.plan_batch(BatchPlanRequest(
+        playlist_references=("Folder/Selected",),
+    ))
+    report = transfer.execute_batch(plan, transfer_id=plan.batch_id)
+    view = transfer.obtain_qualification(
+        QualificationRequest(
+            transfer_id=report.transfer_id,
+            playlist_reference="Folder/Selected",
+        ),
+        TransferAuthorization(private_source=True),
+    )
+
+    assert [item.source_index for item in view.items] == [0, 1]
+    assert len({item.item_id for item in view.items}) == 2
+    for item in view.items:
+        transfer.record_qualification(
+            view.draft_id, item.item_id, QualificationDecision.KEEP_PROPOSAL,
+        )
+    transfer.apply_qualification(
+        view.draft_id,
+        TransferAuthorization(private_source=True, spotify_write=True),
+    )
+    outcome = transfer.approve(report.playlists[0].spotify_playlist_id)
+
+    assert outcome.status.value == "approved"
+    assert outcome.collisions == ()
+    assert spotify.playlists[report.playlists[0].spotify_playlist_id] == [
+        _proposal("repeat")["uri"], _proposal("repeat")["uri"],
+    ]
+
+
+def test_attention_queue_explains_fallback_unresolved_collision_and_conflict(
+    tmp_path,
+):
+    tracks = [
+        _track("fallback", title="Fallback", duration=360),
+        _track(
+            "version", title="Version Conflict", duration=240,
+            version="Extended Mix",
+        ),
+        _track("unresolved", title="Unresolved", duration=200),
+        _track("collision-a", title="Collision A", duration=201),
+        _track("collision-b", title="Collision B", duration=202),
+    ]
+    shared = _proposal("shared")
+    spotify = ProposalSpotify({
+        "fallback": _proposal("fallback", match_type="fallback_version"),
+        "version": _proposal(
+            "version", reasons=(
+                "artist agrees",
+                "version conflict: Spotify proposal differs from source version",
+            ),
+        ),
+        "unresolved": {"alternatives": [_proposal("alternative", score=77.0)]},
+        "collision-a": shared,
+        "collision-b": shared,
+    })
+
+    class ConflictKnowledge(RetainedKnowledge):
+        def should_retry(self, track, threshold, retry_days, force):
+            return True
+
+        def approval_conflict(self, item):
+            return item.source_track_id == "fallback"
+
+    transfer = Transfer(
+        source=RekordboxSelection(tracks),
+        spotify=spotify,
+        matching_knowledge=ConflictKnowledge(),
+        publishing_guards=AccountPublishingGuards(tmp_path / "locks"),
+        transfer_storage=FileTransferStorage(tmp_path / "transfers.json"),
+    )
+    plan = transfer.plan_batch(BatchPlanRequest(
+        playlist_references=("Folder/Selected",), preview=True,
+    ))
+    report = transfer.execute_batch(plan, transfer_id=plan.batch_id)
+    view = transfer.obtain_qualification(
+        QualificationRequest(
+            transfer_id=report.transfer_id,
+            playlist_reference="Folder/Selected",
+        ),
+        TransferAuthorization(private_source=True),
+    )
+    reasons = {
+        item.source_track_id: item.attention_reasons for item in view.items
+    }
+
+    assert [item.source_track_id for item in view.items] == [
+        "fallback", "version", "unresolved", "collision-a", "collision-b",
+    ]
+    assert "fallback_version" in reasons["fallback"]
+    assert "approval_conflict" in reasons["fallback"]
+    assert "version_conflict" in reasons["version"]
+    assert reasons["unresolved"] == ("unresolved", "alternatives")
+    assert "match_collision" in reasons["collision-a"]
+    assert "match_collision" in reasons["collision-b"]
+
+
+@pytest.mark.parametrize("conflict_kind", ["match_collision", "approval_conflict"])
+def test_unresolved_conflicts_block_draft_application_before_mutation(
+    tmp_path, conflict_kind,
+):
+    tracks = [
+        _track("conflict-a", title="Conflict A", duration=181),
+        _track("conflict-b", title="Conflict B", duration=182),
+    ]
+    proposals = {
+        "conflict-a": _proposal("shared"),
+        "conflict-b": (
+            _proposal("shared")
+            if conflict_kind == "match_collision" else _proposal("other")
+        ),
+    }
+
+    class ConflictKnowledge(AuthorityRecordingKnowledge):
+        def approval_conflict(self, item):
+            return (
+                conflict_kind == "approval_conflict"
+                and item.source_track_id == "conflict-a"
+            )
+
+    spotify = PlaylistSpotify(proposals)
+    transfer = Transfer(
+        source=RekordboxSelection(tracks),
+        spotify=spotify,
+        matching_knowledge=ConflictKnowledge(),
+        publishing_guards=AccountPublishingGuards(tmp_path / "locks"),
+        publication_storage=FilePublicationStorage(tmp_path / "publications.json"),
+        transfer_storage=FileTransferStorage(tmp_path / "transfers.json"),
+    )
+    plan = transfer.plan_batch(BatchPlanRequest(
+        playlist_references=("Folder/Conflict",),
+    ))
+    report = transfer.execute_batch(plan, transfer_id=plan.batch_id)
+    view = transfer.obtain_qualification(
+        QualificationRequest(
+            transfer_id=report.transfer_id,
+            playlist_reference="Folder/Conflict",
+        ),
+        TransferAuthorization(private_source=True),
+    )
+    for item in view.items:
+        transfer.record_qualification(
+            view.draft_id, item.item_id, QualificationDecision.KEEP_PROPOSAL,
+        )
+    writes_before = spotify.playlist_writes
+
+    with pytest.raises(SpotifyPlaylistReviewRequired, match="conflict"):
+        transfer.apply_qualification(
+            view.draft_id,
+            TransferAuthorization(private_source=True, spotify_write=True),
+        )
+
+    assert spotify.playlist_writes == writes_before
+
+
+def test_browser_origin_snapshot_never_creates_a_qualification_draft(tmp_path):
+    class BrowserSource:
+        source_label = "Beatport"
+        default_mode = TransferMode.SNAPSHOT
+
+        def consume(self, reference):
+            return SourceSelection(
+                "Browser Selection", reference,
+                [_track("browser", title="Browser Track", duration=180)],
+            )
+
+    storage = FileTransferStorage(tmp_path / "transfers.json")
+    transfer = Transfer(
+        source=BrowserSource(),
+        spotify=ProposalSpotify({"browser": _proposal("browser")}),
+        matching_knowledge=RetainedKnowledge(),
+        publishing_guards=AccountPublishingGuards(tmp_path / "locks"),
+        transfer_storage=storage,
+    )
+    from djsupport.transfer import TransferRequest
+
+    report = transfer.execute(TransferRequest(
+        source="https://browser.example/selection",
+        preview=True,
+        transfer_id="browser-transfer",
+    ))
+
+    with pytest.raises(ValueError, match="only for Rekordbox Mirrors"):
+        transfer.obtain_qualification(
+            QualificationRequest(transfer_id=report.transfer_id),
+            TransferAuthorization(private_source=True),
+        )
+    assert storage.qualifications == {}
+
+
+def test_changed_playlist_head_blocks_draft_application_before_mutation(tmp_path):
+    track = _track("head", title="Head Guard", duration=181)
+    spotify = PlaylistSpotify({"head": _proposal("head")})
+    publications = FilePublicationStorage(tmp_path / "publications.json")
+    transfer = Transfer(
+        source=RekordboxSelection([track]),
+        spotify=spotify,
+        matching_knowledge=AuthorityRecordingKnowledge(),
+        publishing_guards=AccountPublishingGuards(tmp_path / "locks"),
+        publication_storage=publications,
+        transfer_storage=FileTransferStorage(tmp_path / "transfers.json"),
+    )
+    plan = transfer.plan_batch(BatchPlanRequest(
+        playlist_references=("Folder/Selected",),
+    ))
+    report = transfer.execute_batch(plan, transfer_id=plan.batch_id)
+    view = transfer.obtain_qualification(
+        QualificationRequest(
+            transfer_id=report.transfer_id,
+            playlist_reference="Folder/Selected",
+        ),
+        TransferAuthorization(private_source=True),
+    )
+    transfer.record_qualification(
+        view.draft_id, view.items[0].item_id,
+        QualificationDecision.KEEP_PROPOSAL,
+    )
+    playlist_id = report.playlists[0].spotify_playlist_id
+    spotify._mutated(playlist_id, spotify.playlists[playlist_id])
+    writes_after_external_change = spotify.playlist_writes
+
+    with pytest.raises(SpotifyPlaylistChanged, match="changed before"):
+        transfer.apply_qualification(
+            view.draft_id,
+            TransferAuthorization(private_source=True, spotify_write=True),
+        )
+
+    assert spotify.playlist_writes == writes_after_external_change
+
+
+@pytest.mark.parametrize("changed_evidence", ["source", "manifest", "account"])
+def test_changed_bound_evidence_blocks_application_without_mutation(
+    tmp_path, changed_evidence,
+):
+    track = _track("bound", title="Bound Evidence", duration=181)
+    source = RekordboxSelection([track])
+    spotify = PlaylistSpotify({"bound": _proposal("bound")})
+    publications = FilePublicationStorage(tmp_path / "publications.json")
+    transfer = Transfer(
+        source=source,
+        spotify=spotify,
+        matching_knowledge=AuthorityRecordingKnowledge(),
+        publishing_guards=AccountPublishingGuards(tmp_path / "locks"),
+        publication_storage=publications,
+        transfer_storage=FileTransferStorage(tmp_path / "transfers.json"),
+    )
+    plan = transfer.plan_batch(BatchPlanRequest(
+        playlist_references=("Folder/Selected",),
+    ))
+    report = transfer.execute_batch(plan, transfer_id=plan.batch_id)
+    playlist_id = report.playlists[0].spotify_playlist_id
+    view = transfer.obtain_qualification(
+        QualificationRequest(
+            transfer_id=report.transfer_id,
+            playlist_reference="Folder/Selected",
+        ),
+        TransferAuthorization(private_source=True),
+    )
+    transfer.record_qualification(
+        view.draft_id, view.items[0].item_id,
+        QualificationDecision.KEEP_PROPOSAL,
+    )
+    if changed_evidence == "source":
+        source.tracks[0] = replace(track, duration=999)
+    elif changed_evidence == "manifest":
+        manifest = publications.publication_for_playlist(
+            "spotify-account-one", playlist_id,
+        )
+        publications.retain_publication(replace(
+            manifest, spotify_playlist_name="Changed Playlist Name",
+        ))
+    else:
+        spotify.account_id = lambda: "spotify-account-two"
+    writes_before = spotify.playlist_writes
+
+    with pytest.raises((SpotifyPlaylistReviewRequired, ValueError)):
+        transfer.apply_qualification(
+            view.draft_id,
+            TransferAuthorization(private_source=True, spotify_write=True),
+        )
+
+    assert spotify.playlist_writes == writes_before
+
+
+def test_large_draft_application_resumes_from_checkpoints_and_is_idempotent(
+    tmp_path,
+):
+    tracks = [
+        _track(f"track-{index}", title=f"Track {index}", duration=180 + index)
+        for index in range(101)
+    ]
+    spotify = PlaylistSpotify({
+        track.track_id: _proposal(f"{index:022d}")
+        for index, track in enumerate(tracks)
+    })
+    transfer = Transfer(
+        source=RekordboxSelection(tracks),
+        spotify=spotify,
+        matching_knowledge=AuthorityRecordingKnowledge(),
+        publishing_guards=AccountPublishingGuards(tmp_path / "locks"),
+        publication_storage=FilePublicationStorage(tmp_path / "publications.json"),
+        transfer_storage=FileTransferStorage(tmp_path / "transfers.json"),
+    )
+    plan = transfer.plan_batch(BatchPlanRequest(
+        playlist_references=("Folder/Large",), confirm_expensive=True,
+    ))
+    report = transfer.execute_batch(plan, transfer_id=plan.batch_id)
+    view = transfer.obtain_qualification(
+        QualificationRequest(
+            transfer_id=report.transfer_id,
+            playlist_reference="Folder/Large",
+        ),
+        TransferAuthorization(private_source=True),
+    )
+    for item in view.items:
+        transfer.record_qualification(
+            view.draft_id, item.item_id, QualificationDecision.KEEP_PROPOSAL,
+        )
+    writes_before_apply = spotify.playlist_writes
+    transfer.pause()
+
+    paused = transfer.apply_qualification(
+        view.draft_id,
+        TransferAuthorization(private_source=True, spotify_write=True),
+    )
+    resumed = transfer.apply_qualification(
+        view.draft_id,
+        TransferAuthorization(private_source=True, spotify_write=True),
+    )
+    writes_after_resume = spotify.playlist_writes
+    repeated = transfer.apply_qualification(
+        view.draft_id,
+        TransferAuthorization(private_source=True, spotify_write=True),
+    )
+
+    assert paused.status.value == "paused"
+    assert resumed.status.value == repeated.status.value == "applied"
+    assert spotify.playlist_writes == writes_before_apply + 2
+    assert spotify.playlist_writes == writes_after_resume
+    assert len(spotify.playlists[report.playlists[0].spotify_playlist_id]) == 101
+
+
+def test_agent_qualification_documents_are_first_class_and_privacy_redacted(
+    tmp_path,
+):
+    track = _track("agent", title="Private Agent Review", duration=181)
+    spotify = PlaylistSpotify({"agent": _proposal("agent")})
+    transfer = Transfer(
+        source=RekordboxSelection([track]),
+        spotify=spotify,
+        matching_knowledge=AuthorityRecordingKnowledge(),
+        publishing_guards=AccountPublishingGuards(tmp_path / "locks"),
+        publication_storage=FilePublicationStorage(tmp_path / "publications.json"),
+        transfer_storage=FileTransferStorage(tmp_path / "transfers.json"),
+    )
+    plan = transfer.plan_batch(BatchPlanRequest(
+        playlist_references=("Private/Agent",),
+    ))
+    report = transfer.execute_batch(plan, transfer_id=plan.batch_id)
+    contract = AgentTransferContract(transfer)
+    request = QualificationRequest(
+        transfer_id=report.transfer_id,
+        playlist_reference="Private/Agent",
+    )
+
+    blocked = contract.qualification_draft(request, AgentAuthorization())
+    document = contract.qualification_draft(
+        request, AgentAuthorization(private_source=True),
+    )
+
+    assert blocked["status"] == "authorization_required"
+    assert document["contract_version"] == 2
+    assert document["phase"] == "qualification"
+    assert document["status"] == "draft"
+    assert document["counts"] == {
+        "items": 1, "pending": 1, "deferred": 0,
+    }
+    assert document["authority"] == "none"
+    assert document["review_url"].startswith(
+        "http://127.0.0.1:8000/qualification/"
+    )
+    assert document["next_actions"] == ["review"]
+    rendered = str(document)
+    assert "Private/Agent" not in rendered
+    assert "Private Agent Review" not in rendered
+    assert _proposal("agent")["uri"] not in rendered
+
+    item_id = transfer.qualification(document["draft_id"]).items[0].item_id
+    transfer.record_qualification(
+        document["draft_id"], item_id, QualificationDecision.KEEP_PROPOSAL,
+    )
+    ready = contract.qualification_progress(
+        document["draft_id"], AgentAuthorization(private_source=True),
+    )
+    denied_apply = contract.apply_qualification(
+        document["draft_id"], AgentAuthorization(private_source=True),
+    )
+
+    assert ready["status"] == "ready"
+    assert ready["next_actions"] == ["apply"]
+    assert denied_apply["status"] == "authorization_required"
+    assert denied_apply["required_authorizations"] == ["spotify_write"]

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -9,6 +9,7 @@ import pytest
 from djsupport.report import (
     MatchedTrack,
     PlaylistReport,
+    ReviewTrack,
     SyncReport,
     save_report,
     save_review_csv,
@@ -282,3 +283,33 @@ class TestSaveReviewCsv:
         content = (tmp_path / "review.csv").read_text()
         assert "score_reasons" in content.splitlines()[0]
         assert reason in content
+
+    def test_retains_release_duration_version_and_authority_review_facts(self, tmp_path):
+        path = str(tmp_path / "review.csv")
+        playlist = _playlist()
+        playlist.review_items.append(ReviewTrack(
+            source_track_id="source-1",
+            source_name="Source Artist - Source Title",
+            source_artist="Source Artist",
+            source_title="Source Title",
+            source_release="Source Release",
+            source_label="Source Label",
+            source_version="Extended Mix",
+            source_duration=381,
+            spotify_uri="spotify:track:0123456789012345678901",
+            spotify_name="Spotify Title",
+            spotify_artist="Spotify Artist",
+            spotify_release="Spotify Release",
+            spotify_duration=250,
+            score=88,
+            match_type="shorter_version",
+            authority_status="proposal",
+        ))
+
+        save_review_csv(_report(playlists=[playlist]), path)
+
+        content = (tmp_path / "review.csv").read_text()
+        assert "source_release,source_label,source_version" in content
+        assert "spotify_release,spotify_duration,authority_status" in content
+        assert "Source Release,Source Label,Extended Mix" in content
+        assert "Spotify Release,250,proposal" in content

--- a/tests/test_transfer.py
+++ b/tests/test_transfer.py
@@ -635,6 +635,7 @@ class TestProtectedTransferBehavior:
         assert report.playlists[0].match_collisions == []
         assert spotify.playlists[report.playlists[0].spotify_playlist_id]["tracks"] == [
             "spotify:track:shared",
+            "spotify:track:shared",
         ]
 
     def test_previously_unmatched_tracks_retry_only_when_explicitly_requested(
@@ -2098,9 +2099,15 @@ class TestTransferPublicationLifecycle:
             "source_track": "New Artist - New Track",
             "source_artist": "New Artist",
             "source_title": "New Track",
+            "source_release": "",
+            "source_label": "",
+            "source_version": "",
             "source_duration": "420",
             "spotify_url": "",
             "spotify_track": "",
+            "spotify_release": "",
+            "spotify_duration": "0",
+            "authority_status": "proposal",
             "score": "",
             "match_type": "unmatched",
             "score_reasons": "",

--- a/tests/test_transfer.py
+++ b/tests/test_transfer.py
@@ -2034,6 +2034,23 @@ class TestRekordboxBatchExecution:
 
 
 class TestTransferPublicationLifecycle:
+    @pytest.mark.parametrize("stored", [
+        '{"version": 99, "transfers": {"private": {}}}',
+        '{"version": 4, "qualifications": {"private": {"draft_id": "x"}}}',
+        '{"version": 4, "transfers": ',
+    ])
+    def test_transfer_state_fails_closed_without_rewriting_unknown_data(
+        self, tmp_path, stored,
+    ):
+        state_path = tmp_path / "transfers.json"
+        state_path.write_text(stored)
+        original = state_path.read_bytes()
+
+        with pytest.raises(ValueError, match="Transfer state"):
+            FileTransferStorage(state_path)
+
+        assert state_path.read_bytes() == original
+
     def test_settled_playlist_copy_hides_recovery_key_and_retains_curator(self, tmp_path):
         class LifecycleSpotify(StatefulSpotify):
             def set_playlist_description(self, playlist_id, description):
@@ -2702,7 +2719,7 @@ class TestTransferPublicationLifecycle:
             approved_at=datetime(2026, 8, 1),
         ))
 
-        assert json.loads(path.read_text())["version"] == 5
+        assert json.loads(path.read_text())["version"] == 6
         assert len(FilePublicationStorage(path).mirrors_for_account(
             "spotify-user-1"
         )) == 1
@@ -3518,9 +3535,10 @@ class TestBeatportCliTransfer:
         assert "Transfer stop-me abandoned" in result.output
 
     @patch("djsupport.transfer.Transfer.approve")
+    @patch("djsupport.transfer.FileTransferStorage")
     @patch("djsupport.cli.get_client", return_value=MagicMock())
     def test_cli_approves_one_provisional_playlist(
-        self, mock_client, approve, tmp_path,
+        self, mock_client, transfer_storage, approve, tmp_path,
     ):
         approve.return_value = ApprovalOutcome(
             account_id="spotify-user-1",
@@ -3537,6 +3555,9 @@ class TestBeatportCliTransfer:
 
         assert result.exit_code == 0, result.output
         approve.assert_called_once_with("snapshot-1")
+        transfer_storage.assert_called_once_with(
+            str((tmp_path / "state.json").with_suffix(".transfers.json"))
+        )
         assert "1 approved" in result.output
         assert "2 rejected" in result.output
 

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -10,12 +10,17 @@ from fastapi.testclient import TestClient
 
 from djsupport.report import PlaylistReport, SyncReport
 from djsupport.rekordbox import Track
+from djsupport.local_audition import LocalSourceAudition
 from djsupport.transfer import (
     AccountPublishingGuards,
     BatchPlan,
     FilePublicationStorage,
     FileTransferStorage,
     PlaylistPreflight,
+    QualificationDecision,
+    QualificationItem,
+    QualificationStatus,
+    QualificationView,
     SourceSelection,
     Transfer,
     TransferProgress,
@@ -158,7 +163,7 @@ def test_rekordbox_web_execute_preserves_execute_phase_authorization_contract():
     })
 
     assert response.json() == {
-        "contract_version": 1,
+        "contract_version": 2,
         "phase": "execute",
         "status": "authorization_required",
         "required_authorizations": ["private_source"],
@@ -220,7 +225,7 @@ def test_rekordbox_web_execute_renders_spotify_login_as_versioned_error():
 
     assert response.status_code == 401
     assert response.json() == {
-        "contract_version": 1,
+        "contract_version": 2,
         "phase": "execute",
         "status": "error",
         "error": {"code": "spotify_authentication_required"},
@@ -234,14 +239,229 @@ def test_capabilities_are_available_without_spotify_or_private_source(monkeypatc
     response = TestClient(create_app()).get("/capabilities")
 
     assert response.status_code == 200
-    assert response.json()["contract_version"] == 1
+    assert response.json()["contract_version"] == 2
     assert response.json()["phase"] == "capability"
     assert response.json()["capabilities"]["local_audio_identity"] == {
         "available": False,
         "algorithm": "chromaprint",
         "algorithm_version": None,
         "reason": "binary_unavailable",
+        "default_enabled": False,
+        "authority": "approved_match_reuse_only",
+        "first_run_discovery": "none_until_explicit_approval",
+        "execution_order": "after_retained_knowledge_before_spotify_search",
     }
+    assert response.json()["capabilities"]["local_audio_audition"] == {
+        "available": True,
+        "default_enabled": False,
+        "authority": "none",
+        "requires_local_audio_identity": False,
+        "requires_durable_matching_knowledge": False,
+    }
+
+
+def _qualification_view() -> QualificationView:
+    return QualificationView(
+        draft_id="draft-opaque-1",
+        transfer_id="transfer-opaque-1",
+        source_reference="Private/Selection",
+        spotify_playlist_id="playlist-opaque-1",
+        status=QualificationStatus.DRAFT,
+        items=(QualificationItem(
+            item_id="item-opaque-1",
+            source_index=0,
+            source_track_id="source-opaque-1",
+            source_artist="Source Artist",
+            source_title="Source Title",
+            source_release="Source Release",
+            source_label="Source Label",
+            source_version="Extended Mix",
+            source_duration=380,
+            spotify_uri="spotify:track:0123456789012345678901",
+            spotify_name="Spotify Title",
+            spotify_artist="Spotify Artist",
+            spotify_release="Spotify Release",
+            spotify_duration=250,
+            score=86.0,
+            match_type="shorter_version",
+            score_reasons=("title", "artist"),
+            attention_reasons=("new_proposal", "duration_conflict"),
+            audition_status="available",
+        ),),
+    )
+
+
+def _authenticated_manager():
+    manager = MagicMock()
+    manager.get_cached_token.return_value = {"access_token": "synthetic"}
+    manager.is_token_expired.return_value = False
+    return manager
+
+
+def test_rekordbox_qualification_routes_render_rich_path_free_review_facts():
+    transfer = MagicMock()
+    transfer.obtain_qualification.return_value = _qualification_view()
+    transfer.qualification.return_value = _qualification_view()
+    web = create_app(
+        rekordbox_transfer_factory=lambda request, authorized: transfer,
+        auth_manager=_authenticated_manager,
+    )
+
+    response = TestClient(web).post("/rekordbox/qualification/drafts", json={
+        "xml_path": "/private/owner-library.xml",
+        "transfer_id": "batch-opaque-1",
+        "playlist_reference": "Private/Selection",
+        "local_audio_audition": True,
+        "authorize_private_source": True,
+    })
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["draft_id"] == "draft-opaque-1"
+    assert body["authority"] == "none"
+    assert body["counts"] == {"items": 1, "pending": 1, "deferred": 0}
+    assert body["items"][0] == {
+        "item_id": "item-opaque-1",
+        "source": {
+            "artist": "Source Artist",
+            "title": "Source Title",
+            "release": "Source Release",
+            "label": "Source Label",
+            "version": "Extended Mix",
+            "duration": 380,
+        },
+        "spotify": {
+            "uri": "spotify:track:0123456789012345678901",
+            "name": "Spotify Title",
+            "artist": "Spotify Artist",
+            "release": "Spotify Release",
+            "duration": 250,
+            "embed_url": "https://open.spotify.com/embed/track/0123456789012345678901",
+            "open_url": "https://open.spotify.com/track/0123456789012345678901",
+        },
+        "proposal": {
+            "score": 86.0,
+            "match_type": "shorter_version",
+            "score_reasons": ["title", "artist"],
+            "authority_status": "proposal",
+            "attention_reasons": ["new_proposal", "duration_conflict"],
+        },
+        "audition_status": "available",
+        "audition_reason": None,
+        "decision": None,
+        "correction_uri": None,
+        "deferred_reason": None,
+        "excluded": False,
+    }
+    assert "owner-library" not in response.text
+    transfer.obtain_qualification.assert_called_once()
+
+
+def test_qualification_decision_delegates_to_transfer_without_approval():
+    transfer = MagicMock()
+    transfer.obtain_qualification.return_value = _qualification_view()
+    decided = _qualification_view()
+    transfer.record_qualification.return_value = decided
+    web = create_app(
+        rekordbox_transfer_factory=lambda request, authorized: transfer,
+        auth_manager=_authenticated_manager,
+    )
+    client = TestClient(web)
+    created = client.post("/rekordbox/qualification/drafts", json={
+        "xml_path": "/private/owner-library.xml",
+        "transfer_id": "batch-opaque-1",
+        "playlist_reference": "Private/Selection",
+        "authorize_private_source": True,
+    })
+
+    response = client.post(
+        f"/rekordbox/qualification/drafts/{created.json()['draft_id']}/decisions",
+        json={
+            "item_id": "item-opaque-1",
+            "decision": "keep_proposal",
+            "authorize_private_source": True,
+        },
+    )
+
+    assert response.status_code == 200
+    transfer.record_qualification.assert_called_once_with(
+        "draft-opaque-1",
+        "item-opaque-1",
+        QualificationDecision.KEEP_PROPOSAL,
+        spotify_reference=None,
+        reason=None,
+        exclude=False,
+    )
+    assert not transfer.approve.called
+
+
+def test_qualification_audition_requires_exact_authorization_and_returns_url():
+    transfer = MagicMock()
+    transfer.obtain_qualification.return_value = _qualification_view()
+    transfer.audition_qualification.return_value = MagicMock(
+        status="available", handle="opaque-media-handle", media_type="audio/mpeg",
+        content_length=8, expires_in=600, reason=None,
+    )
+    web = create_app(
+        rekordbox_transfer_factory=lambda request, authorized: transfer,
+        auth_manager=_authenticated_manager,
+    )
+    client = TestClient(web)
+    created = client.post("/rekordbox/qualification/drafts", json={
+        "xml_path": "/private/owner-library.xml",
+        "transfer_id": "batch-opaque-1",
+        "playlist_reference": "Private/Selection",
+        "local_audio_audition": True,
+        "authorize_private_source": True,
+    })
+    url = (
+        f"/rekordbox/qualification/drafts/{created.json()['draft_id']}"
+        "/audition/item-opaque-1"
+    )
+
+    denied = client.post(url, json={"authorize_private_source": False})
+    allowed = client.post(url, json={"authorize_private_source": True})
+
+    assert denied.status_code == 403
+    assert allowed.status_code == 200
+    assert allowed.json() == {
+        "status": "available",
+        "media_type": "audio/mpeg",
+        "content_length": 8,
+        "expires_in": 600,
+        "media_url": "/rekordbox/qualification/media/opaque-media-handle",
+    }
+    assert "/private/" not in allowed.text
+    transfer.audition_qualification.assert_called_once()
+
+
+def test_local_media_route_supports_bounded_ranges_without_filename(tmp_path):
+    media = tmp_path / "private-owner-name.mp3"
+    media.write_bytes(b"0123456789")
+    audition = LocalSourceAudition(max_range_bytes=4)
+    opened = audition.open("transfer-1", "item-1", Track(
+        track_id="1", name="Synthetic", artist="Artist", album="", remixer="",
+        label="", genre="", date_added="", location=media.as_uri(),
+    ))
+    web = create_app(local_audition=audition)
+    client = TestClient(web)
+    url = f"/rekordbox/qualification/media/{opened.handle}"
+
+    response = client.get(url, headers={"Range": "bytes=2-5"})
+    excessive = client.get(url, headers={"Range": "bytes=0-8"})
+    missing = client.get("/rekordbox/qualification/media/not-a-handle")
+
+    assert response.status_code == 206
+    assert response.content == b"2345"
+    assert response.headers["content-range"] == "bytes 2-5/10"
+    assert response.headers["accept-ranges"] == "bytes"
+    assert response.headers["cache-control"] == "private, no-store"
+    assert response.headers["content-security-policy"] == "default-src 'none'; media-src 'self'"
+    assert "content-disposition" not in response.headers
+    assert "private-owner-name" not in str(response.headers)
+    assert excessive.status_code == 416
+    assert excessive.headers["content-range"] == "bytes */10"
+    assert missing.status_code == 404
 
 
 class TestAuthEndpoints:
@@ -509,3 +729,22 @@ class TestIndexPage:
         assert "djsupport" in res.text
         assert "djsupport.activeTransfer" in res.text
         assert "text/html" in res.headers["content-type"]
+
+    def test_qualification_workspace_is_public_responsive_and_one_action_at_a_time(self):
+        res = client.get("/qualification/synthetic-draft")
+
+        assert res.status_code == 200
+        assert "classification: public" in res.text
+        assert 'id="qualification-section"' in res.text
+        assert 'class="qualification-grid"' in res.text
+        assert 'id="local-player"' in res.text
+        assert 'id="spotify-player"' in res.text
+        assert "OPEN IN SPOTIFY" in res.text
+        assert ">CORRECT<" in res.text
+        assert "WRONG — FIND ANOTHER" in res.text
+        assert "CANNOT VERIFY" in res.text
+        assert "NOT MY SOURCE" in res.text
+        assert "@media (max-width: 980px)" in res.text
+        assert "grid-auto-flow: column" in res.text
+        assert "authorization mode" not in res.text.casefold()
+        assert "test scenario" not in res.text.casefold()

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -1,6 +1,7 @@
 """Tests for the FastAPI web backend."""
 
 import json
+from dataclasses import replace
 from datetime import datetime
 from pathlib import Path
 from unittest.mock import MagicMock, patch
@@ -14,16 +15,21 @@ from djsupport.local_audition import LocalSourceAudition
 from djsupport.transfer import (
     AccountPublishingGuards,
     BatchPlan,
+    BatchPlanRequest,
+    EphemeralMatchingKnowledge,
     FilePublicationStorage,
     FileTransferStorage,
     PlaylistPreflight,
     QualificationDecision,
     QualificationItem,
+    QualificationRequest,
     QualificationStatus,
     QualificationView,
     SourceSelection,
     Transfer,
+    TransferAuthorization,
     TransferProgress,
+    TransferMode,
 )
 from djsupport.web import _report_to_dict, app, create_app
 
@@ -287,6 +293,12 @@ def _qualification_view() -> QualificationView:
             score_reasons=("title", "artist"),
             attention_reasons=("new_proposal", "duration_conflict"),
             audition_status="available",
+            permitted_actions=(
+                QualificationDecision.KEEP_PROPOSAL,
+                QualificationDecision.CORRECTION,
+                QualificationDecision.DEFERRED,
+                QualificationDecision.REJECT_PROPOSAL,
+            ),
         ),),
     )
 
@@ -320,6 +332,7 @@ def test_rekordbox_qualification_routes_render_rich_path_free_review_facts():
     assert body["draft_id"] == "draft-opaque-1"
     assert body["authority"] == "none"
     assert body["counts"] == {"items": 1, "pending": 1, "deferred": 0}
+    assert body["current_item_id"] == "item-opaque-1"
     assert body["items"][0] == {
         "item_id": "item-opaque-1",
         "source": {
@@ -345,7 +358,14 @@ def test_rekordbox_qualification_routes_render_rich_path_free_review_facts():
             "score_reasons": ["title", "artist"],
             "authority_status": "proposal",
             "attention_reasons": ["new_proposal", "duration_conflict"],
+            "availability_status": "unknown",
+            "availability_reason": "not_checked",
+            "availability_checked_at": None,
+            "availability_source": None,
         },
+        "permitted_actions": [
+            "keep_proposal", "correction", "deferred", "reject_proposal",
+        ],
         "audition_status": "available",
         "audition_reason": None,
         "decision": None,
@@ -388,11 +408,74 @@ def test_qualification_decision_delegates_to_transfer_without_approval():
         "draft-opaque-1",
         "item-opaque-1",
         QualificationDecision.KEEP_PROPOSAL,
+        TransferAuthorization(private_source=True),
         spotify_reference=None,
         reason=None,
         exclude=False,
     )
     assert not transfer.approve.called
+
+
+def test_workspace_can_explicitly_include_all_proposals_through_transfer():
+    transfer = MagicMock()
+    initial = _qualification_view()
+    included = replace(initial, include_all=True)
+    transfer.obtain_qualification.side_effect = [initial, included]
+    web = create_app(
+        rekordbox_transfer_factory=lambda request, authorized: transfer,
+        auth_manager=_authenticated_manager,
+    )
+    client = TestClient(web)
+    created = client.post("/rekordbox/qualification/drafts", json={
+        "xml_path": "/private/owner-library.xml",
+        "transfer_id": "batch-opaque-1",
+        "playlist_reference": "Private/Selection",
+        "authorize_private_source": True,
+    })
+
+    response = client.post(
+        f"/rekordbox/qualification/drafts/{created.json()['draft_id']}"
+        "/include-all",
+        json={"authorize_private_source": True},
+    )
+
+    assert response.status_code == 200
+    assert response.json()["include_all"] is True
+    request = transfer.obtain_qualification.call_args_list[-1].args[0]
+    assert request.transfer_id == "batch-opaque-1"
+    assert request.playlist_reference == "Private/Selection"
+    assert request.include_all is True
+
+
+def test_web_qualification_approval_is_explicit_without_spotify_write_flag():
+    transfer = MagicMock()
+    transfer.obtain_qualification.return_value = _qualification_view()
+    transfer.approve_qualification.return_value = MagicMock(
+        status=MagicMock(value="approved"),
+        approved=(), rejected=(), collisions=(), corrections=(),
+    )
+    web = create_app(
+        rekordbox_transfer_factory=lambda request, authorized: transfer,
+        auth_manager=_authenticated_manager,
+    )
+    client = TestClient(web)
+    created = client.post("/rekordbox/qualification/drafts", json={
+        "xml_path": "/private/owner-library.xml",
+        "transfer_id": "batch-opaque-1",
+        "playlist_reference": "Private/Selection",
+        "authorize_private_source": True,
+    })
+
+    response = client.post(
+        f"/rekordbox/qualification/drafts/{created.json()['draft_id']}/approve",
+        json={"authorize_private_source": True},
+    )
+
+    assert response.status_code == 200
+    assert response.json()["authority"] == "playlist_approval"
+    transfer.approve_qualification.assert_called_once_with(
+        "draft-opaque-1", TransferAuthorization(private_source=True),
+    )
 
 
 def test_qualification_audition_requires_exact_authorization_and_returns_url():
@@ -462,6 +545,105 @@ def test_local_media_route_supports_bounded_ranges_without_filename(tmp_path):
     assert excessive.status_code == 416
     assert excessive.headers["content-range"] == "bytes */10"
     assert missing.status_code == 404
+    for denied in (excessive, missing):
+        assert denied.headers["cache-control"] == "private, no-store"
+        assert denied.headers["content-security-policy"] == (
+            "default-src 'none'; media-src 'self'"
+        )
+        assert denied.headers["x-content-type-options"] == "nosniff"
+        assert "private-owner-name" not in str(denied.headers)
+
+
+def test_qualification_routes_reject_remote_peer_rebinding_host_and_origin():
+    web = create_app()
+    remote = TestClient(
+        web,
+        base_url="http://127.0.0.1",
+        client=("203.0.113.20", 50000),
+    )
+    local = TestClient(web)
+
+    assert remote.get("/qualification/opaque-draft").status_code == 403
+    assert local.get(
+        "/qualification/opaque-draft",
+        headers={"Host": "attacker.example"},
+    ).status_code == 403
+    assert local.post(
+        "/rekordbox/qualification/drafts",
+        headers={"Origin": "https://attacker.example"},
+        json={},
+    ).status_code == 403
+
+
+def test_durable_draft_with_missing_source_is_review_required_not_missing(
+    tmp_path, monkeypatch,
+):
+    class SelectedSource:
+        source_label = "Rekordbox"
+        default_mode = TransferMode.MIRROR
+
+        def consume(self, reference):
+            return SourceSelection("Selected", reference, [Track(
+                track_id="synthetic", name="Synthetic", artist="Artist",
+                album="Release", remixer="", label="Label", genre="",
+                date_added="", duration=180,
+            )])
+
+        def consume_batch(self, references, whole_library):
+            return tuple(self.consume(reference) for reference in references)
+
+    class PreviewSpotify:
+        def account_id(self):
+            return "spotify-account-one"
+
+        def match(self, track, threshold):
+            return {
+                "uri": "spotify:track:0123456789012345678901",
+                "name": "Synthetic", "artist": "Artist", "score": 96.0,
+                "match_type": "exact",
+            }
+
+    publication_path = tmp_path / "publication-manifests.json"
+    transfer = Transfer(
+        source=SelectedSource(),
+        spotify=PreviewSpotify(),
+        matching_knowledge=EphemeralMatchingKnowledge(),
+        publishing_guards=AccountPublishingGuards(tmp_path / "locks"),
+        transfer_storage=FileTransferStorage(
+            publication_path.with_suffix(".transfers.json")
+        ),
+    )
+    plan = transfer.plan_batch(BatchPlanRequest(
+        playlist_references=("Folder/Selected",), preview=True,
+    ))
+    report = transfer.execute_batch(plan, transfer_id=plan.batch_id)
+    draft = transfer.obtain_qualification(
+        QualificationRequest(
+            transfer_id=report.transfer_id,
+            playlist_reference="Folder/Selected",
+        ),
+        TransferAuthorization(private_source=True),
+    )
+    monkeypatch.setattr(
+        "djsupport.web.default_publication_manifest_path",
+        lambda: publication_path,
+    )
+    monkeypatch.setattr(
+        "djsupport.config.ConfigManager.get_rekordbox_xml_path",
+        lambda self: str(tmp_path / "missing-source.xml"),
+    )
+    web = create_app(auth_manager=_authenticated_manager)
+
+    response = TestClient(web).get(
+        f"/rekordbox/qualification/drafts/{draft.draft_id}",
+        params={"authorize_private_source": "true"},
+    )
+
+    assert response.status_code == 409
+    assert response.json()["detail"] == (
+        "Qualification source evidence is unavailable; review required"
+    )
+    assert "missing-source" not in response.text
 
 
 class TestAuthEndpoints:


### PR DESCRIPTION
## Summary

- add the Rekordbox-only, attention-led Qualification Workspace through the public Transfer lifecycle
- keep Qualification Draft decisions non-authoritative and separate explicit Apply from playlist-scoped Approval
- add exact, private-source-authorized local audition with opaque process-local handles and bounded loopback media streaming
- preserve approved local-audio identity reuse, rich retained Spotify facts, truthful availability, and browser-origin Spotify review
- add versioned draft persistence, concurrency guards, crash recovery, additive migration/backup support, and thin web/agent/CLI adapters

## Validation

- 637/637 complete offline tests passed
- 419/419 focused Transfer, media, web, agent, migration, backup, cache, and matcher tests passed
- Python compilation and JavaScript syntax checks passed
- repository privacy, migration, backup, diff, and whitespace checks passed
- source and wheel builds, archive inspection, and clean-wheel import/CLI smoke passed
- independent Standards review: PASS, P0-P3 all zero, 88 focused tests
- independent Spec review: PASS, 109 focused tests
- no live Spotify/Beatport calls or owner XML/audio used

Closes #103