### PR TITLE
Move Rekordbox configuration into private application data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Added
 
+- Preview-first migration of legacy current-directory Rekordbox configuration,
+  with explicit apply and no source-file deletion.
 - Least-privilege GitHub Actions CI for pull requests and `main`, covering the
   offline suite on Python 3.10 and 3.14 plus deterministic package validation.
 - A canonical maintainer checklist that keeps release preparation, CI, tags,
@@ -37,6 +39,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Changed
 
+- Rekordbox path configuration now lives in private platform application data,
+  participates in versioned backup/restore, and requires an explicit restore
+  choice on conflict.
 - `main` now identifies as `0.6.0.dev0`, while installation guidance keeps
   `v0.5.0` as the Latest stable release and limits previews to exact candidates.
 - Transfer checkpoints completed local observations and aggregate API/local

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,6 +36,8 @@ djsupport/
   matcher.py     Spotify candidate scoring and selection
   spotify.py     Typed Spotify API boundary
   cache.py       Durable matching knowledge
+  paths.py       Canonical private application-data locations
+  config.py      Versioned Rekordbox path configuration and migration
   report.py      Terminal, Markdown, and review CSV reports
   backup.py      Versioned local-data backup and restore
   migration.py   Explicit legacy-data migration

--- a/README.md
+++ b/README.md
@@ -119,6 +119,18 @@ djsupport library set /path/to/library.xml
 djsupport library show
 ```
 
+The saved reference lives in private operating-system application data. If an
+older checkout has `.djsupport_config.json` in its current directory, preview
+and then explicitly apply the non-destructive migration:
+
+```bash
+djsupport library migrate-config
+djsupport library migrate-config --apply
+```
+
+Migration leaves the legacy file untouched and refuses to choose when current
+and legacy configurations differ.
+
 List the available playlists:
 
 ```bash

--- a/djsupport/backup.py
+++ b/djsupport/backup.py
@@ -14,12 +14,13 @@ from datetime import datetime
 from pathlib import Path
 from typing import Callable
 
+from djsupport.config import CONFIG_FILENAME, CONFIG_VERSION
 from djsupport.paths import default_app_data_path
 
 
 BACKUP_VERSION = 1
 SUPPORTED_SCHEMAS = {
-    "config.json": (1,),
+    CONFIG_FILENAME: (CONFIG_VERSION,),
     "matching-knowledge.json": (1, 2, 3),
     "transfers.json": (1, 2, 3, 4),
     "publication-manifests.transfers.json": (1, 2, 3, 4),
@@ -257,7 +258,7 @@ class LocalDataBackup:
 
     def _merge_json(self, path, current, incoming, changes, conflicts, resolutions):
         combined = json.loads(json.dumps(current))
-        if path == "config.json":
+        if path == CONFIG_FILENAME:
             if current != incoming:
                 holder = {"configuration": combined}
                 self._resolve_conflict(
@@ -266,7 +267,7 @@ class LocalDataBackup:
                 )
                 combined = holder["configuration"]
                 if resolutions.get(
-                    "configuration:config.json:configuration"
+                    f"configuration:{CONFIG_FILENAME}:configuration"
                 ) == "archive":
                     changes.append("replace configuration")
         elif path == "matching-knowledge.json":

--- a/djsupport/backup.py
+++ b/djsupport/backup.py
@@ -14,9 +14,12 @@ from datetime import datetime
 from pathlib import Path
 from typing import Callable
 
+from djsupport.paths import default_app_data_path
+
 
 BACKUP_VERSION = 1
 SUPPORTED_SCHEMAS = {
+    "config.json": (1,),
     "matching-knowledge.json": (1, 2, 3),
     "transfers.json": (1, 2, 3, 4),
     "publication-manifests.transfers.json": (1, 2, 3, 4),
@@ -254,7 +257,19 @@ class LocalDataBackup:
 
     def _merge_json(self, path, current, incoming, changes, conflicts, resolutions):
         combined = json.loads(json.dumps(current))
-        if path == "matching-knowledge.json":
+        if path == "config.json":
+            if current != incoming:
+                holder = {"configuration": combined}
+                self._resolve_conflict(
+                    holder, "configuration", incoming, "configuration", path,
+                    conflicts, resolutions,
+                )
+                combined = holder["configuration"]
+                if resolutions.get(
+                    "configuration:config.json:configuration"
+                ) == "archive":
+                    changes.append("replace configuration")
+        elif path == "matching-knowledge.json":
             combined["version"] = max(
                 current.get("version", 1), incoming.get("version", 1),
             )
@@ -459,10 +474,3 @@ class LocalDataBackup:
                     else:
                         target.unlink(missing_ok=True)
                 raise
-
-
-def default_app_data_path() -> Path:
-    """Return the ADR-0001 application-data directory."""
-    from djsupport.transfer import default_matching_knowledge_path
-
-    return default_matching_knowledge_path().parent

--- a/djsupport/cli.py
+++ b/djsupport/cli.py
@@ -128,6 +128,39 @@ def library_show():
         click.echo(f"Status: INVALID ({error})")
 
 
+@library.command("migrate-config")
+@click.option(
+    "--apply", is_flag=True,
+    help="Copy valid legacy configuration into private application data.",
+)
+def library_migrate_config(apply: bool) -> None:
+    """Preview or apply migration of the current-directory legacy config."""
+    result = ConfigManager().migrate_legacy(apply=apply)
+    if result.status == "not_found":
+        click.echo("No legacy Rekordbox configuration found in this directory.")
+    elif result.status == "invalid":
+        raise click.ClickException(
+            "Legacy Rekordbox configuration is invalid and was not migrated."
+        )
+    elif result.status == "conflict":
+        raise click.ClickException(
+            "Current and legacy Rekordbox configurations differ. "
+            "Choose explicitly with `djsupport library set`."
+        )
+    elif result.status == "already_current":
+        click.echo("Private Rekordbox configuration already matches the legacy file.")
+    elif result.status == "migrated":
+        click.echo(
+            "Rekordbox configuration migrated to private application data. "
+            "The legacy file was left unchanged."
+        )
+    else:
+        click.echo(
+            "Legacy Rekordbox configuration is ready to migrate. "
+            "Run `djsupport library migrate-config --apply` to copy it."
+        )
+
+
 @cli.command("backup")
 @click.option(
     "--destination", type=click.Path(file_okay=False), default=None,

--- a/djsupport/config.py
+++ b/djsupport/config.py
@@ -3,13 +3,26 @@
 from __future__ import annotations
 
 import json
+import os
+import tempfile
 import xml.etree.ElementTree as ET
 from dataclasses import asdict, dataclass
 from datetime import datetime
 from pathlib import Path
 
+from djsupport.paths import default_app_data_path
+
 CONFIG_VERSION = 1
-DEFAULT_CONFIG_PATH = ".djsupport_config.json"
+CONFIG_FILENAME = "config.json"
+LEGACY_CONFIG_FILENAME = ".djsupport_config.json"
+
+
+def default_config_path() -> Path:
+    """Return the canonical private application-data configuration path."""
+    return default_app_data_path() / CONFIG_FILENAME
+
+
+DEFAULT_CONFIG_PATH = str(default_config_path())
 
 
 @dataclass
@@ -18,30 +31,80 @@ class AppConfig:
     last_set_at: str | None = None
 
 
+@dataclass(frozen=True)
+class ConfigMigrationResult:
+    status: str
+    applied: bool = False
+
+
 class ConfigManager:
-    def __init__(self, path: str = DEFAULT_CONFIG_PATH):
-        self.path = Path(path)
+    def __init__(self, path: str | Path | None = None):
+        self.path = Path(path) if path is not None else default_config_path()
         self.config = AppConfig()
 
     def load(self) -> None:
         """Load config from disk. No-op if file doesn't exist or is invalid."""
         if not self.path.exists():
             return
+        loaded = self._read_valid(self.path)
+        if loaded is not None:
+            self.config = loaded
+
+    @staticmethod
+    def _read_valid(path: Path) -> AppConfig | None:
         try:
-            data = json.loads(self.path.read_text())
+            data = json.loads(path.read_text())
         except (json.JSONDecodeError, OSError):
-            return
+            return None
         if data.get("version") != CONFIG_VERSION:
-            return
-        self.config = AppConfig(
+            return None
+        return AppConfig(
             rekordbox_xml_path=data.get("rekordbox_xml_path"),
             last_set_at=data.get("last_set_at"),
         )
 
+    def migrate_legacy(self, *, apply: bool = False) -> ConfigMigrationResult:
+        """Preview or apply migration from the exact current-directory file."""
+        legacy_path = Path.cwd() / LEGACY_CONFIG_FILENAME
+        if legacy_path.is_symlink():
+            return ConfigMigrationResult("invalid")
+        if not legacy_path.exists():
+            return ConfigMigrationResult("not_found")
+        legacy_config = self._read_valid(legacy_path)
+        if legacy_config is None:
+            return ConfigMigrationResult("invalid")
+        if self.path.exists():
+            current_config = self._read_valid(self.path)
+            status = (
+                "already_current"
+                if current_config == legacy_config
+                else "conflict"
+            )
+            return ConfigMigrationResult(status)
+        if apply:
+            self.config = legacy_config
+            self.save()
+            return ConfigMigrationResult("migrated", applied=True)
+        return ConfigMigrationResult("ready")
+
     def save(self) -> None:
         """Write config to disk."""
         data = {"version": CONFIG_VERSION, **asdict(self.config)}
-        self.path.write_text(json.dumps(data, indent=2))
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        temporary_path: Path | None = None
+        try:
+            with tempfile.NamedTemporaryFile(
+                mode="w", encoding="utf-8", dir=self.path.parent,
+                prefix=f".{self.path.name}.", delete=False,
+            ) as temporary:
+                json.dump(data, temporary, indent=2)
+                temporary.flush()
+                os.fsync(temporary.fileno())
+                temporary_path = Path(temporary.name)
+            os.replace(temporary_path, self.path)
+        finally:
+            if temporary_path is not None:
+                temporary_path.unlink(missing_ok=True)
 
     def get_rekordbox_xml_path(self) -> str | None:
         return self.config.rekordbox_xml_path

--- a/djsupport/config.py
+++ b/djsupport/config.py
@@ -56,8 +56,15 @@ class ConfigManager:
             data = json.loads(path.read_text())
         except (json.JSONDecodeError, OSError):
             return None
+        if not isinstance(data, dict):
+            return None
         if data.get("version") != CONFIG_VERSION:
             return None
+        for field in ("rekordbox_xml_path", "last_set_at"):
+            if data.get(field) is not None and not isinstance(
+                data.get(field), str
+            ):
+                return None
         return AppConfig(
             rekordbox_xml_path=data.get("rekordbox_xml_path"),
             last_set_at=data.get("last_set_at"),

--- a/djsupport/paths.py
+++ b/djsupport/paths.py
@@ -1,0 +1,22 @@
+"""Canonical private application-data paths."""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+
+def default_app_data_path() -> Path:
+    """Return the private, user-local application-data directory."""
+    if sys.platform == "darwin":
+        root = Path.home() / "Library" / "Application Support"
+    elif os.name == "nt":
+        root = Path(
+            os.environ.get("LOCALAPPDATA", Path.home() / "AppData" / "Local")
+        )
+    else:
+        root = Path(
+            os.environ.get("XDG_DATA_HOME", Path.home() / ".local" / "share")
+        )
+    return root / "djsupport"

--- a/djsupport/paths.py
+++ b/djsupport/paths.py
@@ -7,16 +7,26 @@ import sys
 from pathlib import Path
 
 
+def _absolute_environment_path(name: str, fallback: Path) -> Path:
+    """Return an absolute configured root, or a known private fallback."""
+    value = os.environ.get(name)
+    if value:
+        candidate = Path(value)
+        if candidate.is_absolute():
+            return candidate
+    return fallback
+
+
 def default_app_data_path() -> Path:
     """Return the private, user-local application-data directory."""
     if sys.platform == "darwin":
         root = Path.home() / "Library" / "Application Support"
-    elif os.name == "nt":
-        root = Path(
-            os.environ.get("LOCALAPPDATA", Path.home() / "AppData" / "Local")
+    elif sys.platform == "win32":
+        root = _absolute_environment_path(
+            "LOCALAPPDATA", Path.home() / "AppData" / "Local",
         )
     else:
-        root = Path(
-            os.environ.get("XDG_DATA_HOME", Path.home() / ".local" / "share")
+        root = _absolute_environment_path(
+            "XDG_DATA_HOME", Path.home() / ".local" / "share",
         )
     return root / "djsupport"

--- a/djsupport/transfer.py
+++ b/djsupport/transfer.py
@@ -36,6 +36,7 @@ else:
 from djsupport.cache import MatchCache
 from djsupport.local_audition import LocalAuditionResult
 from djsupport.matcher import match_track_with_alternatives
+from djsupport.paths import default_app_data_path
 from djsupport.rekordbox import Track
 from djsupport.report import (
     AlternativeCandidate,
@@ -70,13 +71,7 @@ ResultT = TypeVar("ResultT")
 
 def default_matching_knowledge_path() -> Path:
     """Return a private, user-local path outside the repository."""
-    if sys.platform == "darwin":
-        root = Path.home() / "Library" / "Application Support"
-    elif os.name == "nt":
-        root = Path(os.environ.get("LOCALAPPDATA", Path.home() / "AppData" / "Local"))
-    else:
-        root = Path(os.environ.get("XDG_DATA_HOME", Path.home() / ".local" / "share"))
-    return root / "djsupport" / "matching-knowledge.json"
+    return default_app_data_path() / "matching-knowledge.json"
 
 
 class TransferMode(str, Enum):

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -144,6 +144,7 @@ rendering.
 | Candidate matching and knowledge | [`matcher.py`](../djsupport/matcher.py) and [`cache.py`](../djsupport/cache.py) |
 | Local Audio Identity and Local Audition | [`local_audio.py`](../djsupport/local_audio.py) and [`local_audition.py`](../djsupport/local_audition.py) |
 | Transfer and file-backed persistence adapters | [`transfer.py`](../djsupport/transfer.py) |
+| Private application-data paths, configuration, backup, and migration | [`paths.py`](../djsupport/paths.py), [`config.py`](../djsupport/config.py), [`backup.py`](../djsupport/backup.py), and [`migration.py`](../djsupport/migration.py) |
 
 ### Plain-text module map
 

--- a/docs/backup-and-restore.md
+++ b/docs/backup-and-restore.md
@@ -1,9 +1,9 @@
 # Backup and restore
 
 `djsupport backup` creates a versioned archive in private application storage.
-It includes matching knowledge, Transfer and publication state, migration
-records, and privacy-screened reports. Credentials and unrelated files are not
-included.
+It includes Rekordbox path configuration, matching knowledge, Transfer and
+publication state, migration records, and privacy-screened reports. Credentials
+and unrelated files are not included.
 
 Matching-knowledge schema 3 includes private local-audio observations,
 account-scoped Approved Match associations, and retained Spotify review facts.
@@ -13,7 +13,8 @@ and private Qualification Drafts.
 Both are backed up and restored as private application data. Audition handles,
 audio, paths, filenames, and fingerprints are never part of a Qualification
 Draft. A differing copy of the same draft requires an explicit restore choice;
-neither draft silently wins. Conflicting local-audio authority requires
+neither draft silently wins. A differing Rekordbox configuration also requires
+an explicit `current` or `archive` restore choice. Conflicting local-audio authority requires
 an explicit restore choice identified by a privacy-safe hashed label; reports
 and archive manifests do not print fingerprints or source paths.
 

--- a/docs/storage.md
+++ b/docs/storage.md
@@ -22,25 +22,16 @@ directory:
 | Linux | `$XDG_DATA_HOME/djsupport`, otherwise `~/.local/share/djsupport` |
 | Windows | `%LOCALAPPDATA%/djsupport` |
 
-Two current exceptions are important:
-
-- Rekordbox path configuration defaults to `.djsupport_config.json` in the
-  process working directory.
-- Spotify environment configuration and Spotipy's token cache are managed by
-  the process environment/Spotipy rather than DJ Support's versioned
-  application-data schemas.
-
-Both are private and ignored by the repository, but the Rekordbox configuration
-location does not yet match ADR-0001's intended platform application-data
-placement. This document records the executable behavior; it does not silently
-relocate or migrate user state. The runtime correction and migration decision
-is tracked separately in [issue #110](https://github.com/spontain112/djsupport/issues/110).
+Rekordbox path configuration lives in the same private root as other versioned
+DJ Support data. Spotify environment configuration and Spotipy's token cache
+remain managed by the process environment/Spotipy rather than DJ Support's
+versioned application-data schemas.
 
 ## Current schema owners
 
 | Category | Default file | Current schema | Owning implementation | Contents and authority |
 | --- | --- | --- | --- | --- |
-| Configuration | `.djsupport_config.json` | `1` | [`ConfigManager`](../djsupport/config.py) | Selected Rekordbox XML path and update time; private reference, not source-read authority |
+| Configuration | `config.json` | `1` | [`ConfigManager`](../djsupport/config.py) | Selected Rekordbox XML path and update time; private reference, not source-read authority |
 | Matching knowledge | `matching-knowledge.json` | `3` | [`MatchCache`](../djsupport/cache.py) through `MatchingKnowledge` | Proposals, failures, Approved/Rejected Matches, Corrections, conflicts, private fingerprint observations and account-scoped associations |
 | Publication state | `publication-manifests.json` | `6` | [`FilePublicationStorage`](../djsupport/transfer.py) | Publication manifests, Approval outcomes, and Mirror relationships |
 | Transfer state | `publication-manifests.transfers.json` | `4` | [`FileTransferStorage`](../djsupport/transfer.py) | Transfers, Batches, checkpoints, and Qualification Drafts |
@@ -55,13 +46,14 @@ so a version bump cannot silently leave the inventory behind.
 
 ```mermaid
 flowchart TB
-    CONFIG[".djsupport_config.json<br/>selected XML reference"]
+    CONFIG["config.json<br/>selected XML reference"]
     MATCH["matching-knowledge.json<br/>proposals and approved knowledge"]
     TRANSFERS["publication-manifests.transfers.json<br/>Transfers, Batches, Qualification Drafts"]
     PUBLICATIONS["publication-manifests.json<br/>manifests, Approvals, Mirrors"]
     BACKUP["versioned local backup"]
 
     CONFIG --> T["Transfer"]
+    CONFIG --> BACKUP
     MATCH <--> T
     TRANSFERS <--> T
     PUBLICATIONS <--> T
@@ -84,6 +76,7 @@ schema versions:
 
 | File | Supported reader versions |
 | --- | --- |
+| `config.json` | `1` |
 | `matching-knowledge.json` | `1`, `2`, `3` |
 | `transfers.json` | `1`, `2`, `3`, `4` |
 | `publication-manifests.transfers.json` | `1`, `2`, `3`, `4` |
@@ -94,8 +87,8 @@ schema versions:
 
 `transfers.json` and `playlist-state.json` remain in the supported archive set
 for compatibility with earlier layouts. Their presence does not make them the
-default current write targets. Configuration and Spotify credentials/token
-caches are not currently members of the versioned backup archive.
+default current write targets. Spotify credentials and token caches are not
+members of the versioned backup archive.
 
 ## File contents by category
 
@@ -135,10 +128,14 @@ reading these files directly.
 ### Configuration and credentials
 
 The Rekordbox configuration file contains a private source path. Selecting or
-storing that path does not authorize reading the XML. Spotify client values are
-loaded from environment variables, optionally through `.env`; OAuth token
-storage is delegated to Spotipy. Secrets are never included in DJ Support's
-backup manifest and are explicitly excluded from repository content.
+storing that path does not authorize reading the XML. A legacy
+`.djsupport_config.json` is detected only at the exact process working
+directory and moves only through `djsupport library migrate-config --apply`.
+Migration never scans for, deletes, or silently chooses between configuration
+files. Spotify client values are loaded from environment variables, optionally
+through `.env`; OAuth token storage is delegated to Spotipy. Secrets are never
+included in DJ Support's backup manifest and are explicitly excluded from
+repository content.
 
 ## Write and concurrency behavior
 
@@ -148,7 +145,7 @@ backup manifest and are explicitly excluded from repository content.
 | Publication state | Writes a sibling temporary file and atomically replaces the target | Account publishing guards constrain publication work; the file itself has no per-entity revision contract |
 | Transfer state | Writes the complete document through a temporary file and atomic replace | Process/thread file locking plus per-entity revisions reject stale saves; resume reloads authoritative state |
 | Backup restore | Validates hashes and schemas, stages merged content, then replaces members | On failure, already replaced files are restored from staged originals |
-| Configuration | Rewrites the small versioned document | No concurrent revision contract; it is human setup state rather than Transfer progress |
+| Configuration | Writes a sibling temporary file, flushes it, and atomically replaces `config.json` | No concurrent revision contract; conflicts during migration or restore require an explicit user choice |
 
 Atomic replacement prevents a reader from observing a half-written publication
 or Transfer document. It does not make separate files one transaction. Transfer
@@ -163,6 +160,9 @@ explicitly and represents incomplete ordering as recoverable durable state.
   legacy data through a Preview-first flow and leaves the source unchanged.
 - [`FoundationMigration`](../djsupport/migration.py) binds retained state to a
   stable Spotify account identity only after creating a verified backup.
+- [`ConfigManager`](../djsupport/config.py) previews the exact current-directory
+  legacy configuration and copies it only on explicit apply; the source remains
+  unchanged and a differing canonical file is never selected automatically.
 - Migration marker files record idempotent completion; they do not contain
   credentials or authorize playlist effects.
 - A schema change must keep its supported reader window or ship an explicit,
@@ -172,11 +172,11 @@ explicitly and represents incomplete ordering as recoverable durable state.
 ## Backup boundary
 
 `djsupport backup` creates a local ZIP whose manifest records each supported
-member's relative path, SHA-256 hash, and schema version. Reports beneath the
-application-data report directory are included only when they use supported
-extensions and contain no recognized secret fields. Restore is Preview-first,
-validates paths and hashes, merges supported categories, and requires explicit
-conflict choices.
+member's relative path, SHA-256 hash, and schema version, including
+`config.json` when present. Reports beneath the application-data report
+directory are included only when they use supported extensions and contain no
+recognized secret fields. Restore is Preview-first, validates paths and hashes,
+merges supported categories, and requires explicit conflict choices.
 
 A backup is still private user data. Keep it outside the repository and do not
 attach it to an issue or Agent Client conversation.

--- a/docs/upgrading.md
+++ b/docs/upgrading.md
@@ -6,6 +6,29 @@ Create a local-data backup before an upgrade that changes retained schemas:
 djsupport backup
 ```
 
+## Move legacy Rekordbox configuration
+
+DJ Support now stores the saved Rekordbox XML reference in private platform
+application data as `config.json`. From the directory containing an older
+`.djsupport_config.json`, preview the exact migration candidate:
+
+```bash
+djsupport library migrate-config
+```
+
+Apply only after reviewing the status:
+
+```bash
+djsupport library migrate-config --apply
+```
+
+The command checks only the current directory, never prints the saved XML path,
+and leaves the legacy file unchanged. If both files exist and differ, migration
+stops; use `djsupport library set` to choose the intended XML explicitly.
+`config.json` is included in later `djsupport backup` archives, and a differing
+configuration during restore requires an explicit `current` or `archive`
+choice.
+
 ## To 0.5.0
 
 Spotify authorization now includes `playlist-read-private` so DJ Support can

--- a/tests/test_backup.py
+++ b/tests/test_backup.py
@@ -30,6 +30,11 @@ class TestBackup:
         _write_json(app_data / "playlist-state.json", {
             "version": 2, "entries": {"playlist": {"spotify_id": "playlist-1"}},
         })
+        _write_json(app_data / "config.json", {
+            "version": 1,
+            "rekordbox_xml_path": "/synthetic/library.xml",
+            "last_set_at": "2026-08-09T10:00:00",
+        })
         (app_data / "reports").mkdir()
         (app_data / "reports" / "transfer-1.md").write_text("# Transfer report")
 
@@ -43,7 +48,7 @@ class TestBackup:
             assert set(bundle.namelist()) == {
                 "backup-manifest.json", "matching-knowledge.json",
                 "transfers.json", "publication-manifests.json",
-                "playlist-state.json", "reports/transfer-1.md",
+                "playlist-state.json", "config.json", "reports/transfer-1.md",
             }
 
     def test_excludes_credentials_tokens_secrets_and_unrelated_files(self, tmp_path):
@@ -194,6 +199,42 @@ class TestRestorePreview:
 
 
 class TestRestore:
+    def test_different_configuration_requires_explicit_restore_resolution(
+        self, tmp_path,
+    ):
+        source = tmp_path / "source"
+        target = tmp_path / "target"
+        _write_json(source / "config.json", {
+            "version": 1,
+            "rekordbox_xml_path": "/synthetic/archive.xml",
+            "last_set_at": "2026-08-09T11:00:00",
+        })
+        current = {
+            "version": 1,
+            "rekordbox_xml_path": "/synthetic/current.xml",
+            "last_set_at": "2026-08-09T10:00:00",
+        }
+        _write_json(target / "config.json", current)
+        archive = LocalDataBackup(source).create(tmp_path / "backups")
+        service = LocalDataBackup(target)
+
+        preview = service.preview(archive)
+        result = service.restore(archive)
+
+        assert preview.conflicts[0].kind == "configuration"
+        assert preview.conflicts[0].path == "config.json"
+        assert result.restored is False
+        assert json.loads((target / "config.json").read_text()) == current
+
+        resolved = service.restore(archive, resolutions={
+            preview.conflicts[0].conflict_id: "archive",
+        })
+
+        assert resolved.restored is True
+        assert json.loads((target / "config.json").read_text())[
+            "rekordbox_xml_path"
+        ] == "/synthetic/archive.xml"
+
     def test_merges_non_conflicting_data_and_preserves_existing_knowledge(self, tmp_path):
         source = tmp_path / "source"
         target = tmp_path / "target"

--- a/tests/test_backup.py
+++ b/tests/test_backup.py
@@ -6,7 +6,8 @@ from datetime import datetime
 
 import pytest
 
-from djsupport.backup import LocalDataBackup
+from djsupport.backup import LocalDataBackup, SUPPORTED_SCHEMAS
+from djsupport.config import CONFIG_FILENAME, CONFIG_VERSION
 
 
 def _write_json(path, value):
@@ -15,6 +16,9 @@ def _write_json(path, value):
 
 
 class TestBackup:
+    def test_backup_uses_the_canonical_configuration_schema(self):
+        assert SUPPORTED_SCHEMAS[CONFIG_FILENAME] == (CONFIG_VERSION,)
+
     def test_creates_one_timestamped_archive_with_all_local_data(self, tmp_path):
         app_data = tmp_path / "app-data"
         _write_json(app_data / "matching-knowledge.json", {

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -4,7 +4,10 @@ import json
 from pathlib import Path
 
 import pytest
+from click.testing import CliRunner
 
+from djsupport.backup import default_app_data_path
+from djsupport.cli import cli
 from djsupport.config import ConfigManager, validate_rekordbox_xml, CONFIG_VERSION
 
 
@@ -14,6 +17,9 @@ def cfg(tmp_path):
 
 
 class TestConfigManager:
+    def test_default_path_is_private_platform_application_data(self):
+        assert ConfigManager().path == default_app_data_path() / "config.json"
+
     def test_default_xml_path_is_none(self, cfg):
         assert cfg.get_rekordbox_xml_path() is None
 
@@ -40,6 +46,37 @@ class TestConfigManager:
         c.save()
         data = json.loads(path.read_text())
         assert data["version"] == CONFIG_VERSION
+
+    def test_save_creates_the_private_application_data_directory(self, tmp_path):
+        path = tmp_path / "missing" / "app-data" / "config.json"
+
+        ConfigManager(path=path).save()
+
+        assert json.loads(path.read_text()) == {
+            "version": CONFIG_VERSION,
+            "rekordbox_xml_path": None,
+            "last_set_at": None,
+        }
+
+    def test_failed_save_leaves_existing_configuration_unchanged(
+        self, tmp_path, monkeypatch,
+    ):
+        path = tmp_path / "config.json"
+        manager = ConfigManager(path=path)
+        manager.set_rekordbox_xml_path("/synthetic/current.xml")
+        manager.save()
+        before = path.read_bytes()
+        manager.set_rekordbox_xml_path("/synthetic/replacement.xml")
+
+        def fail_replace(source, target):
+            raise OSError("synthetic replace failure")
+
+        monkeypatch.setattr("djsupport.config.os.replace", fail_replace)
+
+        with pytest.raises(OSError, match="synthetic replace failure"):
+            manager.save()
+
+        assert path.read_bytes() == before
 
     def test_load_nonexistent_file_is_noop(self, cfg):
         cfg.load()
@@ -68,6 +105,174 @@ class TestConfigManager:
     def test_set_path_records_timestamp(self, cfg, tmp_path):
         cfg.set_rekordbox_xml_path(str(tmp_path / "lib.xml"))
         assert cfg.config.last_set_at is not None
+
+    def test_legacy_migration_previews_without_writing_canonical_config(
+        self, tmp_path, monkeypatch,
+    ):
+        monkeypatch.chdir(tmp_path)
+        legacy = tmp_path / ".djsupport_config.json"
+        legacy.write_text(json.dumps({
+            "version": CONFIG_VERSION,
+            "rekordbox_xml_path": "/synthetic/library.xml",
+            "last_set_at": "2026-08-09T10:00:00",
+        }))
+        canonical = tmp_path / "app-data" / "config.json"
+
+        result = ConfigManager(path=canonical).migrate_legacy()
+
+        assert result.status == "ready"
+        assert result.applied is False
+        assert not canonical.exists()
+
+    def test_legacy_migration_apply_copies_but_never_deletes_legacy_config(
+        self, tmp_path, monkeypatch,
+    ):
+        monkeypatch.chdir(tmp_path)
+        legacy = tmp_path / ".djsupport_config.json"
+        legacy_data = {
+            "version": CONFIG_VERSION,
+            "rekordbox_xml_path": "/synthetic/library.xml",
+            "last_set_at": "2026-08-09T10:00:00",
+        }
+        legacy.write_text(json.dumps(legacy_data))
+        before = legacy.read_bytes()
+        canonical = tmp_path / "app-data" / "config.json"
+
+        result = ConfigManager(path=canonical).migrate_legacy(apply=True)
+
+        assert result.status == "migrated"
+        assert result.applied is True
+        assert json.loads(canonical.read_text()) == legacy_data
+        assert legacy.read_bytes() == before
+
+    def test_legacy_migration_rejects_a_link_outside_the_current_directory(
+        self, tmp_path, monkeypatch,
+    ):
+        working = tmp_path / "working"
+        working.mkdir()
+        outside = tmp_path / "outside-config.json"
+        outside.write_text(json.dumps({
+            "version": CONFIG_VERSION,
+            "rekordbox_xml_path": "/synthetic/library.xml",
+            "last_set_at": None,
+        }))
+        (working / ".djsupport_config.json").symlink_to(outside)
+        monkeypatch.chdir(working)
+        canonical = tmp_path / "app-data" / "config.json"
+
+        result = ConfigManager(path=canonical).migrate_legacy(apply=True)
+
+        assert result.status == "invalid"
+        assert result.applied is False
+        assert not canonical.exists()
+
+    def test_legacy_migration_never_chooses_between_different_configs(
+        self, tmp_path, monkeypatch,
+    ):
+        monkeypatch.chdir(tmp_path)
+        legacy = tmp_path / ".djsupport_config.json"
+        canonical = tmp_path / "app-data" / "config.json"
+        canonical.parent.mkdir()
+        legacy.write_text(json.dumps({
+            "version": CONFIG_VERSION,
+            "rekordbox_xml_path": "/synthetic/legacy.xml",
+            "last_set_at": None,
+        }))
+        canonical.write_text(json.dumps({
+            "version": CONFIG_VERSION,
+            "rekordbox_xml_path": "/synthetic/current.xml",
+            "last_set_at": None,
+        }))
+        before = canonical.read_bytes()
+
+        result = ConfigManager(path=canonical).migrate_legacy(apply=True)
+
+        assert vars(result) == {"status": "conflict", "applied": False}
+        assert canonical.read_bytes() == before
+
+
+class TestConfigMigrationCli:
+    def test_preview_is_path_private_and_explains_explicit_apply(
+        self, tmp_path, monkeypatch,
+    ):
+        app_data = tmp_path / "app-data"
+        monkeypatch.setattr(
+            "djsupport.config.default_app_data_path", lambda: app_data,
+        )
+        runner = CliRunner()
+        with runner.isolated_filesystem(temp_dir=tmp_path):
+            Path(".djsupport_config.json").write_text(json.dumps({
+                "version": CONFIG_VERSION,
+                "rekordbox_xml_path": "/private/synthetic/library.xml",
+                "last_set_at": None,
+            }))
+
+            result = runner.invoke(cli, ["library", "migrate-config"])
+
+        assert result.exit_code == 0
+        assert "ready to migrate" in result.output
+        assert "--apply" in result.output
+        assert "/private/synthetic/library.xml" not in result.output
+        assert not (app_data / "config.json").exists()
+
+    def test_apply_migrates_without_deleting_or_printing_the_legacy_path(
+        self, tmp_path, monkeypatch,
+    ):
+        app_data = tmp_path / "app-data"
+        monkeypatch.setattr(
+            "djsupport.config.default_app_data_path", lambda: app_data,
+        )
+        runner = CliRunner()
+        with runner.isolated_filesystem(temp_dir=tmp_path):
+            legacy = Path(".djsupport_config.json")
+            legacy.write_text(json.dumps({
+                "version": CONFIG_VERSION,
+                "rekordbox_xml_path": "/private/synthetic/library.xml",
+                "last_set_at": None,
+            }))
+
+            result = runner.invoke(
+                cli, ["library", "migrate-config", "--apply"],
+            )
+
+            assert legacy.exists()
+        assert result.exit_code == 0
+        assert "migrated to private application data" in result.output
+        assert "/private/synthetic/library.xml" not in result.output
+        assert json.loads((app_data / "config.json").read_text())[
+            "rekordbox_xml_path"
+        ] == "/private/synthetic/library.xml"
+
+    def test_conflict_stops_and_routes_to_explicit_library_set(
+        self, tmp_path, monkeypatch,
+    ):
+        app_data = tmp_path / "app-data"
+        app_data.mkdir()
+        current = {
+            "version": CONFIG_VERSION,
+            "rekordbox_xml_path": "/private/synthetic/current.xml",
+            "last_set_at": None,
+        }
+        (app_data / "config.json").write_text(json.dumps(current))
+        monkeypatch.setattr(
+            "djsupport.config.default_app_data_path", lambda: app_data,
+        )
+        runner = CliRunner()
+        with runner.isolated_filesystem(temp_dir=tmp_path):
+            Path(".djsupport_config.json").write_text(json.dumps({
+                "version": CONFIG_VERSION,
+                "rekordbox_xml_path": "/private/synthetic/legacy.xml",
+                "last_set_at": None,
+            }))
+
+            result = runner.invoke(
+                cli, ["library", "migrate-config", "--apply"],
+            )
+
+        assert result.exit_code == 1
+        assert "Choose explicitly" in result.output
+        assert "/private/synthetic/" not in result.output
+        assert json.loads((app_data / "config.json").read_text()) == current
 
 
 class TestValidateRekordboxXml:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -9,6 +9,7 @@ from click.testing import CliRunner
 from djsupport.backup import default_app_data_path
 from djsupport.cli import cli
 from djsupport.config import ConfigManager, validate_rekordbox_xml, CONFIG_VERSION
+from djsupport import paths
 
 
 @pytest.fixture
@@ -19,6 +20,26 @@ def cfg(tmp_path):
 class TestConfigManager:
     def test_default_path_is_private_platform_application_data(self):
         assert ConfigManager().path == default_app_data_path() / "config.json"
+
+    @pytest.mark.parametrize(
+        ("platform", "environment", "value", "fallback"),
+        (
+            ("linux", "XDG_DATA_HOME", "", Path(".local/share")),
+            ("linux", "XDG_DATA_HOME", "relative-data", Path(".local/share")),
+            ("win32", "LOCALAPPDATA", "", Path("AppData/Local")),
+            ("win32", "LOCALAPPDATA", "relative-data", Path("AppData/Local")),
+        ),
+    )
+    def test_empty_or_relative_platform_data_root_uses_absolute_fallback(
+        self, monkeypatch, platform, environment, value, fallback,
+    ):
+        monkeypatch.setattr(paths.sys, "platform", platform)
+        monkeypatch.setenv(environment, value)
+
+        result = paths.default_app_data_path()
+
+        assert result == Path.home() / fallback / "djsupport"
+        assert result.is_absolute()
 
     def test_default_xml_path_is_none(self, cfg):
         assert cfg.get_rekordbox_xml_path() is None
@@ -166,6 +187,29 @@ class TestConfigManager:
         assert result.applied is False
         assert not canonical.exists()
 
+    @pytest.mark.parametrize(
+        "legacy_data",
+        (
+            [],
+            {"version": CONFIG_VERSION, "rekordbox_xml_path": 42},
+            {"version": CONFIG_VERSION, "last_set_at": ["not", "text"]},
+        ),
+    )
+    def test_legacy_migration_rejects_structurally_invalid_configuration(
+        self, tmp_path, monkeypatch, legacy_data,
+    ):
+        monkeypatch.chdir(tmp_path)
+        (tmp_path / ".djsupport_config.json").write_text(
+            json.dumps(legacy_data)
+        )
+        canonical = tmp_path / "app-data" / "config.json"
+
+        result = ConfigManager(path=canonical).migrate_legacy(apply=True)
+
+        assert result.status == "invalid"
+        assert result.applied is False
+        assert not canonical.exists()
+
     def test_legacy_migration_never_chooses_between_different_configs(
         self, tmp_path, monkeypatch,
     ):
@@ -192,6 +236,25 @@ class TestConfigManager:
 
 
 class TestConfigMigrationCli:
+    def test_structurally_invalid_legacy_config_returns_safe_cli_error(
+        self, tmp_path, monkeypatch,
+    ):
+        app_data = tmp_path / "app-data"
+        monkeypatch.setattr(
+            "djsupport.config.default_app_data_path", lambda: app_data,
+        )
+        runner = CliRunner()
+        with runner.isolated_filesystem(temp_dir=tmp_path):
+            Path(".djsupport_config.json").write_text("[]")
+
+            result = runner.invoke(
+                cli, ["library", "migrate-config", "--apply"],
+            )
+
+        assert result.exit_code == 1
+        assert "invalid and was not migrated" in result.output
+        assert not (app_data / "config.json").exists()
+
     def test_preview_is_path_private_and_explains_explicit_apply(
         self, tmp_path, monkeypatch,
     ):

--- a/tests/test_documentation.py
+++ b/tests/test_documentation.py
@@ -5,7 +5,7 @@ from pathlib import Path
 
 from djsupport.backup import BACKUP_VERSION, SUPPORTED_SCHEMAS
 from djsupport.cache import CACHE_VERSION
-from djsupport.config import CONFIG_VERSION, DEFAULT_CONFIG_PATH
+from djsupport.config import CONFIG_FILENAME, CONFIG_VERSION
 from djsupport.transfer import (
     PUBLICATION_MANIFEST_VERSION,
     TRANSFER_STATE_VERSION,
@@ -81,7 +81,7 @@ def test_storage_document_follows_executable_schema_versions() -> None:
     ).name
 
     expected_lines = {
-        f"| Configuration | `{DEFAULT_CONFIG_PATH}` | `{CONFIG_VERSION}` |",
+        f"| Configuration | `{CONFIG_FILENAME}` | `{CONFIG_VERSION}` |",
         f"| Matching knowledge | `matching-knowledge.json` | `{CACHE_VERSION}` |",
         (
             "| Publication state | `publication-manifests.json` | "


### PR DESCRIPTION
Closes #110

## What changed

- Make platform application data the canonical home for versioned Rekordbox `config.json`.
- Keep explicit `ConfigManager(path=...)` injection for tests and controlled adapters.
- Add privacy-safe `djsupport library migrate-config` preview and explicit `--apply` migration from the exact current-directory legacy file.
- Never scan for, expose, choose between, overwrite, or delete differing legacy configuration automatically.
- Include configuration in versioned local-data backup and require an explicit current/archive choice on restore conflicts.
- Centralize application-data paths and the configuration filename/schema owner.
- Update setup, storage, architecture, backup, upgrade, contributor, and changelog documentation.

## Safety and user impact

Existing `.djsupport_config.json` files remain untouched. Migration is preview-only unless the user supplies `--apply`; malformed or conflicting files fail safely without disclosing saved paths. Blank or relative OS application-data variables cannot redirect private state into a checkout. No owner configuration, Rekordbox XML, audio, credentials, or application data was read.

## Validation

- 676 offline tests passed
- Python compilation passed
- repository privacy and release-channel tests passed
- source and wheel package build passed
- `git diff --check` passed
- independent Standards review passed with zero remaining findings
- independent Spec review passed with zero remaining findings