### PR TITLE
Establish 0.6 development and release-candidate channels

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,6 +52,19 @@ jobs:
           python-version: "3.14"
       - name: Install development and web extras
         run: python -m pip install ".[dev,web]"
+      - name: Read canonical project version
+        run: |
+          python - <<'PY'
+          import os
+          import tomllib
+
+          with open("pyproject.toml", "rb") as pyproject_file:
+              project_version = tomllib.load(pyproject_file)["project"]["version"]
+          with open(
+              os.environ["GITHUB_ENV"], "a", encoding="utf-8"
+          ) as environment:
+              environment.write(f"DJ_SUPPORT_VERSION={project_version}\n")
+          PY
       - name: Build source and wheel distributions once
         run: python -m build
       - name: Inspect package archives and metadata
@@ -60,11 +73,12 @@ jobs:
           python -m zipfile -l dist/*.whl
           python - <<'PY'
           from pathlib import Path, PurePosixPath
+          import os
           import subprocess
           import tarfile
           import zipfile
 
-          expected_version = "0.6.0.dev0"
+          expected_version = os.environ["DJ_SUPPORT_VERSION"]
           tracked = set(
               subprocess.run(
                   ["git", "ls-files"],
@@ -122,6 +136,11 @@ jobs:
           python -m venv "$clean_install_dir/venv"
           source "$clean_install_dir/venv/bin/activate"
           python -m pip install dist/*.whl
-          python -c \
-            'from importlib.metadata import version; assert version("djsupport") == "0.6.0.dev0"; import djsupport'
+          python - <<'PY'
+          import os
+          from importlib.metadata import version
+
+          assert version("djsupport") == os.environ["DJ_SUPPORT_VERSION"]
+          import djsupport
+          PY
           djsupport --help

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,127 @@
+name: CI
+
+'on':
+  pull_request:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    name: Python ${{ matrix.python-version }}
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version:
+          - "3.10"
+          - "3.14"
+    steps:
+      - name: Check out source
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - name: Set up Python
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install development and web extras
+        run: python -m pip install ".[dev,web]"
+      - name: Run complete offline suite
+        run: python -m pytest
+      - name: Compile package and tests
+        run: python -m compileall -q djsupport tests
+
+  package:
+    name: Package validation
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out source
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - name: Set up Python
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.14"
+      - name: Install development and web extras
+        run: python -m pip install ".[dev,web]"
+      - name: Build source and wheel distributions once
+        run: python -m build
+      - name: Inspect package archives and metadata
+        run: |
+          python -m tarfile -l dist/*.tar.gz
+          python -m zipfile -l dist/*.whl
+          python - <<'PY'
+          from pathlib import Path, PurePosixPath
+          import subprocess
+          import tarfile
+          import zipfile
+
+          expected_version = "0.6.0.dev0"
+          tracked = set(
+              subprocess.run(
+                  ["git", "ls-files"],
+                  check=True,
+                  capture_output=True,
+                  text=True,
+              ).stdout.splitlines()
+          )
+          sdists = list(Path("dist").glob("*.tar.gz"))
+          wheels = list(Path("dist").glob("*.whl"))
+          assert len(sdists) == 1, sdists
+          assert len(wheels) == 1, wheels
+
+          def safe_parts(member_name):
+              path = PurePosixPath(member_name)
+              assert not path.is_absolute(), member_name
+              assert ".." not in path.parts, member_name
+              return path.parts
+
+          with tarfile.open(sdists[0], "r:gz") as archive:
+              members = archive.getmembers()
+              assert all(member.isfile() or member.isdir() for member in members)
+              for member in members:
+                  parts = safe_parts(member.name)
+                  if not member.isfile():
+                      continue
+                  relative = PurePosixPath(*parts[1:]).as_posix()
+                  generated = (
+                      relative == "PKG-INFO"
+                      or relative == "setup.cfg"
+                      or relative.startswith("djsupport.egg-info/")
+                  )
+                  assert relative in tracked or generated, relative
+              package_info = next(
+                  member for member in members if member.name.endswith("/PKG-INFO")
+              )
+              package_metadata = archive.extractfile(package_info).read().decode()
+              assert f"\nVersion: {expected_version}\n" in package_metadata
+
+          with zipfile.ZipFile(wheels[0]) as archive:
+              members = archive.namelist()
+              for member in members:
+                  safe_parts(member)
+                  generated = ".dist-info/" in member
+                  assert member in tracked or generated, member
+              metadata_name = next(
+                  member for member in members if member.endswith(".dist-info/METADATA")
+              )
+              wheel_metadata = archive.read(metadata_name).decode()
+              assert f"\nVersion: {expected_version}\n" in wheel_metadata
+          PY
+      - name: Smoke test a clean wheel installation
+        run: |
+          clean_install_dir="$(mktemp -d)"
+          python -m venv "$clean_install_dir/venv"
+          source "$clean_install_dir/venv/bin/activate"
+          python -m pip install dist/*.whl
+          python -c \
+            'from importlib.metadata import version; assert version("djsupport") == "0.6.0.dev0"; import djsupport'
+          djsupport --help

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Added
 
+- Least-privilege GitHub Actions CI for pull requests and `main`, covering the
+  offline suite on Python 3.10 and 3.14 plus deterministic package validation.
+- A canonical maintainer checklist that keeps release preparation, CI, tags,
+  GitHub Releases, and package publication as separate gated operations.
 - Rekordbox-only, attention-led Qualification Workspace with durable,
   non-authoritative drafts; explicit draft application remains separate from
   playlist-scoped Approval.
@@ -33,6 +37,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Changed
 
+- `main` now identifies as `0.6.0.dev0`, while installation guidance keeps
+  `v0.5.0` as the Latest stable release and limits previews to exact candidates.
 - Transfer checkpoints completed local observations and aggregate API/local
   evidence counts so resumed and repeated agent outcomes remain stable.
 - Rekordbox XML intake retains each selected track's private `Location` solely

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -124,6 +124,9 @@ temporary environment for CLI/import smoke tests. Live Spotify and Beatport
 checks are separate, explicitly authorized workflows and are never part of the
 offline release gate.
 
+Follow the canonical [maintainer release checklist](docs/releasing.md) for the
+separate validation, candidate, final-release, and return-to-development gates.
+
 When a persistent schema changes, keep its reader compatible with documented
 older versions or provide an explicit migration. Add a synthetic backup/restore
 test that covers the current schema and the supported upgrade boundary. Never

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,6 +1,7 @@
 include CHANGELOG.md
 include CONTRIBUTING.md
 include docs/backup-and-restore.md
+include docs/releasing.md
 include docs/release-notes-0.4.0.md
 include docs/upgrading.md
 recursive-include djsupport/static *.html *.png

--- a/README.md
+++ b/README.md
@@ -26,20 +26,45 @@ Corrections, or destructive playlist intent.
 
 ## Install
 
-Install the command-line application:
+### Stable — recommended
+
+Ordinary users should follow the
+[Latest final GitHub Release](https://github.com/spontain112/djsupport/releases/latest).
+The current Latest release is
+[`v0.5.0`](https://github.com/spontain112/djsupport/releases/tag/v0.5.0).
+A newer release marked **Pre-release** is not stable.
+
+Install the command-line application from that exact final tag:
 
 ```bash
-python3 -m pip install djsupport
+python3 -m pip install "djsupport @ https://github.com/spontain112/djsupport/archive/refs/tags/v0.5.0.zip"
 ```
 
 Include the optional local web application with:
 
 ```bash
-python3 -m pip install "djsupport[web]"
+python3 -m pip install "djsupport[web] @ https://github.com/spontain112/djsupport/archive/refs/tags/v0.5.0.zip"
 ```
 
-For development from a source checkout, see
-[`CONTRIBUTING.md`](CONTRIBUTING.md).
+### Preview/testing
+
+Preview builds are opt-in release candidates for testing, not updates to the
+stable channel. Install only an exact candidate tag or artifact from a GitHub
+Release explicitly marked **Pre-release**. For example, after `v0.6.0rc1`
+exists as a pre-release, its exact tag can be installed with:
+
+```bash
+python3 -m pip install "djsupport @ https://github.com/spontain112/djsupport/archive/refs/tags/v0.6.0rc1.zip"
+```
+
+Expect instability. Before testing, back up DJ Support's local application data
+with `djsupport backup` and keep the backup outside the test environment. Use
+copies of any Rekordbox library and audio collection involved; never test a
+candidate against their only copy. Do not install the moving `main` branch as a
+preview release.
+
+Source checkouts, including `main`, are development software. Contributors can
+follow [`CONTRIBUTING.md`](CONTRIBUTING.md) for development setup.
 
 ## Spotify setup
 
@@ -291,6 +316,7 @@ is `$XDG_DATA_HOME/djsupport` or `~/.local/share/djsupport`.
 - [Upgrade guide](docs/upgrading.md)
 - [Backup and restore](docs/backup-and-restore.md)
 - [Release notes](docs/release-notes-0.5.0.md)
+- [Maintainer release checklist](docs/releasing.md)
 - [Changelog](CHANGELOG.md)
 - [Contributing](CONTRIBUTING.md)
 

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -124,8 +124,12 @@ authorize any tag, GitHub Release, or package publication.
 
 - [ ] Prepare the final `X.Y.Z` version and changelog in another dedicated PR,
       then rerun the complete validation on its exact commit.
-- [ ] With separate explicit authorization, create and push the annotated final
-      tag, then publish the final GitHub Release as Latest.
+- [ ] Require green CI on the exact final commit. Candidate CI or CI on another
+      SHA does not satisfy the final-release gate.
+- [ ] Obtain explicit authorization to create and push the annotated final tag
+      pointing at the validated final commit.
+- [ ] Separately obtain authorization to publish the final GitHub Release as
+      Latest.
 - [ ] Verify the release page and every downloadable artifact resolve to the
       intended final version. Package-index publication, if any, remains a
       separate explicitly authorized operation and requires its own verification.

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -1,0 +1,138 @@
+# Releasing DJ Support
+
+This is the canonical maintainer checklist for moving DJ Support from
+development through a release candidate to a final release. Replace every
+`X.Y.Z` placeholder deliberately and record the exact commit used at each gate.
+
+A release-preparation PR, passing CI, a tag, a GitHub Release, and
+package-index publication are separate gated operations. None implies or
+authorizes another. Preparing this checklist or completing issue #107 does not
+authorize any tag, GitHub Release, or package publication.
+
+## 1. Choose the version and exact commit
+
+- [ ] Choose the intended candidate `X.Y.ZrcN` or final `X.Y.Z` version.
+- [ ] Record the full commit SHA proposed for release; do not release an
+      unrecorded moving branch head.
+- [ ] Confirm the version follows PEP 440 and that its Git tag will be the same
+      version prefixed with `v`.
+
+## 2. Confirm `main` is ready
+
+- [ ] Ensure every issue and PR required for the release is merged.
+- [ ] Fetch `main`, confirm the recorded commit is reachable from it, and
+      confirm the checkout has no uncommitted or untracked release content.
+- [ ] Keep unrelated work out of the release scope. Create a stable maintenance
+      branch only when an actual patch release needs one.
+
+## 3. Prepare the release through a PR
+
+- [ ] Open a dedicated release-preparation PR that changes the version in
+      `pyproject.toml`, the single source of version truth.
+- [ ] Move the relevant `[Unreleased]` changelog entries under the exact
+      candidate or final version and date; do not rewrite earlier releases.
+- [ ] Review and merge that PR normally. Merging it does not authorize tagging
+      or publication.
+
+## 4. Run the complete release validation
+
+- [ ] From the exact proposed commit, install development and web extras and run
+      the complete offline suite plus compilation:
+
+  ```bash
+  python3 -m pip install ".[dev,web]"
+  python3 -m pytest
+  python3 -m compileall -q djsupport tests
+  ```
+
+- [ ] Run the repository privacy checks and the synthetic migration and backup
+      validation. Never point these commands at real application data:
+
+  ```bash
+  python3 -m pytest tests/test_repository_privacy.py
+  python3 -m pytest tests/test_migration.py tests/test_backup.py
+  ```
+
+- [ ] Build both distributions once in a fresh temporary artifact directory:
+
+  ```bash
+  artifact_dir="$(mktemp -d)"
+  python3 -m build --outdir "$artifact_dir"
+  ```
+
+- [ ] Inspect every source and wheel archive member. Confirm the archives contain
+      only intended package and repository content—never credentials, local
+      paths, owner data, reports, XML, audio, identifiers, or regression
+      evidence:
+
+  ```bash
+  python3 -m tarfile -l "$artifact_dir/djsupport-X.Y.Z.tar.gz"
+  python3 -m zipfile -l "$artifact_dir/djsupport-X.Y.Z-py3-none-any.whl"
+  ```
+
+- [ ] Create a separate disposable environment, install the built wheel, verify
+      its metadata reports exactly `X.Y.Z`, import the public package, and invoke
+      the installed CLI:
+
+  ```bash
+  install_dir="$(mktemp -d)"
+  python3 -m venv "$install_dir/venv"
+  "$install_dir/venv/bin/python" -m pip install \
+    "$artifact_dir/djsupport-X.Y.Z-py3-none-any.whl"
+  "$install_dir/venv/bin/python" -c \
+    'from importlib.metadata import version; assert version("djsupport") == "X.Y.Z"; import djsupport'
+  "$install_dir/venv/bin/djsupport" --help
+  ```
+
+- [ ] Resolve every validation failure. A skipped or partially run command is not
+      a passing release gate.
+
+## 5. Require green CI on the release commit
+
+- [ ] Confirm the exact release commit has green CI for Python 3.10 and 3.14,
+      compilation, packaging, archive inspection, and clean installation.
+- [ ] Confirm no later commit has replaced the reviewed release commit. Passing
+      CI on another SHA does not satisfy this gate.
+
+## 6. Publish an exact release candidate
+
+- [ ] Obtain explicit authorization to create and push an annotated
+      `vX.Y.ZrcN` tag pointing at the validated commit.
+- [ ] Separately obtain authorization to create the GitHub Release for that tag.
+- [ ] Mark the candidate as a GitHub pre-release, never Latest, and attach or
+      link only the exact validated artifacts.
+- [ ] If package-index publication is intended, treat it as another separately
+      authorized operation; neither the tag nor GitHub pre-release authorizes it.
+
+## 7. Test the exact candidate artifact
+
+- [ ] Install the exact tagged artifact in a disposable environment rather than
+      rebuilding from a later checkout.
+- [ ] Back up local application data before any owner testing. Never test with
+      the only copy of a Rekordbox library or audio collection.
+- [ ] Treat any live Spotify or Beatport call and any owner-data access as a
+      separately authorized, bounded validation—not as part of offline CI.
+
+## 8. Fix defects through normal development
+
+- [ ] Record candidate defects in issues and fix them through named branches,
+      reviewed PRs, and `main`.
+- [ ] Repeat the complete validation and issue a new candidate number. Never
+      move or replace an existing candidate tag or artifact.
+
+## 9. Promote a final release deliberately
+
+- [ ] Prepare the final `X.Y.Z` version and changelog in another dedicated PR,
+      then rerun the complete validation on its exact commit.
+- [ ] With separate explicit authorization, create and push the annotated final
+      tag, then publish the final GitHub Release as Latest.
+- [ ] Verify the release page and every downloadable artifact resolve to the
+      intended final version. Package-index publication, if any, remains a
+      separate explicitly authorized operation and requires its own verification.
+
+## 10. Return `main` to development
+
+- [ ] Immediately open a follow-up PR moving `pyproject.toml` to the next
+      `.dev0` version while keeping new work under `[Unreleased]`.
+- [ ] Confirm stable users still resolve to the final Latest release and that
+      `main` is again clearly identified as development software.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ djsupport = ["static/*.html", "static/*.png"]
 
 [project]
 name = "djsupport"
-version = "0.5.0"
+version = "0.6.0.dev0"
 description = "Transfer Rekordbox and Beatport selections to Spotify"
 readme = "README.md"
 license = "MIT"
@@ -29,9 +29,12 @@ web = [
     "uvicorn>=0.34",
 ]
 dev = [
+    "build>=1.2",
     "pytest>=8.0",
     "pytest-cov>=5.0",
     "httpx>=0.27",
+    "PyYAML>=6.0",
+    "tomli>=2.0; python_version < '3.11'",
 ]
 
 [project.scripts]

--- a/tests/test_release_channels.py
+++ b/tests/test_release_channels.py
@@ -41,6 +41,12 @@ def test_manual_release_checklist_separates_validation_from_publication():
         "GitHub pre-release",
         "disposable environment",
         "final GitHub Release as Latest",
+        "authorization to create and push the annotated final tag",
+        (
+            "Separately obtain authorization to publish the final GitHub Release "
+            "as Latest"
+        ),
+        "green CI on the exact final commit",
         "next `.dev0` version",
         "separate gated operations",
     )
@@ -71,6 +77,8 @@ def test_ci_is_a_least_privilege_offline_release_gate():
         errors.append("concurrency must be scoped to the ref")
 
     jobs = workflow.get("jobs", {})
+    if any("permissions" in job for job in jobs.values()):
+        errors.append("jobs must not override the read-only workflow permissions")
     test_job = jobs.get("test", {})
     versions = test_job.get("strategy", {}).get("matrix", {}).get("python-version")
     if versions != ["3.10", "3.14"]:
@@ -102,6 +110,10 @@ def test_ci_is_a_least_privilege_offline_release_gate():
             errors.append(f"package validation is missing: {command}")
     if workflow_text.count("python -m build") != 1:
         errors.append("source and wheel distributions must be built exactly once")
+    if "0.6.0.dev0" in workflow_text:
+        errors.append("CI must read version truth from pyproject.toml")
+    if "pyproject.toml" not in package_commands:
+        errors.append("package validation must read the canonical project version")
 
     steps = [step for job in jobs.values() for step in job.get("steps", [])]
     uses = [step["uses"] for step in steps if "uses" in step]

--- a/tests/test_release_channels.py
+++ b/tests/test_release_channels.py
@@ -1,0 +1,133 @@
+"""Repository behavior tests for development and release channels."""
+
+import re
+from pathlib import Path
+
+import yaml
+
+try:
+    import tomllib
+except ModuleNotFoundError:  # pragma: no cover - exercised on Python 3.10
+    import tomli as tomllib
+
+
+REPOSITORY_ROOT = Path(__file__).parents[1]
+
+
+def test_source_checkout_uses_0_6_development_version():
+    with (REPOSITORY_ROOT / "pyproject.toml").open("rb") as pyproject_file:
+        project = tomllib.load(pyproject_file)["project"]
+
+    assert project["version"] == "0.6.0.dev0"
+
+
+def test_documented_latest_stable_release_differs_from_development():
+    readme = (REPOSITORY_ROOT / "README.md").read_text()
+    with (REPOSITORY_ROOT / "pyproject.toml").open("rb") as pyproject_file:
+        development_version = tomllib.load(pyproject_file)["project"]["version"]
+
+    assert "v0.5.0" in readme and development_version != "0.5.0"
+
+
+def test_manual_release_checklist_separates_validation_from_publication():
+    checklist = (REPOSITORY_ROOT / "docs" / "releasing.md").read_text()
+    normalized_checklist = " ".join(checklist.split())
+    required_policy = (
+        "exact commit",
+        "release-preparation PR",
+        "migration and backup",
+        "green CI",
+        "annotated `vX.Y.ZrcN` tag",
+        "GitHub pre-release",
+        "disposable environment",
+        "final GitHub Release as Latest",
+        "next `.dev0` version",
+        "separate gated operations",
+    )
+
+    assert not [
+        phrase for phrase in required_policy if phrase not in normalized_checklist
+    ]
+
+
+def test_ci_is_a_least_privilege_offline_release_gate():
+    workflow_path = REPOSITORY_ROOT / ".github" / "workflows" / "ci.yml"
+    workflow_text = workflow_path.read_text()
+    workflow = yaml.safe_load(workflow_text)
+    errors = []
+
+    triggers = workflow.get("on", {})
+    if set(triggers) != {"push", "pull_request"}:
+        errors.append("CI must run only for pushes and pull requests")
+    if triggers.get("push", {}).get("branches") != ["main"]:
+        errors.append("push CI must be limited to main")
+    if workflow.get("permissions") != {"contents": "read"}:
+        errors.append("workflow permissions must be contents: read only")
+
+    concurrency = workflow.get("concurrency", {})
+    if concurrency.get("cancel-in-progress") is not True:
+        errors.append("superseded runs must be cancelled")
+    if "github.ref" not in concurrency.get("group", ""):
+        errors.append("concurrency must be scoped to the ref")
+
+    jobs = workflow.get("jobs", {})
+    test_job = jobs.get("test", {})
+    versions = test_job.get("strategy", {}).get("matrix", {}).get("python-version")
+    if versions != ["3.10", "3.14"]:
+        errors.append("the complete suite must run on Python 3.10 and 3.14")
+
+    test_commands = "\n".join(
+        step.get("run", "") for step in test_job.get("steps", [])
+    )
+    for command in (
+        'python -m pip install ".[dev,web]"',
+        "python -m pytest",
+        "python -m compileall -q djsupport tests",
+    ):
+        if command not in test_commands:
+            errors.append(f"test matrix is missing: {command}")
+
+    package_commands = "\n".join(
+        step.get("run", "") for step in jobs.get("package", {}).get("steps", [])
+    )
+    for command in (
+        "python -m build",
+        "python -m tarfile -l",
+        "python -m zipfile -l",
+        "python -m venv",
+        "import djsupport",
+        "djsupport --help",
+    ):
+        if command not in package_commands:
+            errors.append(f"package validation is missing: {command}")
+    if workflow_text.count("python -m build") != 1:
+        errors.append("source and wheel distributions must be built exactly once")
+
+    steps = [step for job in jobs.values() for step in job.get("steps", [])]
+    uses = [step["uses"] for step in steps if "uses" in step]
+    action_pin = re.compile(r"^actions/(checkout|setup-python)@[0-9a-f]{40}$")
+    if not uses or any(action_pin.fullmatch(action) is None for action in uses):
+        errors.append("only checkout/setup-python pinned to full SHAs may be used")
+    for step in steps:
+        if step.get("uses", "").startswith("actions/checkout@"):
+            if step.get("with", {}).get("persist-credentials") is not False:
+                errors.append("checkout credentials must not persist")
+
+    forbidden = (
+        "secrets.",
+        "permissions: write",
+        "continue-on-error",
+        "spotify",
+        "beatport",
+        "git tag",
+        "gh release",
+        "twine",
+        "pypi",
+        "upload-artifact",
+    )
+    lowered_workflow = workflow_text.lower()
+    for marker in forbidden:
+        if marker in lowered_workflow:
+            errors.append(f"forbidden workflow capability: {marker}")
+
+    assert not errors, "\n".join(errors)


### PR DESCRIPTION
## Summary

- identify `main` as `0.6.0.dev0` while documenting `v0.5.0` as the Latest stable release
- separate stable installation from exact opt-in release-candidate testing
- add read-only, offline GitHub Actions CI for Python 3.10 and 3.14
- build and inspect one sdist/wheel pair and smoke-test a clean wheel installation
- add the canonical gated maintainer release checklist
- add repository contract tests for version identity, channel guidance, workflow safety, and release authority boundaries

## Why

`main` contained unreleased 0.6 work while still claiming the same `0.5.0` identity as the immutable stable release. The repository also lacked an auditable CI gate and a release-candidate protocol. This establishes those channels without adding a permanent development branch or automating publication.

## Validation

- `python3 -m pytest` — 641 passed (2 existing duplicate-member fixture warnings)
- `python3 -m pytest tests/test_release_channels.py` — 4 passed
- `python3 -m pytest tests/test_repository_privacy.py` — 18 passed
- `python3 -m pytest tests/test_migration.py tests/test_backup.py` — 46 passed (same 2 fixture warnings)
- `python3 -m compileall -q djsupport tests`
- isolated `python3 -m build` produced `djsupport-0.6.0.dev0.tar.gz` and `djsupport-0.6.0.dev0-py3-none-any.whl`
- archive path, tracked-content, and source/wheel metadata checks passed at `0.6.0.dev0`
- fresh-venv wheel import, metadata assertion, and `djsupport --help` passed
- `git diff --check origin/main...HEAD` and clean-tree validation passed
- independent Standards review: 0 findings, 0 blockers
- independent Spec review: 0 findings, 0 blockers

## Safety

CI grants only `contents: read`, disables persisted checkout credentials, uses pinned official actions, and contains no secrets, live-service calls, uploads, tag/release mutation, or publication step. This PR created no tag, GitHub Release, package publication, secret, or owner-data artifact, and it does not implement #105.

Closes #107