### PR TITLE
Guide a first-time Rekordbox Transfer through the agent-native lifecycle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 - Qualification Approval now retains its aggregate outcome so repeated guide
   invocation is idempotent and does not repeat matching-authority writes.
+- First-transfer readiness is derived consistently by CLI and web without
+  opening token contents, and interrupted Approval fails closed for review
+  rather than repeating uncertain authority writes.
 - Rekordbox path configuration now lives in private platform application data,
   participates in versioned backup/restore, and requires an explicit restore
   choice on conflict.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Added
 
+- A harness-neutral First Rekordbox Transfer guide with one structured next
+  action at a time across readiness, bounded Preview, Qualification,
+  publication, draft application, and separate playlist-scoped Approval.
+- Thin `first-transfer --json` and `/rekordbox/first-transfer` adapters with
+  deterministic non-interactive behavior and runtime input shapes.
 - Preview-first migration of legacy current-directory Rekordbox configuration,
   with explicit apply and no source-file deletion.
 - Least-privilege GitHub Actions CI for pull requests and `main`, covering the
@@ -36,9 +41,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - Transfer-state schema 4 for durable local-audio opt-in, evidence checkpoints,
   stable aggregate outcomes, and Qualification Drafts; schemas 1–3 remain
   readable.
+- Transfer-state schema 5 for idempotent retained Qualification Approval
+  outcomes; schemas 1–4 remain readable.
 
 ### Changed
 
+- Qualification Approval now retains its aggregate outcome so repeated guide
+  invocation is idempotent and does not repeat matching-authority writes.
 - Rekordbox path configuration now lives in private platform application data,
   participates in versioned backup/restore, and requires an explicit restore
   choice on conflict.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,6 +28,7 @@ every flag.
 djsupport/
   transfer.py    Durable Transfer policy, planning, checkpoints, and publication
   agent.py       Versioned, harness-neutral Transfer contract rendering
+  readiness.py   Shared presence-only readiness for CLI and web adapters
   cli.py         Thin Click command-line adapter
   web.py         Optional thin FastAPI adapter and static web application
   rekordbox.py   Rekordbox XML intake

--- a/README.md
+++ b/README.md
@@ -332,6 +332,10 @@ journey without treating ordinary human input as a command failure. JSON mode
 never prompts, truncates private facts into prose, or mixes diagnostics into
 the document.
 
+Readiness inspects only local configuration and file presence. Spotify token
+contents are verified only when you explicitly continue into a Spotify phase;
+an expired or invalid login then returns authentication as the next safe step.
+
 Advanced clients can also use the lower-level public seams. Inspect optional
 capabilities without reading private source data:
 

--- a/README.md
+++ b/README.md
@@ -127,7 +127,9 @@ The journey always starts with Preview and never selects the whole library.
 Preview can retain private matching knowledge and a resumable checkpoint, but
 cannot create or update a Spotify playlist. After review, applying the
 Qualification Draft requires explicit Spotify-write authorization; Approval is
-a later decision and is the only step that makes matches authoritative.
+a later decision and is the only step that makes matches authoritative. That
+Approval records local authority only; it does not perform another Spotify
+mutation.
 
 When prompted for the Rekordbox source, export your collection from Rekordbox
 with **File → Export Collection in xml format**, then save its location:

--- a/README.md
+++ b/README.md
@@ -111,8 +111,26 @@ clients.
 
 ## Your first Rekordbox Transfer
 
-Export your collection from Rekordbox with **File → Export Collection in xml
-format**, then save its location:
+DJ Support is designed to be operated through a local AI harness. Start with a
+plain request such as:
+
+> Help me transfer my first Rekordbox playlist.
+
+The harness calls `djsupport first-transfer --json` and receives exactly one
+safe next action. It guides you through Spotify setup, the Rekordbox XML export,
+one explicit playlist, the optional local-audio identity decision, Preview,
+local Qualification, draft application, and separate Approval. Missing input
+is a successful machine-readable result, not an interactive prompt or an
+error. The harness cannot infer authorization from conversation.
+
+The journey always starts with Preview and never selects the whole library.
+Preview can retain private matching knowledge and a resumable checkpoint, but
+cannot create or update a Spotify playlist. After review, applying the
+Qualification Draft requires explicit Spotify-write authorization; Approval is
+a later decision and is the only step that makes matches authoritative.
+
+When prompted for the Rekordbox source, export your collection from Rekordbox
+with **File → Export Collection in xml format**, then save its location:
 
 ```bash
 djsupport library set /path/to/library.xml
@@ -131,7 +149,11 @@ djsupport library migrate-config --apply
 Migration leaves the legacy file untouched and refuses to choose when current
 and legacy configurations differ.
 
-List the available playlists:
+The selected path is private operating-system application data and is never
+returned in an agent document. Listing or reading it requires explicit
+private-source authorization.
+
+For direct expert use, list the available playlists:
 
 ```bash
 djsupport list
@@ -144,8 +166,12 @@ djsupport sync --playlist "Deep House" --dry-run
 ```
 
 Preview may retain local matching knowledge and a resumable Transfer checkpoint.
-When the report looks right, run the same bounded selection without
-`--dry-run`:
+These lower-level commands remain available for experts. The first-transfer
+guide instead routes Preview into the Qualification Workspace and keeps
+publication, draft application, and Approval as distinct steps.
+
+When using the direct workflow and the report looks right, run the same bounded
+selection without `--dry-run`:
 
 ```bash
 djsupport sync --playlist "Deep House"
@@ -293,7 +319,21 @@ automatically triggers this calculation.
 ## AI-agent use
 
 Codex and other harnesses are first-class clients of the same Transfer policy.
-Inspect capabilities without reading private source data:
+For a first Rekordbox journey, begin with:
+
+```bash
+djsupport first-transfer --json
+```
+
+The response is stable structured output with a single `next_action` and, when
+needed, an exact `required_input` shape. An `input_required` or
+`decision_required` response exits successfully so an agent can continue the
+journey without treating ordinary human input as a command failure. JSON mode
+never prompts, truncates private facts into prose, or mixes diagnostics into
+the document.
+
+Advanced clients can also use the lower-level public seams. Inspect optional
+capabilities without reading private source data:
 
 ```bash
 djsupport capabilities --json

--- a/djsupport/agent.py
+++ b/djsupport/agent.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import ipaddress
+from dataclasses import dataclass
 from urllib.parse import urlsplit
 
 from djsupport.transfer import (
@@ -21,6 +22,21 @@ AGENT_CONTRACT_VERSION = 2
 
 
 AgentAuthorization = TransferAuthorization
+
+
+@dataclass(frozen=True)
+class FirstTransferGuideRequest:
+    """Explicit setup facts for the first Rekordbox Transfer guide."""
+
+    spotify_configured: bool = False
+    spotify_authenticated: bool = False
+    rekordbox_configured: bool = False
+    rekordbox_available: bool = False
+    playlist_reference: str | None = None
+    local_audio_identity: bool | None = None
+    action: str | None = None
+    transfer_id: str | None = None
+    draft_id: str | None = None
 
 
 def _loopback_review_origin(value: str) -> str:
@@ -151,6 +167,319 @@ class AgentTransferContract:
             self._transfer.local_audio_capability(),
             self._transfer.local_audition_capability(),
         )
+
+    def first_rekordbox_transfer(
+        self,
+        request: FirstTransferGuideRequest,
+        authorization: AgentAuthorization,
+    ) -> dict:
+        """Return the next safe decision in a first Rekordbox journey."""
+        if not request.spotify_configured:
+            next_action = "configure_spotify"
+            required_input = {
+                "kind": "spotify_configuration",
+                "redirect_uri": "http://127.0.0.1:8888/callback",
+                "callback_policy": "add_without_replacing_existing",
+            }
+        elif not request.spotify_authenticated:
+            next_action = "authenticate_spotify"
+            required_input = {"kind": "spotify_authentication"}
+        elif not request.rekordbox_configured:
+            next_action = "select_rekordbox_xml"
+            required_input = {
+                "kind": "rekordbox_xml", "selection": "exact_file",
+            }
+        elif not request.rekordbox_available:
+            next_action = "repair_rekordbox_xml"
+            required_input = {
+                "kind": "rekordbox_xml", "selection": "exact_file",
+            }
+        elif request.playlist_reference is None:
+            next_action = "select_playlist"
+            required_input = {
+                "kind": "rekordbox_playlist",
+                "selection": "one_explicit_playlist",
+                "whole_library": False,
+            }
+        elif request.local_audio_identity is None:
+            capability = self._transfer.local_audio_capability()
+            return {
+                "contract_version": AGENT_CONTRACT_VERSION,
+                "phase": "first_rekordbox_transfer",
+                "status": "decision_required",
+                "next_action": "choose_local_audio_identity",
+                "required_input": {"kind": "boolean", "default": False},
+                "local_audio_identity": {
+                    "available": capability.available,
+                    "scope": "selected_tracks_only",
+                    "uploads": "none",
+                    "file_changes": "none",
+                    "first_run_spotify_search_reduction": False,
+                    "future_reuse": "exact_approved_match_after_approval",
+                    "approval_authority": "none",
+                    "audition": "separate",
+                },
+            }
+        elif (
+            request.local_audio_identity
+            and not self._transfer.local_audio_capability().available
+        ):
+            return {
+                "contract_version": AGENT_CONTRACT_VERSION,
+                "phase": "first_rekordbox_transfer",
+                "status": "decision_required",
+                "next_action": "continue_without_local_audio_identity",
+                "required_input": {"kind": "boolean", "value": False},
+                "reason": {"code": "local_audio_identity_unavailable"},
+            }
+        elif not authorization.private_source:
+            return {
+                "contract_version": AGENT_CONTRACT_VERSION,
+                "phase": "first_rekordbox_transfer",
+                "status": "authorization_required",
+                "next_action": "authorize_private_source",
+                "required_authorization": "private_source",
+            }
+        else:
+            allowed_actions = {
+                None, "preview", "qualify", "publish_and_link", "apply",
+                "approve", "resume", "abandon",
+            }
+            if request.action not in allowed_actions:
+                return {
+                    "contract_version": AGENT_CONTRACT_VERSION,
+                    "phase": "first_rekordbox_transfer",
+                    "status": "error",
+                    "error": {"code": "unsupported_action"},
+                    "next_action": "review_request",
+                }
+            batch_request = BatchPlanRequest(
+                playlist_references=(request.playlist_reference,),
+                preview=True,
+                local_audio_identity=request.local_audio_identity,
+            )
+            if request.action == "resume":
+                if request.transfer_id is None:
+                    raise ValueError("Resume requires a Transfer identity")
+                outcome = self.execute_batch(
+                    batch_request, authorization,
+                    transfer_id=request.transfer_id,
+                )
+                next_actions = outcome.pop("next_actions", None) or ["qualify"]
+                next_action = next_actions[0]
+                outcome.update({
+                    "phase": "first_rekordbox_transfer",
+                    "next_action": next_action,
+                    "required_input": {
+                        "kind": "action_confirmation", "action": next_action,
+                    },
+                })
+                return outcome
+            if request.action == "abandon":
+                if request.transfer_id is None:
+                    raise ValueError("Abandonment requires a Transfer identity")
+                self._transfer.abandon(request.transfer_id)
+                return {
+                    "contract_version": AGENT_CONTRACT_VERSION,
+                    "phase": "first_rekordbox_transfer",
+                    "status": "abandoned",
+                    "transfer_id": request.transfer_id,
+                    "next_action": None,
+                }
+            if request.action == "approve":
+                if request.draft_id is None:
+                    raise ValueError(
+                        "Approval requires a Qualification Draft identity"
+                    )
+                approved = self.approve_qualification(
+                    request.draft_id, authorization,
+                )
+                approved.pop("next_actions", None)
+                counts = approved["counts"]
+                approved.update({
+                    "phase": "first_rekordbox_transfer",
+                    "retained": {
+                        "approved_matches": counts["approved"],
+                        "corrections": counts["corrections"],
+                        "rejected_matches": counts["rejected"],
+                    },
+                    "next_action": None,
+                })
+                return approved
+            if request.action == "apply":
+                if request.draft_id is None:
+                    raise ValueError(
+                        "Draft application requires a Qualification identity"
+                    )
+                if not authorization.spotify_write:
+                    return {
+                        "contract_version": AGENT_CONTRACT_VERSION,
+                        "phase": "first_rekordbox_transfer",
+                        "status": "authorization_required",
+                        "draft_id": request.draft_id,
+                        "authority": "none",
+                        "next_action": "authorize_spotify_write",
+                        "required_authorization": "spotify_write",
+                    }
+                applied = self.apply_qualification(
+                    request.draft_id, authorization,
+                )
+                applied.pop("next_actions", None)
+                applied.update({
+                    "phase": "first_rekordbox_transfer",
+                    "next_action": "approve",
+                    "required_input": {
+                        "kind": "authority_confirmation",
+                        "authority": "playlist_approval",
+                    },
+                })
+                return applied
+            if request.action == "publish_and_link":
+                if request.draft_id is None:
+                    raise ValueError(
+                        "Publication requires a Qualification Draft identity"
+                    )
+                progress = self.qualification_progress(
+                    request.draft_id, authorization,
+                )
+                progress_actions = progress["next_actions"]
+                if progress_actions[0] == "apply":
+                    progress.pop("next_actions")
+                    progress.update({
+                        "phase": "first_rekordbox_transfer",
+                        "next_action": "apply",
+                        "required_input": {
+                            "kind": "action_confirmation", "action": "apply",
+                        },
+                    })
+                    return progress
+                if not authorization.spotify_write:
+                    return {
+                        "contract_version": AGENT_CONTRACT_VERSION,
+                        "phase": "first_rekordbox_transfer",
+                        "status": "authorization_required",
+                        "draft_id": request.draft_id,
+                        "authority": "none",
+                        "next_action": "authorize_spotify_write",
+                        "required_authorization": "spotify_write",
+                    }
+                publishing_request = BatchPlanRequest(
+                    playlist_references=(request.playlist_reference,),
+                    preview=False,
+                    local_audio_identity=request.local_audio_identity,
+                )
+                published = self.execute_batch(
+                    publishing_request, authorization,
+                )
+                linked = self.link_qualification(
+                    request.draft_id, published["transfer_id"], authorization,
+                )
+                linked.pop("next_actions", None)
+                linked.update({
+                    "phase": "first_rekordbox_transfer",
+                    "next_action": "apply",
+                    "required_input": {
+                        "kind": "action_confirmation", "action": "apply",
+                    },
+                })
+                return linked
+            if request.draft_id is not None and request.action is None:
+                qualification = self.qualification_progress(
+                    request.draft_id, authorization,
+                )
+                next_actions = qualification.pop("next_actions")
+                if not next_actions:
+                    qualification.update({
+                        "phase": "first_rekordbox_transfer",
+                        "next_action": None,
+                    })
+                    return qualification
+                primary_action = next_actions[0]
+                if (
+                    primary_action in {"publish_and_link", "apply"}
+                    and not authorization.spotify_write
+                ):
+                    return {
+                        "contract_version": AGENT_CONTRACT_VERSION,
+                        "phase": "first_rekordbox_transfer",
+                        "status": "authorization_required",
+                        "draft_id": request.draft_id,
+                        "authority": "none",
+                        "next_action": "authorize_spotify_write",
+                        "required_authorization": "spotify_write",
+                    }
+                qualification.update({
+                    "phase": "first_rekordbox_transfer",
+                    "next_action": primary_action,
+                    "required_input": {
+                        "kind": "action_confirmation",
+                        "action": primary_action,
+                    },
+                })
+                return qualification
+            if request.transfer_id is not None and request.action is None:
+                progress = self.progress(request.transfer_id, authorization)
+                next_actions = progress.pop("next_actions", None) or []
+                next_action = next_actions[0] if next_actions else None
+                progress.update({
+                    "phase": "first_rekordbox_transfer",
+                    "next_action": next_action,
+                })
+                if next_action is not None:
+                    progress["required_input"] = {
+                        "kind": "action_confirmation", "action": next_action,
+                    }
+                return progress
+            if request.action == "qualify":
+                if request.transfer_id is None:
+                    raise ValueError("Qualification requires a Transfer identity")
+                qualification = self.qualification_draft(
+                    QualificationRequest(
+                        transfer_id=request.transfer_id,
+                        playlist_reference=request.playlist_reference,
+                        include_all=True,
+                    ),
+                    authorization,
+                )
+                next_actions = qualification.pop("next_actions")
+                qualification.update({
+                    "phase": "first_rekordbox_transfer",
+                    "next_action": next_actions[0],
+                    "required_input": {
+                        "kind": "local_qualification_review",
+                        "review_url": qualification["review_url"],
+                    },
+                })
+                return qualification
+            if request.action == "preview":
+                outcome = self.execute_batch(batch_request, authorization)
+                next_actions = outcome.pop("next_actions", None) or ["qualify"]
+                next_action = next_actions[0]
+                outcome.update({
+                    "phase": "first_rekordbox_transfer",
+                    "next_action": next_action,
+                    "required_input": {
+                        "kind": "action_confirmation", "action": next_action,
+                    },
+                })
+                return outcome
+            plan_document = self.plan_batch(batch_request, authorization)
+            plan_document.pop("next_actions", None)
+            plan_document.update({
+                "phase": "first_rekordbox_transfer",
+                "next_action": "preview",
+                "required_input": {
+                    "kind": "action_confirmation", "action": "preview",
+                },
+            })
+            return plan_document
+        return {
+            "contract_version": AGENT_CONTRACT_VERSION,
+            "phase": "first_rekordbox_transfer",
+            "status": "input_required",
+            "next_action": next_action,
+            "required_input": required_input,
+        }
 
     def plan_batch(
         self, request: BatchPlanRequest, authorization: AgentAuthorization,

--- a/djsupport/agent.py
+++ b/djsupport/agent.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import ipaddress
 from dataclasses import dataclass
+from enum import Enum
 from urllib.parse import urlsplit
 
 from djsupport.transfer import (
@@ -24,6 +25,28 @@ AGENT_CONTRACT_VERSION = 2
 AgentAuthorization = TransferAuthorization
 
 
+class FirstTransferAction(str, Enum):
+    PREVIEW = "preview"
+    QUALIFY = "qualify"
+    PUBLISH_AND_LINK = "publish_and_link"
+    APPLY = "apply"
+    APPROVE = "approve"
+    RESUME = "resume"
+    ABANDON = "abandon"
+
+    @property
+    def needs_spotify_access(self) -> bool:
+        return self != FirstTransferAction.ABANDON
+
+    @property
+    def publishes(self) -> bool:
+        return self in {
+            FirstTransferAction.PUBLISH_AND_LINK,
+            FirstTransferAction.APPLY,
+            FirstTransferAction.APPROVE,
+        }
+
+
 @dataclass(frozen=True)
 class FirstTransferGuideRequest:
     """Explicit setup facts for the first Rekordbox Transfer guide."""
@@ -34,7 +57,7 @@ class FirstTransferGuideRequest:
     rekordbox_available: bool = False
     playlist_reference: str | None = None
     local_audio_identity: bool | None = None
-    action: str | None = None
+    action: FirstTransferAction | str | None = None
     transfer_id: str | None = None
     draft_id: str | None = None
 
@@ -241,11 +264,12 @@ class AgentTransferContract:
                 "required_authorization": "private_source",
             }
         else:
-            allowed_actions = {
-                None, "preview", "qualify", "publish_and_link", "apply",
-                "approve", "resume", "abandon",
-            }
-            if request.action not in allowed_actions:
+            try:
+                action = (
+                    FirstTransferAction(request.action)
+                    if request.action is not None else None
+                )
+            except ValueError:
                 return {
                     "contract_version": AGENT_CONTRACT_VERSION,
                     "phase": "first_rekordbox_transfer",
@@ -258,24 +282,15 @@ class AgentTransferContract:
                 preview=True,
                 local_audio_identity=request.local_audio_identity,
             )
-            if request.action == "resume":
+            if action == FirstTransferAction.RESUME:
                 if request.transfer_id is None:
                     raise ValueError("Resume requires a Transfer identity")
                 outcome = self.execute_batch(
                     batch_request, authorization,
                     transfer_id=request.transfer_id,
                 )
-                next_actions = outcome.pop("next_actions", None) or ["qualify"]
-                next_action = next_actions[0]
-                outcome.update({
-                    "phase": "first_rekordbox_transfer",
-                    "next_action": next_action,
-                    "required_input": {
-                        "kind": "action_confirmation", "action": next_action,
-                    },
-                })
-                return outcome
-            if request.action == "abandon":
+                return self._first_guide_step(outcome, default_action="qualify")
+            if action == FirstTransferAction.ABANDON:
                 if request.transfer_id is None:
                     raise ValueError("Abandonment requires a Transfer identity")
                 self._transfer.abandon(request.transfer_id)
@@ -286,18 +301,39 @@ class AgentTransferContract:
                     "transfer_id": request.transfer_id,
                     "next_action": None,
                 }
-            if request.action == "approve":
+            if action == FirstTransferAction.APPROVE:
                 if request.draft_id is None:
                     raise ValueError(
                         "Approval requires a Qualification Draft identity"
                     )
+                progress = self.qualification_progress(
+                    request.draft_id, authorization,
+                )
+                progress_actions = progress.get("next_actions", [])
+                if (
+                    progress.get("status") != "approved"
+                    and (
+                        not progress_actions
+                        or progress_actions[0] != "approve"
+                    )
+                ):
+                    return self._first_guide_step(progress)
                 approved = self.approve_qualification(
                     request.draft_id, authorization,
                 )
-                approved.pop("next_actions", None)
+                next_actions = approved.pop("next_actions", None) or []
+                if "counts" not in approved:
+                    approved["next_actions"] = next_actions
+                    return self._first_guide_step(approved)
                 counts = approved["counts"]
                 approved.update({
                     "phase": "first_rekordbox_transfer",
+                    "effects": {
+                        "spotify_writes_during_approval": 0,
+                        "spotify_playlist_items": (
+                            counts["approved"] + counts["corrections"]
+                        ),
+                    },
                     "retained": {
                         "approved_matches": counts["approved"],
                         "corrections": counts["corrections"],
@@ -306,11 +342,26 @@ class AgentTransferContract:
                     "next_action": None,
                 })
                 return approved
-            if request.action == "apply":
+            if action == FirstTransferAction.APPLY:
                 if request.draft_id is None:
                     raise ValueError(
                         "Draft application requires a Qualification identity"
                     )
+                progress = self.qualification_progress(
+                    request.draft_id, authorization,
+                )
+                progress_actions = progress.get("next_actions", [])
+                if (
+                    progress.get("status") == "approved"
+                    or not progress_actions
+                    or progress_actions[0] not in {"apply", "approve"}
+                ):
+                    return self._first_guide_step(progress)
+                if (
+                    progress_actions[0] == "approve"
+                    and not authorization.spotify_write
+                ):
+                    return self._first_guide_step(progress)
                 if not authorization.spotify_write:
                     return {
                         "contract_version": AGENT_CONTRACT_VERSION,
@@ -324,17 +375,8 @@ class AgentTransferContract:
                 applied = self.apply_qualification(
                     request.draft_id, authorization,
                 )
-                applied.pop("next_actions", None)
-                applied.update({
-                    "phase": "first_rekordbox_transfer",
-                    "next_action": "approve",
-                    "required_input": {
-                        "kind": "authority_confirmation",
-                        "authority": "playlist_approval",
-                    },
-                })
-                return applied
-            if request.action == "publish_and_link":
+                return self._first_guide_step(applied)
+            if action == FirstTransferAction.PUBLISH_AND_LINK:
                 if request.draft_id is None:
                     raise ValueError(
                         "Publication requires a Qualification Draft identity"
@@ -342,17 +384,9 @@ class AgentTransferContract:
                 progress = self.qualification_progress(
                     request.draft_id, authorization,
                 )
-                progress_actions = progress["next_actions"]
-                if progress_actions[0] == "apply":
-                    progress.pop("next_actions")
-                    progress.update({
-                        "phase": "first_rekordbox_transfer",
-                        "next_action": "apply",
-                        "required_input": {
-                            "kind": "action_confirmation", "action": "apply",
-                        },
-                    })
-                    return progress
+                progress_actions = progress.get("next_actions", [])
+                if not progress_actions or progress_actions[0] != "publish_and_link":
+                    return self._first_guide_step(progress)
                 if not authorization.spotify_write:
                     return {
                         "contract_version": AGENT_CONTRACT_VERSION,
@@ -371,29 +405,19 @@ class AgentTransferContract:
                 published = self.execute_batch(
                     publishing_request, authorization,
                 )
+                if published.get("status") != "completed":
+                    return self._first_guide_step(published)
                 linked = self.link_qualification(
                     request.draft_id, published["transfer_id"], authorization,
                 )
-                linked.pop("next_actions", None)
-                linked.update({
-                    "phase": "first_rekordbox_transfer",
-                    "next_action": "apply",
-                    "required_input": {
-                        "kind": "action_confirmation", "action": "apply",
-                    },
-                })
-                return linked
-            if request.draft_id is not None and request.action is None:
+                return self._first_guide_step(linked)
+            if request.draft_id is not None and action is None:
                 qualification = self.qualification_progress(
                     request.draft_id, authorization,
                 )
-                next_actions = qualification.pop("next_actions")
+                next_actions = qualification.get("next_actions", [])
                 if not next_actions:
-                    qualification.update({
-                        "phase": "first_rekordbox_transfer",
-                        "next_action": None,
-                    })
-                    return qualification
+                    return self._first_guide_step(qualification)
                 primary_action = next_actions[0]
                 if (
                     primary_action in {"publish_and_link", "apply"}
@@ -408,29 +432,11 @@ class AgentTransferContract:
                         "next_action": "authorize_spotify_write",
                         "required_authorization": "spotify_write",
                     }
-                qualification.update({
-                    "phase": "first_rekordbox_transfer",
-                    "next_action": primary_action,
-                    "required_input": {
-                        "kind": "action_confirmation",
-                        "action": primary_action,
-                    },
-                })
-                return qualification
-            if request.transfer_id is not None and request.action is None:
+                return self._first_guide_step(qualification)
+            if request.transfer_id is not None and action is None:
                 progress = self.progress(request.transfer_id, authorization)
-                next_actions = progress.pop("next_actions", None) or []
-                next_action = next_actions[0] if next_actions else None
-                progress.update({
-                    "phase": "first_rekordbox_transfer",
-                    "next_action": next_action,
-                })
-                if next_action is not None:
-                    progress["required_input"] = {
-                        "kind": "action_confirmation", "action": next_action,
-                    }
-                return progress
-            if request.action == "qualify":
+                return self._first_guide_step(progress)
+            if action == FirstTransferAction.QUALIFY:
                 if request.transfer_id is None:
                     raise ValueError("Qualification requires a Transfer identity")
                 qualification = self.qualification_draft(
@@ -441,28 +447,12 @@ class AgentTransferContract:
                     ),
                     authorization,
                 )
-                next_actions = qualification.pop("next_actions")
-                qualification.update({
-                    "phase": "first_rekordbox_transfer",
-                    "next_action": next_actions[0],
-                    "required_input": {
-                        "kind": "local_qualification_review",
-                        "review_url": qualification["review_url"],
-                    },
-                })
-                return qualification
-            if request.action == "preview":
+                return self._first_guide_step(qualification)
+            if action == FirstTransferAction.PREVIEW:
                 outcome = self.execute_batch(batch_request, authorization)
-                next_actions = outcome.pop("next_actions", None) or ["qualify"]
-                next_action = next_actions[0]
-                outcome.update({
-                    "phase": "first_rekordbox_transfer",
-                    "next_action": next_action,
-                    "required_input": {
-                        "kind": "action_confirmation", "action": next_action,
-                    },
-                })
-                return outcome
+                return self._first_guide_step(
+                    outcome, default_action="qualify",
+                )
             plan_document = self.plan_batch(batch_request, authorization)
             plan_document.pop("next_actions", None)
             plan_document.update({
@@ -480,6 +470,35 @@ class AgentTransferContract:
             "next_action": next_action,
             "required_input": required_input,
         }
+
+    @staticmethod
+    def _first_guide_step(
+        document: dict, *, default_action: str | None = None,
+    ) -> dict:
+        """Render one truthful primary action from an existing policy result."""
+        actions = document.pop("next_actions", None) or []
+        next_action = actions[0] if actions else default_action
+        document.update({
+            "phase": "first_rekordbox_transfer",
+            "next_action": next_action,
+        })
+        if next_action is None:
+            document.pop("required_input", None)
+        elif next_action == "review" and document.get("review_url"):
+            document["required_input"] = {
+                "kind": "local_qualification_review",
+                "review_url": document["review_url"],
+            }
+        elif next_action == "approve":
+            document["required_input"] = {
+                "kind": "authority_confirmation",
+                "authority": "playlist_approval",
+            }
+        else:
+            document["required_input"] = {
+                "kind": "action_confirmation", "action": next_action,
+            }
+        return document
 
     def plan_batch(
         self, request: BatchPlanRequest, authorization: AgentAuthorization,

--- a/djsupport/agent.py
+++ b/djsupport/agent.py
@@ -330,9 +330,7 @@ class AgentTransferContract:
                     "phase": "first_rekordbox_transfer",
                     "effects": {
                         "spotify_writes_during_approval": 0,
-                        "spotify_playlist_items": (
-                            counts["approved"] + counts["corrections"]
-                        ),
+                        "spotify_playlist_items": counts["approved"],
                     },
                     "retained": {
                         "approved_matches": counts["approved"],
@@ -919,10 +917,10 @@ class AgentTransferContract:
             "status": outcome.status.value.replace(" ", "_"),
             "draft_id": draft_id,
             "counts": {
-                "approved": len(outcome.approved),
-                "rejected": len(outcome.rejected),
-                "collisions": len(outcome.collisions),
-                "corrections": len(outcome.corrections),
+                "approved": outcome.approved_count,
+                "rejected": outcome.rejected_count,
+                "collisions": outcome.collision_count,
+                "corrections": outcome.correction_count,
             },
             "authority": (
                 "playlist_approval"

--- a/djsupport/backup.py
+++ b/djsupport/backup.py
@@ -22,8 +22,8 @@ BACKUP_VERSION = 1
 SUPPORTED_SCHEMAS = {
     CONFIG_FILENAME: (CONFIG_VERSION,),
     "matching-knowledge.json": (1, 2, 3),
-    "transfers.json": (1, 2, 3, 4),
-    "publication-manifests.transfers.json": (1, 2, 3, 4),
+    "transfers.json": (1, 2, 3, 4, 5),
+    "publication-manifests.transfers.json": (1, 2, 3, 4, 5),
     "publication-manifests.json": (1, 2, 3, 4, 5, 6),
     "playlist-state.json": (1, 2),
     "legacy-migration.json": (1,),

--- a/djsupport/cli.py
+++ b/djsupport/cli.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import os
 from pathlib import Path
 from uuid import uuid4
 
@@ -58,6 +59,210 @@ def capabilities(as_json: bool) -> None:
     else:
         click.echo("Local audio identity unavailable; install fpcalc to enable it.")
     click.echo("Local audition available for explicitly authorized Rekordbox audio.")
+
+
+FIRST_TRANSFER_CALLBACK = "http://127.0.0.1:8888/callback"
+
+
+def _first_transfer_readiness(
+    explicit_xml_path: str | None,
+) -> tuple[bool, bool, bool, bool, str | None]:
+    """Inspect only local setup state; never call Spotify or parse the XML."""
+    spotify_configured = (
+        "SPOTIPY_CLIENT_ID" in os.environ
+        and "SPOTIPY_CLIENT_SECRET" in os.environ
+        and os.environ.get("SPOTIPY_REDIRECT_URI") == FIRST_TRANSFER_CALLBACK
+    )
+    spotify_authenticated = False
+    if spotify_configured:
+        try:
+            from spotipy.oauth2 import SpotifyOAuth
+            from djsupport.spotify import SCOPES
+
+            manager = SpotifyOAuth(scope=SCOPES, open_browser=False)
+            token = manager.get_cached_token()
+            spotify_authenticated = bool(
+                token and not manager.is_token_expired(token)
+            )
+        except Exception:
+            spotify_authenticated = False
+
+    selected_path = explicit_xml_path
+    if selected_path is None:
+        config = ConfigManager()
+        config.load()
+        selected_path = config.get_rekordbox_xml_path()
+    configured = selected_path is not None
+    available = False
+    if selected_path is not None:
+        try:
+            path = Path(selected_path).expanduser()
+            available = path.exists() and path.is_file()
+            selected_path = str(path)
+        except OSError:
+            available = False
+    return (
+        spotify_configured,
+        spotify_authenticated,
+        configured,
+        available,
+        selected_path,
+    )
+
+
+def _first_transfer_contract(
+    *,
+    xml_path: str | None,
+    activate: bool,
+    spotify_access: bool,
+    local_audio_identity: bool | None,
+    cache_path: str,
+    state_path: str,
+):
+    """Build the public contract only as deeply as the current phase needs."""
+    from djsupport.agent import AgentTransferContract
+    from djsupport.cache import MatchCache
+    from djsupport.local_audio import ChromaprintLocalAudio
+    from djsupport.transfer import (
+        EphemeralMatchingKnowledge,
+        FilePublicationStorage,
+        FileTransferStorage,
+        MatchCacheKnowledge,
+        RekordboxPlaylistSource,
+        SpotifyMatcher,
+        Transfer,
+    )
+
+    local_audio = ChromaprintLocalAudio()
+    if not activate:
+        return AgentTransferContract(Transfer(
+            source=object(),
+            spotify=object(),
+            matching_knowledge=EphemeralMatchingKnowledge(),
+            publishing_guards=AccountPublishingGuards(),
+            local_audio=local_audio,
+        ))
+
+    if xml_path is None:
+        raise ValueError("Rekordbox XML is unavailable")
+    cache = MatchCache(cache_path)
+    cache.load()
+    publication_path = Path(state_path)
+    return AgentTransferContract(Transfer(
+        source=RekordboxPlaylistSource(
+            xml_path, include_locations=bool(local_audio_identity),
+        ),
+        spotify=(SpotifyMatcher(get_client()) if spotify_access else object()),
+        matching_knowledge=MatchCacheKnowledge(cache),
+        publishing_guards=AccountPublishingGuards(),
+        publication_storage=FilePublicationStorage(publication_path),
+        transfer_storage=FileTransferStorage(
+            publication_path.with_suffix(".transfers.json")
+        ),
+        local_audio=(local_audio if local_audio_identity else None),
+    ))
+
+
+@cli.command("first-transfer")
+@click.option("--xml-path", type=click.Path(), default=None)
+@click.option("--playlist", "playlist_reference", default=None)
+@click.option(
+    "--local-audio-identity/--no-local-audio-identity", default=None,
+)
+@click.option(
+    "--action",
+    type=click.Choice([
+        "preview", "qualify", "publish_and_link", "apply", "approve",
+        "resume", "abandon",
+    ]),
+    default=None,
+)
+@click.option("--transfer-id", default=None)
+@click.option("--draft-id", default=None)
+@click.option("--authorize-private-source", is_flag=True)
+@click.option("--authorize-spotify-write", is_flag=True)
+@click.option("--cache-path", default=DEFAULT_MATCHING_KNOWLEDGE_PATH)
+@click.option("--state-path", default=DEFAULT_PUBLICATION_MANIFEST_PATH)
+@click.option("--json", "as_json", is_flag=True)
+def first_transfer(
+    xml_path: str | None,
+    playlist_reference: str | None,
+    local_audio_identity: bool | None,
+    action: str | None,
+    transfer_id: str | None,
+    draft_id: str | None,
+    authorize_private_source: bool,
+    authorize_spotify_write: bool,
+    cache_path: str,
+    state_path: str,
+    as_json: bool,
+) -> None:
+    """Return the next safe step for one first Rekordbox Transfer."""
+    from djsupport.agent import FirstTransferGuideRequest
+    from djsupport.transfer import TransferAuthorization
+
+    readiness = _first_transfer_readiness(xml_path)
+    (
+        spotify_configured,
+        spotify_authenticated,
+        rekordbox_configured,
+        rekordbox_available,
+        selected_xml_path,
+    ) = readiness
+    if (
+        authorize_private_source
+        and rekordbox_available
+        and selected_xml_path is not None
+    ):
+        rekordbox_available, _ = validate_rekordbox_xml(selected_xml_path)
+    activate = bool(
+        spotify_configured
+        and spotify_authenticated
+        and rekordbox_configured
+        and rekordbox_available
+        and playlist_reference is not None
+        and local_audio_identity is not None
+        and authorize_private_source
+    )
+    spotify_access = action in {
+        "preview", "qualify", "publish_and_link", "apply", "approve", "resume",
+    }
+    try:
+        contract = _first_transfer_contract(
+            xml_path=selected_xml_path,
+            activate=activate,
+            spotify_access=spotify_access,
+            local_audio_identity=local_audio_identity,
+            cache_path=cache_path,
+            state_path=state_path,
+        )
+        document = contract.first_rekordbox_transfer(
+            FirstTransferGuideRequest(
+                spotify_configured=spotify_configured,
+                spotify_authenticated=spotify_authenticated,
+                rekordbox_configured=rekordbox_configured,
+                rekordbox_available=rekordbox_available,
+                playlist_reference=playlist_reference,
+                local_audio_identity=local_audio_identity,
+                action=action,
+                transfer_id=transfer_id,
+                draft_id=draft_id,
+            ),
+            TransferAuthorization(
+                private_source=authorize_private_source,
+                spotify_write=authorize_spotify_write,
+            ),
+        )
+    except (OSError, PermissionError, ValueError):
+        from djsupport.agent import error_document
+
+        document = error_document(
+            "first_rekordbox_transfer", "transfer_failed",
+        )
+    if as_json:
+        click.echo(json.dumps(document, sort_keys=True))
+        return
+    click.echo(f"Next: {document.get('next_action') or 'complete'}")
 
 
 def _resolve_xml_path(explicit_xml_path: str | None) -> str:

--- a/djsupport/cli.py
+++ b/djsupport/cli.py
@@ -3,14 +3,15 @@
 from __future__ import annotations
 
 import json
-import os
 from pathlib import Path
 from uuid import uuid4
 
 import click
+from spotipy.exceptions import SpotifyOauthError
 
 from dotenv import load_dotenv
 
+from djsupport.agent import FirstTransferAction
 from djsupport.config import ConfigManager, validate_rekordbox_xml
 from djsupport.rekordbox import parse_xml
 from djsupport.report import (
@@ -61,52 +62,19 @@ def capabilities(as_json: bool) -> None:
     click.echo("Local audition available for explicitly authorized Rekordbox audio.")
 
 
-FIRST_TRANSFER_CALLBACK = "http://127.0.0.1:8888/callback"
-
-
 def _first_transfer_readiness(
     explicit_xml_path: str | None,
 ) -> tuple[bool, bool, bool, bool, str | None]:
     """Inspect only local setup state; never call Spotify or parse the XML."""
-    spotify_configured = (
-        "SPOTIPY_CLIENT_ID" in os.environ
-        and "SPOTIPY_CLIENT_SECRET" in os.environ
-        and os.environ.get("SPOTIPY_REDIRECT_URI") == FIRST_TRANSFER_CALLBACK
-    )
-    spotify_authenticated = False
-    if spotify_configured:
-        try:
-            from spotipy.oauth2 import SpotifyOAuth
-            from djsupport.spotify import SCOPES
+    from djsupport.readiness import inspect_first_transfer_readiness
 
-            manager = SpotifyOAuth(scope=SCOPES, open_browser=False)
-            token = manager.get_cached_token()
-            spotify_authenticated = bool(
-                token and not manager.is_token_expired(token)
-            )
-        except Exception:
-            spotify_authenticated = False
-
-    selected_path = explicit_xml_path
-    if selected_path is None:
-        config = ConfigManager()
-        config.load()
-        selected_path = config.get_rekordbox_xml_path()
-    configured = selected_path is not None
-    available = False
-    if selected_path is not None:
-        try:
-            path = Path(selected_path).expanduser()
-            available = path.exists() and path.is_file()
-            selected_path = str(path)
-        except OSError:
-            available = False
+    readiness = inspect_first_transfer_readiness(explicit_xml_path)
     return (
-        spotify_configured,
-        spotify_authenticated,
-        configured,
-        available,
-        selected_path,
+        readiness.spotify_configured,
+        readiness.spotify_authenticated,
+        readiness.rekordbox_configured,
+        readiness.rekordbox_available,
+        readiness.xml_path,
     )
 
 
@@ -171,10 +139,7 @@ def _first_transfer_contract(
 )
 @click.option(
     "--action",
-    type=click.Choice([
-        "preview", "qualify", "publish_and_link", "apply", "approve",
-        "resume", "abandon",
-    ]),
+    type=click.Choice([action.value for action in FirstTransferAction]),
     default=None,
 )
 @click.option("--transfer-id", default=None)
@@ -209,12 +174,13 @@ def first_transfer(
         rekordbox_available,
         selected_xml_path,
     ) = readiness
-    if (
-        authorize_private_source
-        and rekordbox_available
-        and selected_xml_path is not None
-    ):
-        rekordbox_available, _ = validate_rekordbox_xml(selected_xml_path)
+    if authorize_private_source:
+        from djsupport.readiness import inspect_first_transfer_readiness
+
+        authorized_readiness = inspect_first_transfer_readiness(
+            selected_xml_path, authorize_private_source=True,
+        )
+        rekordbox_available = authorized_readiness.rekordbox_available
     activate = bool(
         spotify_configured
         and spotify_authenticated
@@ -224,9 +190,10 @@ def first_transfer(
         and local_audio_identity is not None
         and authorize_private_source
     )
-    spotify_access = action in {
-        "preview", "qualify", "publish_and_link", "apply", "approve", "resume",
-    }
+    action_kind = FirstTransferAction(action) if action is not None else None
+    spotify_access = bool(
+        action_kind is not None and action_kind.needs_spotify_access
+    )
     try:
         contract = _first_transfer_contract(
             xml_path=selected_xml_path,
@@ -244,7 +211,7 @@ def first_transfer(
                 rekordbox_available=rekordbox_available,
                 playlist_reference=playlist_reference,
                 local_audio_identity=local_audio_identity,
-                action=action,
+                action=action_kind,
                 transfer_id=transfer_id,
                 draft_id=draft_id,
             ),
@@ -252,6 +219,12 @@ def first_transfer(
                 private_source=authorize_private_source,
                 spotify_write=authorize_spotify_write,
             ),
+        )
+    except SpotifyOauthError:
+        from djsupport.agent import error_document
+
+        document = error_document(
+            "first_rekordbox_transfer", "spotify_authentication_required",
         )
     except (OSError, PermissionError, ValueError):
         from djsupport.agent import error_document

--- a/djsupport/readiness.py
+++ b/djsupport/readiness.py
@@ -1,0 +1,63 @@
+"""Side-effect-free local setup facts for the first Transfer guide."""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from pathlib import Path
+
+from djsupport.config import ConfigManager, validate_rekordbox_xml
+
+
+FIRST_TRANSFER_CALLBACK = "http://127.0.0.1:8888/callback"
+
+
+@dataclass(frozen=True)
+class FirstTransferReadiness:
+    spotify_configured: bool
+    spotify_authenticated: bool
+    rekordbox_configured: bool
+    rekordbox_available: bool
+    xml_path: str | None = None
+
+
+def inspect_first_transfer_readiness(
+    explicit_xml_path: str | None = None,
+    *,
+    authorize_private_source: bool = False,
+) -> FirstTransferReadiness:
+    """Inspect names and file presence without reading credentials or tokens."""
+    spotify_configured = (
+        "SPOTIPY_CLIENT_ID" in os.environ
+        and "SPOTIPY_CLIENT_SECRET" in os.environ
+        and os.environ.get("SPOTIPY_REDIRECT_URI") == FIRST_TRANSFER_CALLBACK
+    )
+    cache_name = ".cache"
+    spotify_username = os.environ.get("SPOTIPY_CLIENT_USERNAME")
+    if spotify_username:
+        cache_name = f"{cache_name}-{spotify_username}"
+    spotify_authenticated = spotify_configured and Path(cache_name).is_file()
+
+    selected_path = explicit_xml_path
+    if selected_path is None:
+        config = ConfigManager()
+        config.load()
+        selected_path = config.get_rekordbox_xml_path()
+    configured = selected_path is not None
+    available = False
+    if selected_path is not None:
+        try:
+            path = Path(selected_path).expanduser()
+            available = path.exists() and path.is_file()
+            selected_path = str(path)
+        except OSError:
+            available = False
+    if authorize_private_source and available and selected_path is not None:
+        available, _ = validate_rekordbox_xml(selected_path)
+    return FirstTransferReadiness(
+        spotify_configured=spotify_configured,
+        spotify_authenticated=spotify_authenticated,
+        rekordbox_configured=configured,
+        rekordbox_available=available,
+        xml_path=selected_path,
+    )

--- a/djsupport/transfer.py
+++ b/djsupport/transfer.py
@@ -827,6 +827,19 @@ class ApprovalOutcome:
 
 
 @dataclass(frozen=True)
+class QualificationApprovalOutcome:
+    """Privacy-minimal, replayable summary of Qualification Approval."""
+
+    reviewed_at: datetime
+    status: ApprovalStatus
+    approved_count: int
+    rejected_count: int
+    collision_count: int
+    correction_count: int
+    conflict_count: int
+
+
+@dataclass(frozen=True)
 class ApprovalConflict:
     source_artist: str
     source_title: str
@@ -3891,7 +3904,7 @@ class Transfer:
         self,
         draft_id: str,
         authorization: TransferAuthorization,
-    ) -> ApprovalOutcome:
+    ) -> QualificationApprovalOutcome:
         """Approve an applied draft as a distinct playlist-scoped operation."""
         required = self.private_source_authorization_requirement(authorization)
         if required:
@@ -3917,9 +3930,10 @@ class Transfer:
         draft.status = QualificationStatus.APPROVING
         draft.updated_at = datetime.now().isoformat()
         self._transfer_storage.save_qualification(draft_id, draft)
-        outcome = self._approve(
+        approval = self._approve(
             None, qualification_draft_id=draft_id,
         )
+        outcome = self._qualification_approval_outcome(approval)
         draft = self._transfer_storage.load_qualification(draft_id)
         if draft is None:
             raise ValueError(f"Unknown Qualification Draft: {draft_id}")
@@ -4243,36 +4257,34 @@ class Transfer:
         })
 
     @staticmethod
-    def _stored_approval(outcome: ApprovalOutcome) -> dict:
-        stored = asdict(outcome)
-        stored["reviewed_at"] = outcome.reviewed_at.isoformat()
-        stored["status"] = outcome.status.value
-        return stored
+    def _stored_approval(outcome: QualificationApprovalOutcome) -> dict:
+        return {
+            **asdict(outcome),
+            "reviewed_at": outcome.reviewed_at.isoformat(),
+            "status": outcome.status.value,
+        }
 
     @staticmethod
-    def _approval_from_stored(stored: dict) -> ApprovalOutcome:
-        return ApprovalOutcome(**{
+    def _approval_from_stored(stored: dict) -> QualificationApprovalOutcome:
+        return QualificationApprovalOutcome(**{
             **stored,
             "reviewed_at": datetime.fromisoformat(stored["reviewed_at"]),
             "status": ApprovalStatus(stored["status"]),
-            "approved": tuple(
-                PublicationItem(**item) for item in stored.get("approved", ())
-            ),
-            "rejected": tuple(
-                PublicationItem(**item) for item in stored.get("rejected", ())
-            ),
-            "collisions": tuple(
-                PublicationItem(**item)
-                for item in stored.get("collisions", ())
-            ),
-            "corrections": tuple(
-                PublicationItem(**item)
-                for item in stored.get("corrections", ())
-            ),
-            "conflicts": tuple(
-                ApprovalConflict(**item) for item in stored.get("conflicts", ())
-            ),
         })
+
+    @staticmethod
+    def _qualification_approval_outcome(
+        outcome: ApprovalOutcome,
+    ) -> QualificationApprovalOutcome:
+        return QualificationApprovalOutcome(
+            reviewed_at=outcome.reviewed_at,
+            status=outcome.status,
+            approved_count=len(outcome.approved),
+            rejected_count=len(outcome.rejected),
+            collision_count=len(outcome.collisions),
+            correction_count=len(outcome.corrections),
+            conflict_count=len(outcome.conflicts),
+        )
 
     @classmethod
     def _publication_digest(cls, manifest: PublicationManifest) -> str:
@@ -4892,15 +4904,6 @@ class Transfer:
                         spotify_playlist_name=manifest.spotify_playlist_name,
                         approved_at=outcome.reviewed_at,
                     ))
-                if (
-                    outcome.status == ApprovalStatus.APPROVED
-                    and hasattr(self._spotify, "set_playlist_description")
-                ):
-                    self._retry_policy.run(
-                        lambda: self._spotify.set_playlist_description(
-                            playlist_id, self._approved_description(manifest),
-                        )
-                    )
             self._publication_storage.retain_approval(outcome)
             if (
                 outcome.status == ApprovalStatus.ABANDONED
@@ -4920,19 +4923,6 @@ class Transfer:
                         qualification_draft.transfer_id
                     )
             return outcome
-
-    @staticmethod
-    def _approved_description(manifest: PublicationManifest) -> str:
-        relationship = (
-            "managed Mirror relationship" if manifest.mode == TransferMode.MIRROR
-            else "approved Snapshot provenance"
-        )
-        chart = manifest.chart_title or manifest.source_label
-        curator = f" by {manifest.curator}" if manifest.curator else ""
-        return (
-            f"{chart}{curator}; {relationship}. Source: "
-            f"{manifest.source_reference}"
-        )
 
     def _read_corrections(
         self, corrections: str | Path | None, manifest: PublicationManifest,

--- a/djsupport/transfer.py
+++ b/djsupport/transfer.py
@@ -60,7 +60,7 @@ from djsupport.spotify import (
 
 
 PUBLICATION_MANIFEST_VERSION = 6
-TRANSFER_STATE_VERSION = 4
+TRANSFER_STATE_VERSION = 5
 EXPENSIVE_BATCH_LOOKUP_THRESHOLD = 100
 SPOTIFY_TRACK_URI = re.compile(r"^spotify:track:([A-Za-z0-9]{22})$")
 SPOTIFY_TRACK_URL = re.compile(
@@ -362,6 +362,7 @@ class QualificationStatus(str, Enum):
     APPLYING = "applying"
     PAUSED = "paused"
     APPLIED = "applied"
+    APPROVED = "approved"
     REVIEW_REQUIRED = "review_required"
     DISCARDED = "discarded"
 
@@ -398,6 +399,7 @@ class QualificationDraftState:
     completed_chunks: list[str] = field(default_factory=list)
     applied_manifest: dict | None = None
     applied_uris: list[str] = field(default_factory=list)
+    approval_outcome: dict | None = None
     audition_statuses: dict[str, dict] = field(default_factory=dict)
     audition_selection_digest: str | None = None
     supersedes: str | None = None
@@ -412,6 +414,7 @@ class QualificationDraftState:
             "completed_chunks": [],
             "applied_manifest": None,
             "applied_uris": [],
+            "approval_outcome": None,
             "audition_statuses": {},
             "audition_selection_digest": None,
             "supersedes": None,
@@ -489,6 +492,8 @@ class QualificationView:
     @property
     def next_actions(self) -> tuple[str, ...]:
         """Return policy-owned lifecycle actions for thin clients."""
+        if self.status == QualificationStatus.APPROVED:
+            return ()
         if self.status == QualificationStatus.APPLIED:
             return ("approve",)
         if self.status == QualificationStatus.DISCARDED:
@@ -512,6 +517,7 @@ class QualificationView:
             QualificationStatus.APPLYING,
             QualificationStatus.PAUSED,
             QualificationStatus.APPLIED,
+            QualificationStatus.APPROVED,
             QualificationStatus.DISCARDED,
         }:
             return None
@@ -1181,7 +1187,7 @@ class FileTransferStorage:
                 "Transfer state is malformed; repair or restore it before use"
             ) from exc
         if not isinstance(data, dict) or data.get("version") not in (
-            1, 2, 3, TRANSFER_STATE_VERSION,
+            1, 2, 3, 4, TRANSFER_STATE_VERSION,
         ):
             raise ValueError(
                 "Transfer state schema is unsupported; upgrade djsupport "
@@ -2762,6 +2768,7 @@ class Transfer:
                     QualificationStatus.APPLYING,
                     QualificationStatus.PAUSED,
                     QualificationStatus.APPLIED,
+                    QualificationStatus.APPROVED,
                     QualificationStatus.DISCARDED,
                 }
             ):
@@ -2786,6 +2793,7 @@ class Transfer:
                 QualificationStatus.APPLYING,
                 QualificationStatus.PAUSED,
                 QualificationStatus.APPLIED,
+                QualificationStatus.APPROVED,
                 QualificationStatus.DISCARDED,
             }:
                 return self._qualification_view(draft, state)
@@ -2865,6 +2873,7 @@ class Transfer:
                 QualificationStatus.APPLYING,
                 QualificationStatus.PAUSED,
                 QualificationStatus.APPLIED,
+                QualificationStatus.APPROVED,
                 QualificationStatus.DISCARDED,
             }:
                 raise ValueError(
@@ -2984,6 +2993,7 @@ class Transfer:
                 if candidate.draft_id != draft_id
                 and candidate.status not in {
                     QualificationStatus.APPLIED,
+                    QualificationStatus.APPROVED,
                     QualificationStatus.DISCARDED,
                 }
             ]
@@ -3336,6 +3346,7 @@ class Transfer:
                     QualificationStatus.APPLYING,
                     QualificationStatus.PAUSED,
                     QualificationStatus.APPLIED,
+                    QualificationStatus.APPROVED,
                     QualificationStatus.DISCARDED,
                 }
                 or (
@@ -3523,6 +3534,7 @@ class Transfer:
             QualificationStatus.APPLYING,
             QualificationStatus.PAUSED,
             QualificationStatus.APPLIED,
+            QualificationStatus.APPROVED,
             QualificationStatus.DISCARDED,
         } or (
             draft.status == QualificationStatus.REVIEW_REQUIRED
@@ -3713,6 +3725,7 @@ class Transfer:
             QualificationStatus.APPLYING,
             QualificationStatus.PAUSED,
             QualificationStatus.APPLIED,
+            QualificationStatus.APPROVED,
         }:
             raise ValueError(
                 "A Qualification Draft cannot be discarded after application starts"
@@ -3874,9 +3887,26 @@ class Transfer:
             raise PermissionError(required)
         if self._transfer_storage is None:
             raise ValueError("Qualification requires durable Transfer storage")
-        return self._approve(
+        draft = self._transfer_storage.load_qualification(draft_id)
+        if draft is None:
+            raise ValueError(f"Unknown Qualification Draft: {draft_id}")
+        if (
+            draft.status == QualificationStatus.APPROVED
+            and draft.approval_outcome is not None
+        ):
+            return self._approval_from_stored(draft.approval_outcome)
+        outcome = self._approve(
             None, qualification_draft_id=draft_id,
         )
+        if outcome.status == ApprovalStatus.APPROVED:
+            draft = self._transfer_storage.load_qualification(draft_id)
+            if draft is None:
+                raise ValueError(f"Unknown Qualification Draft: {draft_id}")
+            draft.status = QualificationStatus.APPROVED
+            draft.approval_outcome = self._stored_approval(outcome)
+            draft.updated_at = datetime.now().isoformat()
+            self._transfer_storage.save_qualification(draft_id, draft)
+        return outcome
 
     def apply_qualification(
         self,
@@ -3909,12 +3939,19 @@ class Transfer:
                 )
             if draft.status == QualificationStatus.DISCARDED:
                 raise ValueError("A discarded Qualification Draft cannot be applied")
-            if draft.status == QualificationStatus.APPLIED:
+            if draft.status in {
+                QualificationStatus.APPLIED,
+                QualificationStatus.APPROVED,
+            }:
                 assert draft.playlist_id is not None
+                next_actions = (
+                    ("approve",)
+                    if draft.status == QualificationStatus.APPLIED else ()
+                )
                 return QualificationApplyOutcome(
-                    draft_id, draft.playlist_id, QualificationStatus.APPLIED,
+                    draft_id, draft.playlist_id, draft.status,
                     len((draft.applied_manifest or {}).get("managed_items", ())),
-                    ("approve",),
+                    next_actions,
                 )
             if draft.playlist_id is None:
                 raise SpotifyPlaylistReviewRequired(
@@ -4167,6 +4204,38 @@ class Transfer:
             "managed_items": tuple(
                 PublicationItem(**item)
                 for item in stored.get("managed_items", stored.get("items", ()))
+            ),
+        })
+
+    @staticmethod
+    def _stored_approval(outcome: ApprovalOutcome) -> dict:
+        stored = asdict(outcome)
+        stored["reviewed_at"] = outcome.reviewed_at.isoformat()
+        stored["status"] = outcome.status.value
+        return stored
+
+    @staticmethod
+    def _approval_from_stored(stored: dict) -> ApprovalOutcome:
+        return ApprovalOutcome(**{
+            **stored,
+            "reviewed_at": datetime.fromisoformat(stored["reviewed_at"]),
+            "status": ApprovalStatus(stored["status"]),
+            "approved": tuple(
+                PublicationItem(**item) for item in stored.get("approved", ())
+            ),
+            "rejected": tuple(
+                PublicationItem(**item) for item in stored.get("rejected", ())
+            ),
+            "collisions": tuple(
+                PublicationItem(**item)
+                for item in stored.get("collisions", ())
+            ),
+            "corrections": tuple(
+                PublicationItem(**item)
+                for item in stored.get("corrections", ())
+            ),
+            "conflicts": tuple(
+                ApprovalConflict(**item) for item in stored.get("conflicts", ())
             ),
         })
 

--- a/djsupport/transfer.py
+++ b/djsupport/transfer.py
@@ -362,6 +362,7 @@ class QualificationStatus(str, Enum):
     APPLYING = "applying"
     PAUSED = "paused"
     APPLIED = "applied"
+    APPROVING = "approving"
     APPROVED = "approved"
     REVIEW_REQUIRED = "review_required"
     DISCARDED = "discarded"
@@ -494,6 +495,8 @@ class QualificationView:
         """Return policy-owned lifecycle actions for thin clients."""
         if self.status == QualificationStatus.APPROVED:
             return ()
+        if self.status == QualificationStatus.APPROVING:
+            return ("review",)
         if self.status == QualificationStatus.APPLIED:
             return ("approve",)
         if self.status == QualificationStatus.DISCARDED:
@@ -517,6 +520,7 @@ class QualificationView:
             QualificationStatus.APPLYING,
             QualificationStatus.PAUSED,
             QualificationStatus.APPLIED,
+            QualificationStatus.APPROVING,
             QualificationStatus.APPROVED,
             QualificationStatus.DISCARDED,
         }:
@@ -2768,6 +2772,7 @@ class Transfer:
                     QualificationStatus.APPLYING,
                     QualificationStatus.PAUSED,
                     QualificationStatus.APPLIED,
+                    QualificationStatus.APPROVING,
                     QualificationStatus.APPROVED,
                     QualificationStatus.DISCARDED,
                 }
@@ -2793,6 +2798,7 @@ class Transfer:
                 QualificationStatus.APPLYING,
                 QualificationStatus.PAUSED,
                 QualificationStatus.APPLIED,
+                QualificationStatus.APPROVING,
                 QualificationStatus.APPROVED,
                 QualificationStatus.DISCARDED,
             }:
@@ -2873,6 +2879,7 @@ class Transfer:
                 QualificationStatus.APPLYING,
                 QualificationStatus.PAUSED,
                 QualificationStatus.APPLIED,
+                QualificationStatus.APPROVING,
                 QualificationStatus.APPROVED,
                 QualificationStatus.DISCARDED,
             }:
@@ -2993,6 +3000,7 @@ class Transfer:
                 if candidate.draft_id != draft_id
                 and candidate.status not in {
                     QualificationStatus.APPLIED,
+                    QualificationStatus.APPROVING,
                     QualificationStatus.APPROVED,
                     QualificationStatus.DISCARDED,
                 }
@@ -3346,6 +3354,7 @@ class Transfer:
                     QualificationStatus.APPLYING,
                     QualificationStatus.PAUSED,
                     QualificationStatus.APPLIED,
+                    QualificationStatus.APPROVING,
                     QualificationStatus.APPROVED,
                     QualificationStatus.DISCARDED,
                 }
@@ -3534,6 +3543,7 @@ class Transfer:
             QualificationStatus.APPLYING,
             QualificationStatus.PAUSED,
             QualificationStatus.APPLIED,
+            QualificationStatus.APPROVING,
             QualificationStatus.APPROVED,
             QualificationStatus.DISCARDED,
         } or (
@@ -3725,6 +3735,7 @@ class Transfer:
             QualificationStatus.APPLYING,
             QualificationStatus.PAUSED,
             QualificationStatus.APPLIED,
+            QualificationStatus.APPROVING,
             QualificationStatus.APPROVED,
         }:
             raise ValueError(
@@ -3890,22 +3901,41 @@ class Transfer:
         draft = self._transfer_storage.load_qualification(draft_id)
         if draft is None:
             raise ValueError(f"Unknown Qualification Draft: {draft_id}")
-        if (
-            draft.status == QualificationStatus.APPROVED
-            and draft.approval_outcome is not None
-        ):
+        if draft.approval_outcome is not None:
             return self._approval_from_stored(draft.approval_outcome)
+        if draft.status == QualificationStatus.APPROVING:
+            raise SpotifyPlaylistReviewRequired(
+                "Qualification Approval was interrupted; review retained "
+                "authority before any retry",
+                draft_id=draft_id,
+            )
+        if draft.status != QualificationStatus.APPLIED:
+            raise SpotifyPlaylistReviewRequired(
+                "Qualification Draft must be applied before Approval",
+                draft_id=draft_id,
+            )
+        draft.status = QualificationStatus.APPROVING
+        draft.updated_at = datetime.now().isoformat()
+        self._transfer_storage.save_qualification(draft_id, draft)
         outcome = self._approve(
             None, qualification_draft_id=draft_id,
         )
-        if outcome.status == ApprovalStatus.APPROVED:
-            draft = self._transfer_storage.load_qualification(draft_id)
-            if draft is None:
-                raise ValueError(f"Unknown Qualification Draft: {draft_id}")
-            draft.status = QualificationStatus.APPROVED
-            draft.approval_outcome = self._stored_approval(outcome)
-            draft.updated_at = datetime.now().isoformat()
-            self._transfer_storage.save_qualification(draft_id, draft)
+        draft = self._transfer_storage.load_qualification(draft_id)
+        if draft is None:
+            raise ValueError(f"Unknown Qualification Draft: {draft_id}")
+        draft.status = (
+            QualificationStatus.APPROVED
+            if outcome.status == ApprovalStatus.APPROVED
+            else QualificationStatus.REVIEW_REQUIRED
+        )
+        draft.review_reason = (
+            None
+            if outcome.status == ApprovalStatus.APPROVED
+            else "approval_needs_review"
+        )
+        draft.approval_outcome = self._stored_approval(outcome)
+        draft.updated_at = datetime.now().isoformat()
+        self._transfer_storage.save_qualification(draft_id, draft)
         return outcome
 
     def apply_qualification(
@@ -3939,6 +3969,11 @@ class Transfer:
                 )
             if draft.status == QualificationStatus.DISCARDED:
                 raise ValueError("A discarded Qualification Draft cannot be applied")
+            if draft.status == QualificationStatus.APPROVING:
+                raise SpotifyPlaylistReviewRequired(
+                    "Qualification Approval was interrupted; review required",
+                    draft_id=draft_id,
+                )
             if draft.status in {
                 QualificationStatus.APPLIED,
                 QualificationStatus.APPROVED,
@@ -4480,7 +4515,10 @@ class Transfer:
                 if (
                     qualification_draft is None
                     or qualification_draft.status
-                    != QualificationStatus.APPLIED
+                    not in {
+                        QualificationStatus.APPLIED,
+                        QualificationStatus.APPROVING,
+                    }
                 ):
                     raise SpotifyPlaylistReviewRequired(
                         "Qualification Draft must be applied before Approval"
@@ -4514,11 +4552,17 @@ class Transfer:
                 )
                 applied_drafts = [
                     draft for draft in playlist_drafts
-                    if draft.status == QualificationStatus.APPLIED
+                    if draft.status in {
+                        QualificationStatus.APPLIED,
+                        QualificationStatus.APPROVING,
+                    }
                 ]
                 unapplied = []
                 for draft in playlist_drafts:
-                    if draft.status == QualificationStatus.APPLIED:
+                    if draft.status in {
+                        QualificationStatus.APPLIED,
+                        QualificationStatus.APPROVING,
+                    }:
                         continue
                     if (
                         draft.status == QualificationStatus.DISCARDED
@@ -5434,6 +5478,13 @@ class Transfer:
                         lambda: self._spotify.match(track, request.threshold)
                     )
                     playlist.api_lookups += 1
+                    if result is not None and "alternatives" not in result:
+                        result = {
+                            **result,
+                            **self._availability_facts(
+                                result, source="spotify_or_retained_result",
+                            ),
+                        }
                     self._knowledge.retain(
                         track, request.threshold,
                         None if result and "alternatives" in result else result,

--- a/djsupport/web.py
+++ b/djsupport/web.py
@@ -24,8 +24,14 @@ from fastapi.responses import (
 from fastapi.staticfiles import StaticFiles
 from pydantic import BaseModel, Field
 from spotipy.oauth2 import SpotifyOAuth
+from spotipy.exceptions import SpotifyOauthError
 
 from djsupport.report import SyncReport
+from djsupport.agent import FirstTransferAction
+from djsupport.readiness import (
+    FirstTransferReadiness,
+    inspect_first_transfer_readiness,
+)
 from djsupport.spotify import SCOPES
 from djsupport.local_audition import (
     AuditionHandleUnavailable,
@@ -99,14 +105,10 @@ class RekordboxBatchRequest(BaseModel):
 class FirstRekordboxTransferRequest(BaseModel):
     """Explicit facts for one harness-neutral first Transfer step."""
 
-    spotify_configured: bool = False
-    spotify_authenticated: bool = False
-    rekordbox_configured: bool = False
-    rekordbox_available: bool = False
     xml_path: str | None = None
     playlist_reference: str | None = None
     local_audio_identity: bool | None = None
-    action: str | None = None
+    action: FirstTransferAction | None = None
     transfer_id: str | None = None
     draft_id: str | None = None
     authorize_private_source: bool = False
@@ -277,6 +279,9 @@ def create_app(
     auth_manager: Callable[[], SpotifyOAuth] | None = None,
     background_runner: Callable[[Callable, tuple], None] | None = None,
     local_audition: LocalSourceAudition | None = None,
+    first_transfer_readiness: Callable[
+        [str | None, bool], FirstTransferReadiness
+    ] | None = None,
 ) -> FastAPI:
     """Create the web adapter with replaceable external-boundary wiring."""
     web_app = FastAPI(title="djsupport", lifespan=lifespan)
@@ -293,6 +298,14 @@ def create_app(
         make_rekordbox_transfer = rekordbox_transfer_factory
     run_background = background_runner or _thread_runner
     qualification_contexts: dict[str, QualificationDraftRequest] = {}
+    if first_transfer_readiness is None:
+        def inspect_readiness(xml_path, authorize_private_source):
+            return inspect_first_transfer_readiness(
+                xml_path,
+                authorize_private_source=authorize_private_source,
+            )
+    else:
+        inspect_readiness = first_transfer_readiness
 
     @web_app.middleware("http")
     async def qualification_privacy(request: FastAPIRequest, call_next):
@@ -541,34 +554,34 @@ def create_app(
         )
         from djsupport.local_audio import ChromaprintLocalAudio
 
+        readiness = inspect_readiness(
+            request.xml_path, request.authorize_private_source,
+        )
+
         adapter_request = RekordboxBatchRequest(
-            xml_path=request.xml_path or "",
+            xml_path=readiness.xml_path or "",
             playlists=(
                 [request.playlist_reference]
                 if request.playlist_reference is not None else []
             ),
-            preview=request.action not in {
-                "publish_and_link", "apply", "approve",
-            },
+            preview=not bool(request.action and request.action.publishes),
             local_audio_identity=bool(request.local_audio_identity),
             authorize_private_source=request.authorize_private_source,
             authorize_spotify_write=request.authorize_spotify_write,
         )
         activate = bool(
-            request.spotify_configured
-            and request.spotify_authenticated
-            and request.rekordbox_configured
-            and request.rekordbox_available
+            readiness.spotify_configured
+            and readiness.spotify_authenticated
+            and readiness.rekordbox_configured
+            and readiness.rekordbox_available
             and request.playlist_reference is not None
             and request.local_audio_identity is not None
             and request.authorize_private_source
         )
         spotify_access = bool(
-            activate and request.spotify_authenticated
-            and request.action in {
-                "preview", "qualify", "publish_and_link", "apply", "approve",
-                "resume",
-            }
+            activate and readiness.spotify_authenticated
+            and request.action is not None
+            and request.action.needs_spotify_access
         )
         try:
             if uses_default_rekordbox_wiring and not activate:
@@ -586,10 +599,10 @@ def create_app(
             contract = AgentTransferContract(transfer)
             return contract.first_rekordbox_transfer(
                 FirstTransferGuideRequest(
-                    spotify_configured=request.spotify_configured,
-                    spotify_authenticated=request.spotify_authenticated,
-                    rekordbox_configured=request.rekordbox_configured,
-                    rekordbox_available=request.rekordbox_available,
+                    spotify_configured=readiness.spotify_configured,
+                    spotify_authenticated=readiness.spotify_authenticated,
+                    rekordbox_configured=readiness.rekordbox_configured,
+                    rekordbox_available=readiness.rekordbox_available,
                     playlist_reference=request.playlist_reference,
                     local_audio_identity=request.local_audio_identity,
                     action=request.action,
@@ -600,6 +613,11 @@ def create_app(
                     private_source=request.authorize_private_source,
                     spotify_write=request.authorize_spotify_write,
                 ),
+            )
+        except SpotifyOauthError:
+            return error_document(
+                "first_rekordbox_transfer",
+                "spotify_authentication_required",
             )
         except Exception:
             return error_document(

--- a/djsupport/web.py
+++ b/djsupport/web.py
@@ -1032,10 +1032,10 @@ def create_app(
                 if outcome.status.value == "approved" else "none"
             ),
             "counts": {
-                "approved": len(outcome.approved),
-                "rejected": len(outcome.rejected),
-                "collisions": len(outcome.collisions),
-                "corrections": len(outcome.corrections),
+                "approved": outcome.approved_count,
+                "rejected": outcome.rejected_count,
+                "collisions": outcome.collision_count,
+                "corrections": outcome.correction_count,
             },
             "next_actions": (
                 ["review"] if outcome.status.value == "needs review" else []

--- a/djsupport/web.py
+++ b/djsupport/web.py
@@ -96,6 +96,23 @@ class RekordboxBatchRequest(BaseModel):
     authorize_spotify_write: bool = False
 
 
+class FirstRekordboxTransferRequest(BaseModel):
+    """Explicit facts for one harness-neutral first Transfer step."""
+
+    spotify_configured: bool = False
+    spotify_authenticated: bool = False
+    rekordbox_configured: bool = False
+    rekordbox_available: bool = False
+    xml_path: str | None = None
+    playlist_reference: str | None = None
+    local_audio_identity: bool | None = None
+    action: str | None = None
+    transfer_id: str | None = None
+    draft_id: str | None = None
+    authorize_private_source: bool = False
+    authorize_spotify_write: bool = False
+
+
 class QualificationDraftRequest(BaseModel):
     """One explicit Rekordbox playlist selected for local qualification."""
 
@@ -513,6 +530,81 @@ def create_app(
     @web_app.post("/rekordbox/batches/execute")
     def execute_rekordbox_batch(request: RekordboxBatchRequest):
         return rekordbox_contract(request, execute=True)
+
+    @web_app.post("/rekordbox/first-transfer")
+    def first_rekordbox_transfer(request: FirstRekordboxTransferRequest):
+        """Render exactly one public guide step without adding policy."""
+        from djsupport.agent import (
+            AgentTransferContract,
+            FirstTransferGuideRequest,
+            error_document,
+        )
+        from djsupport.local_audio import ChromaprintLocalAudio
+
+        adapter_request = RekordboxBatchRequest(
+            xml_path=request.xml_path or "",
+            playlists=(
+                [request.playlist_reference]
+                if request.playlist_reference is not None else []
+            ),
+            preview=request.action not in {
+                "publish_and_link", "apply", "approve",
+            },
+            local_audio_identity=bool(request.local_audio_identity),
+            authorize_private_source=request.authorize_private_source,
+            authorize_spotify_write=request.authorize_spotify_write,
+        )
+        activate = bool(
+            request.spotify_configured
+            and request.spotify_authenticated
+            and request.rekordbox_configured
+            and request.rekordbox_available
+            and request.playlist_reference is not None
+            and request.local_audio_identity is not None
+            and request.authorize_private_source
+        )
+        spotify_access = bool(
+            activate and request.spotify_authenticated
+            and request.action in {
+                "preview", "qualify", "publish_and_link", "apply", "approve",
+                "resume",
+            }
+        )
+        try:
+            if uses_default_rekordbox_wiring and not activate:
+                transfer = Transfer(
+                    source=object(),
+                    spotify=object(),
+                    matching_knowledge=EphemeralMatchingKnowledge(),
+                    publishing_guards=AccountPublishingGuards(),
+                    local_audio=ChromaprintLocalAudio(),
+                )
+            else:
+                transfer = make_rekordbox_transfer(
+                    adapter_request, spotify_access,
+                )
+            contract = AgentTransferContract(transfer)
+            return contract.first_rekordbox_transfer(
+                FirstTransferGuideRequest(
+                    spotify_configured=request.spotify_configured,
+                    spotify_authenticated=request.spotify_authenticated,
+                    rekordbox_configured=request.rekordbox_configured,
+                    rekordbox_available=request.rekordbox_available,
+                    playlist_reference=request.playlist_reference,
+                    local_audio_identity=request.local_audio_identity,
+                    action=request.action,
+                    transfer_id=request.transfer_id,
+                    draft_id=request.draft_id,
+                ),
+                TransferAuthorization(
+                    private_source=request.authorize_private_source,
+                    spotify_write=request.authorize_spotify_write,
+                ),
+            )
+        except Exception:
+            return error_document(
+                "first_rekordbox_transfer", "transfer_failed",
+            )
 
     def recover_qualification_context(
         draft_id: str,

--- a/docs/adr/0002-make-transfer-agent-native.md
+++ b/docs/adr/0002-make-transfer-agent-native.md
@@ -56,9 +56,20 @@ successful structured state. JSON clients are non-interactive, stdout remains
 machine-readable, and `required_input` acts as runtime schema discovery for the
 next invocation.
 
+Readiness checks only configuration-key and local file presence. They do not
+open or validate Spotipy's token cache; expired, malformed, declined, or
+wrong-account authentication is reported when an explicitly requested Spotify
+phase verifies it. CLI and web derive these facts through the same local probe;
+callers cannot assert their own readiness booleans.
+
 The guide may order existing operations and translate their reason codes into
 plain language. It cannot estimate work outside Transfer, select a playlist,
 broaden a Batch, read private input, open authentication, write Spotify, apply a
 draft, or create Approval without the exact input and authorization owned by
 that phase. CLI and local web routes are equivalent thin renderings of the
 versioned agent document.
+
+Before applying matching authority, Transfer durably marks a Qualification
+Approval as in progress. If the process stops before its aggregate outcome is
+retained, later invocations require review instead of repeating uncertain
+authority writes. A completed outcome is retained and replayed idempotently.

--- a/docs/adr/0002-make-transfer-agent-native.md
+++ b/docs/adr/0002-make-transfer-agent-native.md
@@ -47,3 +47,18 @@ Approved Match; similar evidence remains non-authoritative.
 This decision does not require a proprietary harness, an MCP server, a hosted
 agent service, conversational authorization inference, or an agent-specific
 policy engine. Those may be evaluated later as adapters over the same contract.
+
+The First Rekordbox Transfer guide is an additive presentation over that same
+contract. It derives readiness from current local configuration and durable
+Transfer or Qualification state; it has no onboarding-state store. Every
+response contains one primary `next_action`, and ordinary missing input is a
+successful structured state. JSON clients are non-interactive, stdout remains
+machine-readable, and `required_input` acts as runtime schema discovery for the
+next invocation.
+
+The guide may order existing operations and translate their reason codes into
+plain language. It cannot estimate work outside Transfer, select a playlist,
+broaden a Batch, read private input, open authentication, write Spotify, apply a
+draft, or create Approval without the exact input and authorization owned by
+that phase. CLI and local web routes are equivalent thin renderings of the
+versioned agent document.

--- a/docs/adr/0002-make-transfer-agent-native.md
+++ b/docs/adr/0002-make-transfer-agent-native.md
@@ -73,3 +73,6 @@ Before applying matching authority, Transfer durably marks a Qualification
 Approval as in progress. If the process stops before its aggregate outcome is
 retained, later invocations require review instead of repeating uncertain
 authority writes. A completed outcome is retained and replayed idempotently.
+Approval itself is authority-only and does not mutate Spotify; playlist
+publication and Qualification application remain separately authorized Spotify
+write phases.

--- a/docs/backup-and-restore.md
+++ b/docs/backup-and-restore.md
@@ -8,8 +8,8 @@ and unrelated files are not included.
 Matching-knowledge schema 3 includes private local-audio observations,
 account-scoped Approved Match associations, and retained Spotify review facts.
 Publication schema 6 retains the corresponding review and availability facts.
-Transfer-state schema 4 includes the opt-in, completed evidence checkpoints,
-and private Qualification Drafts.
+Transfer-state schema 5 includes the opt-in, completed evidence checkpoints,
+private Qualification Drafts, and their aggregate retained Approval outcomes.
 Both are backed up and restored as private application data. Audition handles,
 audio, paths, filenames, and fingerprints are never part of a Qualification
 Draft. A differing copy of the same draft requires an explicit restore choice;

--- a/docs/storage.md
+++ b/docs/storage.md
@@ -34,7 +34,7 @@ versioned application-data schemas.
 | Configuration | `config.json` | `1` | [`ConfigManager`](../djsupport/config.py) | Selected Rekordbox XML path and update time; private reference, not source-read authority |
 | Matching knowledge | `matching-knowledge.json` | `3` | [`MatchCache`](../djsupport/cache.py) through `MatchingKnowledge` | Proposals, failures, Approved/Rejected Matches, Corrections, conflicts, private fingerprint observations and account-scoped associations |
 | Publication state | `publication-manifests.json` | `6` | [`FilePublicationStorage`](../djsupport/transfer.py) | Publication manifests, Approval outcomes, and Mirror relationships |
-| Transfer state | `publication-manifests.transfers.json` | `4` | [`FileTransferStorage`](../djsupport/transfer.py) | Transfers, Batches, checkpoints, and Qualification Drafts |
+| Transfer state | `publication-manifests.transfers.json` | `5` | [`FileTransferStorage`](../djsupport/transfer.py) | Transfers, Batches, checkpoints, Qualification Drafts, and retained aggregate Approval outcomes |
 | Backup manifest | `backup-manifest.json` | `1` | [`LocalDataBackup`](../djsupport/backup.py) | Archive member names, hashes, and schema versions; never credentials |
 
 The current values come from `CONFIG_VERSION`, `CACHE_VERSION`,
@@ -78,8 +78,8 @@ schema versions:
 | --- | --- |
 | `config.json` | `1` |
 | `matching-knowledge.json` | `1`, `2`, `3` |
-| `transfers.json` | `1`, `2`, `3`, `4` |
-| `publication-manifests.transfers.json` | `1`, `2`, `3`, `4` |
+| `transfers.json` | `1`, `2`, `3`, `4`, `5` |
+| `publication-manifests.transfers.json` | `1`, `2`, `3`, `4`, `5` |
 | `publication-manifests.json` | `1`, `2`, `3`, `4`, `5`, `6` |
 | `playlist-state.json` | `1`, `2` |
 | `legacy-migration.json` | `1` |

--- a/docs/upgrading.md
+++ b/docs/upgrading.md
@@ -77,6 +77,15 @@ explicit current/archive choice when the same draft differs, so neither state
 wins silently. Audition handles, audio bytes, paths, filenames, and fingerprints
 are not stored in a draft.
 
+## To the First Rekordbox Transfer guide release
+
+The next durable write upgrades Transfer state to schema 5. Schemas 1–4 remain
+readable. Schema 5 retains only the aggregate outcome of a completed
+playlist-scoped Approval so a repeated agent invocation can return the same
+result without applying matching authority twice. It does not add source paths,
+track metadata, playlist names, fingerprints, credentials, or a separate
+onboarding store.
+
 ## From 0.3.0
 
 DJ Support does not migrate working-directory data automatically. Keep the old

--- a/tests/test_agent_cli.py
+++ b/tests/test_agent_cli.py
@@ -1,10 +1,105 @@
 """Thin CLI mapping for the harness-neutral agent contract."""
 
 import json
+from unittest.mock import MagicMock
 
 from click.testing import CliRunner
 
 from djsupport.cli import cli
+
+
+def test_first_transfer_json_renders_one_input_required_action(monkeypatch):
+    transfer = MagicMock()
+    monkeypatch.setattr(
+        "djsupport.cli._first_transfer_readiness",
+        lambda xml_path: (False, False, False, False, None),
+    )
+    monkeypatch.setattr(
+        "djsupport.cli._first_transfer_contract",
+        lambda **kwargs: __import__(
+            "djsupport.agent", fromlist=["AgentTransferContract"]
+        ).AgentTransferContract(transfer),
+    )
+
+    result = CliRunner().invoke(cli, ["first-transfer", "--json"])
+
+    assert result.exit_code == 0, result.output
+    assert json.loads(result.output) == {
+        "contract_version": 2,
+        "phase": "first_rekordbox_transfer",
+        "status": "input_required",
+        "next_action": "configure_spotify",
+        "required_input": {
+            "kind": "spotify_configuration",
+            "redirect_uri": "http://127.0.0.1:8888/callback",
+            "callback_policy": "add_without_replacing_existing",
+        },
+    }
+    transfer.assert_not_called()
+
+
+def test_first_transfer_cli_maps_explicit_inputs_to_public_contract(monkeypatch):
+    contract = MagicMock()
+    contract.first_rekordbox_transfer.return_value = {
+        "contract_version": 2,
+        "phase": "first_rekordbox_transfer",
+        "status": "ready",
+        "next_action": "preview",
+        "required_input": {
+            "kind": "action_confirmation", "action": "preview",
+        },
+    }
+    monkeypatch.setattr(
+        "djsupport.cli._first_transfer_readiness",
+        lambda xml_path: (True, True, True, True, "/private/library.xml"),
+    )
+    monkeypatch.setattr(
+        "djsupport.cli._first_transfer_contract",
+        lambda **kwargs: contract,
+    )
+
+    result = CliRunner().invoke(cli, [
+        "first-transfer", "--playlist", "Private/Selection",
+        "--no-local-audio-identity", "--authorize-private-source", "--json",
+    ])
+
+    assert result.exit_code == 0, result.output
+    assert json.loads(result.output)["next_action"] == "preview"
+    request, authorization = contract.first_rekordbox_transfer.call_args.args
+    assert request.playlist_reference == "Private/Selection"
+    assert request.local_audio_identity is False
+    assert request.spotify_configured is True
+    assert request.spotify_authenticated is True
+    assert authorization.private_source is True
+    assert authorization.spotify_write is False
+
+
+def test_first_transfer_json_never_prompts_and_input_required_is_success(
+    monkeypatch,
+):
+    monkeypatch.setattr(
+        "djsupport.cli._first_transfer_readiness",
+        lambda xml_path: (True, True, True, True, "/private/library.xml"),
+    )
+    contract = MagicMock()
+    contract.first_rekordbox_transfer.return_value = {
+        "contract_version": 2,
+        "phase": "first_rekordbox_transfer",
+        "status": "decision_required",
+        "next_action": "choose_local_audio_identity",
+        "required_input": {"kind": "boolean", "default": False},
+    }
+    monkeypatch.setattr(
+        "djsupport.cli._first_transfer_contract", lambda **kwargs: contract,
+    )
+
+    result = CliRunner().invoke(cli, [
+        "first-transfer", "--playlist", "Private/Selection", "--json",
+    ], input="this must never be consumed\n")
+
+    assert result.exit_code == 0
+    assert "[y/N]" not in result.output
+    assert json.loads(result.output)["status"] == "decision_required"
 
 
 def test_capabilities_json_does_not_require_xml_or_spotify(monkeypatch):

--- a/tests/test_agent_cli.py
+++ b/tests/test_agent_cli.py
@@ -6,6 +6,44 @@ from unittest.mock import MagicMock
 from click.testing import CliRunner
 
 from djsupport.cli import cli
+from djsupport.readiness import inspect_first_transfer_readiness
+
+
+def test_first_transfer_readiness_does_not_open_or_validate_token_cache(
+    monkeypatch, tmp_path,
+):
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("SPOTIPY_CLIENT_ID", "synthetic-client")
+    monkeypatch.setenv("SPOTIPY_CLIENT_SECRET", "synthetic-secret")
+    monkeypatch.setenv(
+        "SPOTIPY_REDIRECT_URI", "http://127.0.0.1:8888/callback",
+    )
+    xml_path = tmp_path / "selected.xml"
+    xml_path.write_text("private content must remain unread")
+
+    readiness = inspect_first_transfer_readiness(str(xml_path))
+
+    assert readiness.spotify_configured is True
+    assert readiness.spotify_authenticated is False
+    assert readiness.rekordbox_available is True
+
+
+def test_first_transfer_readiness_only_checks_cache_presence(
+    monkeypatch, tmp_path,
+):
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("SPOTIPY_CLIENT_ID", "synthetic-client")
+    monkeypatch.setenv("SPOTIPY_CLIENT_SECRET", "synthetic-secret")
+    monkeypatch.setenv(
+        "SPOTIPY_REDIRECT_URI", "http://127.0.0.1:8888/callback",
+    )
+    (tmp_path / ".cache").write_text("not a token and never parsed")
+    xml_path = tmp_path / "selected.xml"
+    xml_path.write_text("private content must remain unread")
+
+    readiness = inspect_first_transfer_readiness(str(xml_path))
+
+    assert readiness.spotify_authenticated is True
 
 
 def test_first_transfer_json_renders_one_input_required_action(monkeypatch):

--- a/tests/test_agent_contract.py
+++ b/tests/test_agent_contract.py
@@ -6,6 +6,7 @@ from unittest.mock import MagicMock
 
 import pytest
 
+from djsupport.cache import MatchCache
 from djsupport.agent import (
     AgentAuthorization,
     AgentTransferContract,
@@ -20,9 +21,14 @@ from djsupport.transfer import (
     BatchPlanRequest,
     FilePublicationStorage,
     FileTransferStorage,
+    LocalAudioObservation,
+    MatchCacheKnowledge,
     QualificationDecision,
+    QualificationDraftState,
     QualificationRequest,
+    QualificationStatus,
     SourceSelection,
+    SpotifyPlaylistReviewRequired,
     Transfer,
 )
 
@@ -289,6 +295,21 @@ class AvailableLocalAudio:
         )
 
 
+class FixedGuideLocalAudio(AvailableLocalAudio):
+    def preflight(self, track):
+        del track
+        return "eligible"
+
+    def observe(self, track):
+        del track
+        return LocalAudioObservation.available(
+            fingerprint="synthetic-guide-fingerprint",
+            algorithm="chromaprint",
+            algorithm_version="1.6.1",
+            duration=180,
+        )
+
+
 class AvailableAudition:
     def capability(self):
         return LocalAuditionCapability(available=True)
@@ -354,6 +375,7 @@ class BoundedSource(UntouchedSource):
             genre="",
             date_added="",
             duration=180,
+            location="file:///synthetic/selected.wav",
         )])
 
     def consume(self, reference):
@@ -1162,6 +1184,10 @@ def test_first_transfer_approval_is_a_final_explicit_authority_step(tmp_path):
             "corrections": 0,
         },
         "authority": "playlist_approval",
+        "effects": {
+            "spotify_writes_during_approval": 0,
+            "spotify_playlist_items": 1,
+        },
         "retained": {
             "approved_matches": 1,
             "corrections": 0,
@@ -1170,6 +1196,144 @@ def test_first_transfer_approval_is_a_final_explicit_authority_step(tmp_path):
         "next_action": None,
     }
     assert len(knowledge.approved) == 1
+    writes = spotify.playlist_writes
+
+    terminal_publish = contract.first_rekordbox_transfer(
+        FirstTransferGuideRequest(
+            **base, action="publish_and_link", draft_id=draft["draft_id"],
+        ),
+        spotify_write,
+    )
+    terminal_apply = contract.first_rekordbox_transfer(
+        FirstTransferGuideRequest(
+            **base, action="apply", draft_id=draft["draft_id"],
+        ),
+        spotify_write,
+    )
+
+    assert terminal_publish["status"] == "approved"
+    assert terminal_publish["next_action"] is None
+    assert terminal_apply["status"] == "approved"
+    assert terminal_apply["next_action"] is None
+    assert spotify.playlist_writes == writes
+
+
+def test_interrupted_approval_never_repeats_matching_authority(tmp_path):
+    storage = FileTransferStorage(tmp_path / "transfers.json")
+    storage.save_qualification("opaque-draft", QualificationDraftState(
+        draft_id="opaque-draft",
+        transfer_id="opaque-transfer",
+        batch_id=None,
+        source_reference="Private/Selection",
+        account_id="spotify-account-one",
+        playlist_id="provisional-one",
+        playlist_head="head-1",
+        manifest_digest="opaque-manifest",
+        selection_digest="opaque-selection",
+        include_all=True,
+        item_ids=[],
+        decisions={},
+        status=QualificationStatus.APPROVING,
+        created_at="2026-08-10T00:00:00",
+        updated_at="2026-08-10T00:00:00",
+    ))
+    knowledge = FirstTransferKnowledge()
+    transfer = Transfer(
+        source=BoundedSource(),
+        spotify=FirstTransferSpotify(),
+        matching_knowledge=knowledge,
+        publishing_guards=AccountPublishingGuards(tmp_path / "locks"),
+        publication_storage=FilePublicationStorage(
+            tmp_path / "publications.json",
+        ),
+        transfer_storage=storage,
+    )
+
+    with pytest.raises(SpotifyPlaylistReviewRequired, match="interrupted"):
+        transfer.approve_qualification(
+            "opaque-draft", AgentAuthorization(private_source=True),
+        )
+
+    assert knowledge.approved == []
+
+
+def test_first_transfer_approved_fingerprint_reuses_after_metadata_change(
+    tmp_path,
+):
+    spotify = FirstTransferSpotify()
+    cache_path = tmp_path / "matching-knowledge.json"
+    source = BoundedSource()
+    local_audio = FixedGuideLocalAudio()
+    publication_path = tmp_path / "publications.json"
+    storage_path = tmp_path / "transfers.json"
+
+    def guide_contract():
+        cache = MatchCache(cache_path)
+        cache.load()
+        return AgentTransferContract(Transfer(
+            source=source,
+            spotify=spotify,
+            matching_knowledge=MatchCacheKnowledge(cache),
+            publishing_guards=AccountPublishingGuards(tmp_path / "locks"),
+            publication_storage=FilePublicationStorage(publication_path),
+            transfer_storage=FileTransferStorage(storage_path),
+            local_audio=local_audio,
+        ))
+
+    base = dict(
+        spotify_configured=True,
+        spotify_authenticated=True,
+        rekordbox_configured=True,
+        rekordbox_available=True,
+        playlist_reference="Private/Selection",
+        local_audio_identity=True,
+    )
+    private = AgentAuthorization(private_source=True)
+    write = AgentAuthorization(private_source=True, spotify_write=True)
+    contract = guide_contract()
+    preview = contract.first_rekordbox_transfer(
+        FirstTransferGuideRequest(**base, action="preview"), private,
+    )
+    draft = contract.first_rekordbox_transfer(
+        FirstTransferGuideRequest(
+            **base, action="qualify", transfer_id=preview["transfer_id"],
+        ),
+        private,
+    )
+    contract.record_qualification(
+        draft["draft_id"], draft["current_item"]["item_id"],
+        QualificationDecision.KEEP_PROPOSAL, private,
+    )
+    published = contract.first_rekordbox_transfer(
+        FirstTransferGuideRequest(
+            **base, action="publish_and_link", draft_id=draft["draft_id"],
+        ),
+        write,
+    )
+    assert published["next_action"] == "apply", published
+    applied = contract.first_rekordbox_transfer(
+        FirstTransferGuideRequest(
+            **base, action="apply", draft_id=draft["draft_id"],
+        ),
+        write,
+    )
+    assert applied["status"] == "applied", applied
+    approval = contract.first_rekordbox_transfer(
+        FirstTransferGuideRequest(
+            **base, action="approve", draft_id=draft["draft_id"],
+        ),
+        private,
+    )
+    assert approval["status"] == "approved", json.dumps(approval, sort_keys=True)
+
+    source.title = "Metadata Changed Completely"
+    later = guide_contract().first_rekordbox_transfer(
+        FirstTransferGuideRequest(**base, action="preview"), private,
+    )
+
+    assert later["counts"]["local_audio_reused"] == 1
+    assert later["counts"]["spotify_api_lookups"] == 0
+    assert spotify.searches == 1
 
 
 def test_authorized_preview_executes_non_interactively_and_is_idempotent(tmp_path):

--- a/tests/test_agent_contract.py
+++ b/tests/test_agent_contract.py
@@ -9,6 +9,7 @@ import pytest
 from djsupport.agent import (
     AgentAuthorization,
     AgentTransferContract,
+    FirstTransferGuideRequest,
     error_document,
 )
 from djsupport.local_audio import LocalAudioCapability
@@ -19,6 +20,7 @@ from djsupport.transfer import (
     BatchPlanRequest,
     FilePublicationStorage,
     FileTransferStorage,
+    QualificationDecision,
     QualificationRequest,
     SourceSelection,
     Transfer,
@@ -34,6 +36,199 @@ class UntouchedSource:
     def consume(self, reference):
         self.calls += 1
         raise AssertionError("capability inspection must not read the source")
+
+
+@pytest.mark.parametrize(
+    ("guide_request", "next_action", "required_input"),
+    (
+        (
+            FirstTransferGuideRequest(),
+            "configure_spotify",
+            {
+                "kind": "spotify_configuration",
+                "redirect_uri": "http://127.0.0.1:8888/callback",
+                "callback_policy": "add_without_replacing_existing",
+            },
+        ),
+        (
+            FirstTransferGuideRequest(spotify_configured=True),
+            "authenticate_spotify",
+            {"kind": "spotify_authentication"},
+        ),
+        (
+            FirstTransferGuideRequest(
+                spotify_configured=True,
+                spotify_authenticated=True,
+            ),
+            "select_rekordbox_xml",
+            {"kind": "rekordbox_xml", "selection": "exact_file"},
+        ),
+        (
+            FirstTransferGuideRequest(
+                spotify_configured=True,
+                spotify_authenticated=True,
+                rekordbox_configured=True,
+                rekordbox_available=False,
+            ),
+            "repair_rekordbox_xml",
+            {"kind": "rekordbox_xml", "selection": "exact_file"},
+        ),
+    ),
+)
+def test_first_transfer_readiness_returns_one_privacy_safe_next_action(
+    guide_request, next_action, required_input,
+):
+    transfer = MagicMock()
+    contract = AgentTransferContract(transfer)
+
+    document = contract.first_rekordbox_transfer(
+        guide_request, AgentAuthorization(),
+    )
+
+    assert document == {
+        "contract_version": 2,
+        "phase": "first_rekordbox_transfer",
+        "status": "input_required",
+        "next_action": next_action,
+        "required_input": required_input,
+    }
+    transfer.assert_not_called()
+    rendered = json.dumps(document)
+    for private_value in (
+        "client_secret", "access_token", "account_id", "playlist_name",
+        "track_name", "source_path", "fingerprint",
+    ):
+        assert private_value not in rendered
+
+
+def test_first_transfer_asks_for_one_bounded_playlist_after_setup():
+    transfer = MagicMock()
+    contract = AgentTransferContract(transfer)
+    guide_request = FirstTransferGuideRequest(
+        spotify_configured=True,
+        spotify_authenticated=True,
+        rekordbox_configured=True,
+        rekordbox_available=True,
+    )
+
+    document = contract.first_rekordbox_transfer(
+        guide_request, AgentAuthorization(),
+    )
+
+    assert document == {
+        "contract_version": 2,
+        "phase": "first_rekordbox_transfer",
+        "status": "input_required",
+        "next_action": "select_playlist",
+        "required_input": {
+            "kind": "rekordbox_playlist",
+            "selection": "one_explicit_playlist",
+            "whole_library": False,
+        },
+    }
+    transfer.assert_not_called()
+
+
+def test_first_transfer_explains_local_identity_before_an_explicit_choice():
+    transfer = MagicMock()
+    transfer.local_audio_capability.return_value = LocalAudioCapability(
+        available=True,
+        algorithm="chromaprint",
+        algorithm_version="1.6.1",
+    )
+    contract = AgentTransferContract(transfer)
+    guide_request = FirstTransferGuideRequest(
+        spotify_configured=True,
+        spotify_authenticated=True,
+        rekordbox_configured=True,
+        rekordbox_available=True,
+        playlist_reference="Private/Selection",
+    )
+
+    document = contract.first_rekordbox_transfer(
+        guide_request, AgentAuthorization(),
+    )
+
+    assert document == {
+        "contract_version": 2,
+        "phase": "first_rekordbox_transfer",
+        "status": "decision_required",
+        "next_action": "choose_local_audio_identity",
+        "required_input": {
+            "kind": "boolean",
+            "default": False,
+        },
+        "local_audio_identity": {
+            "available": True,
+            "scope": "selected_tracks_only",
+            "uploads": "none",
+            "file_changes": "none",
+            "first_run_spotify_search_reduction": False,
+            "future_reuse": "exact_approved_match_after_approval",
+            "approval_authority": "none",
+            "audition": "separate",
+        },
+    }
+    transfer.local_audio_capability.assert_called_once_with()
+
+
+def test_first_transfer_cannot_enable_unavailable_local_identity():
+    transfer = MagicMock()
+    transfer.local_audio_capability.return_value = LocalAudioCapability(
+        available=False,
+        algorithm="chromaprint",
+        algorithm_version=None,
+        reason="binary_unavailable",
+    )
+    contract = AgentTransferContract(transfer)
+
+    document = contract.first_rekordbox_transfer(
+        FirstTransferGuideRequest(
+            spotify_configured=True,
+            spotify_authenticated=True,
+            rekordbox_configured=True,
+            rekordbox_available=True,
+            playlist_reference="Private/Selection",
+            local_audio_identity=True,
+        ),
+        AgentAuthorization(private_source=True),
+    )
+
+    assert document == {
+        "contract_version": 2,
+        "phase": "first_rekordbox_transfer",
+        "status": "decision_required",
+        "next_action": "continue_without_local_audio_identity",
+        "required_input": {"kind": "boolean", "value": False},
+        "reason": {"code": "local_audio_identity_unavailable"},
+    }
+    transfer.plan_batch.assert_not_called()
+
+
+def test_first_transfer_requires_private_source_authority_before_planning():
+    transfer = MagicMock()
+    contract = AgentTransferContract(transfer)
+    guide_request = FirstTransferGuideRequest(
+        spotify_configured=True,
+        spotify_authenticated=True,
+        rekordbox_configured=True,
+        rekordbox_available=True,
+        playlist_reference="Private/Selection",
+        local_audio_identity=False,
+    )
+
+    document = contract.first_rekordbox_transfer(
+        guide_request, AgentAuthorization(),
+    )
+
+    assert document == {
+        "contract_version": 2,
+        "phase": "first_rekordbox_transfer",
+        "status": "authorization_required",
+        "next_action": "authorize_private_source",
+        "required_authorization": "private_source",
+    }
+    transfer.plan_batch.assert_not_called()
 
 
 def test_machine_error_next_actions_are_specific_to_the_failure():
@@ -185,6 +380,31 @@ class EmptyKnowledge(UntouchedKnowledge):
 
     def checkpoint(self):
         pass
+
+
+class FirstTransferKnowledge(EmptyKnowledge):
+    def __init__(self):
+        super().__init__()
+        self.approved = []
+        self.rejected = []
+        self.corrected = []
+
+    def approve(self, item):
+        self.approved.append(item)
+
+    def reject(self, item):
+        self.rejected.append(item)
+
+    def correct(self, item):
+        self.corrected.append(item)
+
+    def approval_conflict(self, item):
+        del item
+        return False
+
+    def approve_local_audio(self, item, account_id):
+        del item, account_id
+        return None
 
 
 def test_batch_plan_requires_explicit_private_source_authorization(tmp_path):
@@ -353,6 +573,603 @@ class PreviewSpotify:
             "score": 96.0,
             "match_type": "exact",
         }
+
+
+class FirstTransferSpotify(PreviewSpotify):
+    def __init__(self):
+        super().__init__()
+        self.playlists = {}
+        self.heads = {}
+        self.playlist_writes = 0
+
+    def create_playlist(self, name, description):
+        del name, description
+        self.playlists["provisional-one"] = []
+        self.heads["provisional-one"] = "head-0"
+        return "provisional-one"
+
+    def find_recovery_playlist(self, publication_key):
+        del publication_key
+        return None
+
+    def replace_items(self, playlist_id, uris):
+        self.playlist_writes += 1
+        self.playlists[playlist_id] = list(uris)
+        head = f"head-{self.playlist_writes}"
+        self.heads[playlist_id] = head
+        return SimpleNamespace(snapshot_id=head)
+
+    def add_items(self, playlist_id, uris):
+        return self.replace_items(
+            playlist_id, [*self.playlists[playlist_id], *uris],
+        )
+
+    def playlist_head(self, playlist_id):
+        return SimpleNamespace(snapshot_id=self.heads[playlist_id])
+
+    def ordered_playlist_items(self, playlist_id):
+        from djsupport.transfer import (
+            SpotifyItemKind,
+            SpotifyPlaylistItem,
+            SpotifyPlaylistPage,
+        )
+
+        return SpotifyPlaylistPage(tuple(
+            SpotifyPlaylistItem(index, SpotifyItemKind.TRACK, uri)
+            for index, uri in enumerate(self.playlists[playlist_id])
+        ))
+
+    def set_playlist_description(self, playlist_id, description):
+        del playlist_id, description
+
+    def provisional_playlist_track_uris(self, playlist_id):
+        return list(self.playlists[playlist_id])
+
+    def replace_provisional_playlist_tracks(self, playlist_id, uris):
+        return self.replace_items(playlist_id, uris)
+
+    def spotify_track(self, uri):
+        return {
+            "uri": uri,
+            "name": "Invented Signal",
+            "artist": "Invented Artist",
+            "album": "Invented Release",
+            "duration_ms": 180_000,
+            "is_playable": True,
+        }
+
+
+def test_first_transfer_returns_transfer_owned_preview_plan():
+    spotify = PreviewSpotify()
+    contract = AgentTransferContract(Transfer(
+        source=BoundedSource(),
+        spotify=spotify,
+        matching_knowledge=EmptyKnowledge(),
+        publishing_guards=AccountPublishingGuards(),
+    ))
+    guide_request = FirstTransferGuideRequest(
+        spotify_configured=True,
+        spotify_authenticated=True,
+        rekordbox_configured=True,
+        rekordbox_available=True,
+        playlist_reference="Private/Selection",
+        local_audio_identity=False,
+    )
+
+    document = contract.first_rekordbox_transfer(
+        guide_request, AgentAuthorization(private_source=True),
+    )
+
+    assert document["contract_version"] == 2
+    assert document["phase"] == "first_rekordbox_transfer"
+    assert document["status"] == "ready"
+    assert document["next_action"] == "preview"
+    assert document["required_input"] == {
+        "kind": "action_confirmation", "action": "preview",
+    }
+    assert document["counts"] == {
+        "playlists": 1,
+        "tracks": 1,
+        "approved_match_hits": 0,
+        "retained_proposal_hits": 0,
+        "expected_spotify_lookups": 1,
+        "local_audio_eligible": 0,
+        "local_audio_indexed": 0,
+        "local_audio_pending": 0,
+        "local_audio_unavailable": 0,
+    }
+    assert "next_actions" not in document
+    assert spotify.searches == 0
+    rendered = json.dumps(document)
+    assert "Private" not in rendered
+    assert "Invented" not in rendered
+
+
+def test_first_transfer_preview_is_explicit_and_idempotent(tmp_path):
+    spotify = PreviewSpotify()
+    contract = AgentTransferContract(Transfer(
+        source=BoundedSource(),
+        spotify=spotify,
+        matching_knowledge=EmptyKnowledge(),
+        publishing_guards=AccountPublishingGuards(tmp_path / "locks"),
+        transfer_storage=FileTransferStorage(tmp_path / "transfers.json"),
+    ))
+    guide_request = FirstTransferGuideRequest(
+        spotify_configured=True,
+        spotify_authenticated=True,
+        rekordbox_configured=True,
+        rekordbox_available=True,
+        playlist_reference="Private/Selection",
+        local_audio_identity=False,
+        action="preview",
+    )
+    authorization = AgentAuthorization(private_source=True)
+
+    first = contract.first_rekordbox_transfer(guide_request, authorization)
+    repeated = contract.first_rekordbox_transfer(guide_request, authorization)
+
+    assert first == repeated
+    assert first["phase"] == "first_rekordbox_transfer"
+    assert first["status"] == "completed"
+    assert first["next_action"] == "qualify"
+    assert first["required_input"] == {
+        "kind": "action_confirmation", "action": "qualify",
+    }
+    assert first["transfer_id"] == first["batch_id"]
+    assert "next_actions" not in first
+    assert spotify.searches == 1
+
+
+def test_first_transfer_paused_preview_exposes_resume_not_qualification():
+    transfer = MagicMock()
+    transfer.authorization_requirement.return_value = None
+    transfer.plan_batch.return_value = SimpleNamespace(
+        batch_id="opaque-batch",
+        ready=True,
+    )
+    contract = AgentTransferContract(transfer)
+    contract.execute_batch = MagicMock(return_value={
+        "contract_version": 2,
+        "phase": "outcome",
+        "status": "paused",
+        "transfer_id": "opaque-transfer",
+        "next_actions": ["resume"],
+    })
+
+    document = contract.first_rekordbox_transfer(
+        FirstTransferGuideRequest(
+            spotify_configured=True,
+            spotify_authenticated=True,
+            rekordbox_configured=True,
+            rekordbox_available=True,
+            playlist_reference="Private/Selection",
+            local_audio_identity=False,
+            action="preview",
+        ),
+        AgentAuthorization(private_source=True),
+    )
+
+    assert document["next_action"] == "resume"
+    assert document["required_input"] == {
+        "kind": "action_confirmation", "action": "resume",
+    }
+
+
+def test_first_transfer_resume_reuses_the_exact_transfer_identity():
+    transfer = MagicMock()
+    contract = AgentTransferContract(transfer)
+    contract.execute_batch = MagicMock(return_value={
+        "contract_version": 2,
+        "phase": "outcome",
+        "status": "completed",
+        "transfer_id": "opaque-transfer",
+        "next_actions": ["qualify"],
+    })
+    request = FirstTransferGuideRequest(
+        spotify_configured=True,
+        spotify_authenticated=True,
+        rekordbox_configured=True,
+        rekordbox_available=True,
+        playlist_reference="Private/Selection",
+        local_audio_identity=False,
+        action="resume",
+        transfer_id="opaque-transfer",
+    )
+
+    document = contract.first_rekordbox_transfer(
+        request, AgentAuthorization(private_source=True),
+    )
+
+    _, authorization = contract.execute_batch.call_args.args
+    assert authorization.private_source is True
+    assert contract.execute_batch.call_args.kwargs == {
+        "transfer_id": "opaque-transfer",
+    }
+    assert document["next_action"] == "qualify"
+
+
+def test_first_transfer_abandonment_is_explicit_and_terminal():
+    transfer = MagicMock()
+    contract = AgentTransferContract(transfer)
+    request = FirstTransferGuideRequest(
+        spotify_configured=True,
+        spotify_authenticated=True,
+        rekordbox_configured=True,
+        rekordbox_available=True,
+        playlist_reference="Private/Selection",
+        local_audio_identity=False,
+        action="abandon",
+        transfer_id="opaque-transfer",
+    )
+
+    document = contract.first_rekordbox_transfer(
+        request, AgentAuthorization(private_source=True),
+    )
+
+    assert document == {
+        "contract_version": 2,
+        "phase": "first_rekordbox_transfer",
+        "status": "abandoned",
+        "transfer_id": "opaque-transfer",
+        "next_action": None,
+    }
+    transfer.abandon.assert_called_once_with("opaque-transfer")
+
+
+def test_first_transfer_restart_derives_the_next_action_from_durable_progress():
+    transfer = MagicMock()
+    contract = AgentTransferContract(transfer)
+    contract.progress = MagicMock(return_value={
+        "contract_version": 2,
+        "phase": "progress",
+        "status": "paused",
+        "transfer_id": "opaque-transfer",
+        "counts": {
+            "playlists": 1, "completed": 0, "failed": 0, "pending": 1,
+        },
+        "next_actions": ["resume"],
+    })
+
+    document = contract.first_rekordbox_transfer(
+        FirstTransferGuideRequest(
+            spotify_configured=True,
+            spotify_authenticated=True,
+            rekordbox_configured=True,
+            rekordbox_available=True,
+            playlist_reference="Private/Selection",
+            local_audio_identity=False,
+            transfer_id="opaque-transfer",
+        ),
+        AgentAuthorization(private_source=True),
+    )
+
+    assert document["phase"] == "first_rekordbox_transfer"
+    assert document["next_action"] == "resume"
+    assert document["required_input"] == {
+        "kind": "action_confirmation", "action": "resume",
+    }
+    contract.progress.assert_called_once()
+
+
+def test_first_transfer_rejects_unknown_actions_without_falling_back_to_plan():
+    transfer = MagicMock()
+    contract = AgentTransferContract(transfer)
+
+    document = contract.first_rekordbox_transfer(
+        FirstTransferGuideRequest(
+            spotify_configured=True,
+            spotify_authenticated=True,
+            rekordbox_configured=True,
+            rekordbox_available=True,
+            playlist_reference="Private/Selection",
+            local_audio_identity=False,
+            action="invent_authority",
+        ),
+        AgentAuthorization(private_source=True),
+    )
+
+    assert document == {
+        "contract_version": 2,
+        "phase": "first_rekordbox_transfer",
+        "status": "error",
+        "error": {"code": "unsupported_action"},
+        "next_action": "review_request",
+    }
+    transfer.plan_batch.assert_not_called()
+
+
+def test_first_transfer_hands_preview_to_local_qualification(tmp_path):
+    spotify = PreviewSpotify()
+    contract = AgentTransferContract(Transfer(
+        source=BoundedSource(),
+        spotify=spotify,
+        matching_knowledge=EmptyKnowledge(),
+        publishing_guards=AccountPublishingGuards(tmp_path / "locks"),
+        transfer_storage=FileTransferStorage(tmp_path / "transfers.json"),
+    ))
+    base = dict(
+        spotify_configured=True,
+        spotify_authenticated=True,
+        rekordbox_configured=True,
+        rekordbox_available=True,
+        playlist_reference="Private/Selection",
+        local_audio_identity=False,
+    )
+    authorization = AgentAuthorization(private_source=True)
+    preview = contract.first_rekordbox_transfer(
+        FirstTransferGuideRequest(**base, action="preview"), authorization,
+    )
+
+    document = contract.first_rekordbox_transfer(
+        FirstTransferGuideRequest(
+            **base, action="qualify", transfer_id=preview["transfer_id"],
+        ),
+        authorization,
+    )
+
+    assert document["phase"] == "first_rekordbox_transfer"
+    assert document["status"] == "draft"
+    assert document["authority"] == "none"
+    assert document["counts"] == {"items": 1, "pending": 1, "deferred": 0}
+    assert document["next_action"] == "review"
+    assert document["required_input"] == {
+        "kind": "local_qualification_review",
+        "review_url": document["review_url"],
+    }
+    assert document["review_url"].startswith(
+        "http://127.0.0.1:8000/qualification/"
+    )
+    assert "next_actions" not in document
+    rendered = json.dumps(document)
+    assert "Private" not in rendered
+    assert "Invented" not in rendered
+
+
+def test_completed_preview_qualification_requires_separate_spotify_write(
+    tmp_path,
+):
+    spotify = PreviewSpotify()
+    contract = AgentTransferContract(Transfer(
+        source=BoundedSource(),
+        spotify=spotify,
+        matching_knowledge=EmptyKnowledge(),
+        publishing_guards=AccountPublishingGuards(tmp_path / "locks"),
+        transfer_storage=FileTransferStorage(tmp_path / "transfers.json"),
+    ))
+    base = dict(
+        spotify_configured=True,
+        spotify_authenticated=True,
+        rekordbox_configured=True,
+        rekordbox_available=True,
+        playlist_reference="Private/Selection",
+        local_audio_identity=False,
+    )
+    private_source = AgentAuthorization(private_source=True)
+    preview = contract.first_rekordbox_transfer(
+        FirstTransferGuideRequest(**base, action="preview"), private_source,
+    )
+    draft = contract.first_rekordbox_transfer(
+        FirstTransferGuideRequest(
+            **base, action="qualify", transfer_id=preview["transfer_id"],
+        ),
+        private_source,
+    )
+    contract.record_qualification(
+        draft["draft_id"], draft["current_item"]["item_id"],
+        QualificationDecision.KEEP_PROPOSAL, private_source,
+    )
+
+    document = contract.first_rekordbox_transfer(
+        FirstTransferGuideRequest(**base, draft_id=draft["draft_id"]),
+        private_source,
+    )
+
+    assert document == {
+        "contract_version": 2,
+        "phase": "first_rekordbox_transfer",
+        "status": "authorization_required",
+        "draft_id": draft["draft_id"],
+        "authority": "none",
+        "next_action": "authorize_spotify_write",
+        "required_authorization": "spotify_write",
+    }
+    assert spotify.searches == 1
+
+
+def test_first_transfer_publishes_and_links_without_applying_the_draft(
+    tmp_path,
+):
+    spotify = FirstTransferSpotify()
+    contract = AgentTransferContract(Transfer(
+        source=BoundedSource(),
+        spotify=spotify,
+        matching_knowledge=EmptyKnowledge(),
+        publishing_guards=AccountPublishingGuards(tmp_path / "locks"),
+        publication_storage=FilePublicationStorage(tmp_path / "publications.json"),
+        transfer_storage=FileTransferStorage(tmp_path / "transfers.json"),
+    ))
+    base = dict(
+        spotify_configured=True,
+        spotify_authenticated=True,
+        rekordbox_configured=True,
+        rekordbox_available=True,
+        playlist_reference="Private/Selection",
+        local_audio_identity=False,
+    )
+    private_source = AgentAuthorization(private_source=True)
+    preview = contract.first_rekordbox_transfer(
+        FirstTransferGuideRequest(**base, action="preview"), private_source,
+    )
+    draft = contract.first_rekordbox_transfer(
+        FirstTransferGuideRequest(
+            **base, action="qualify", transfer_id=preview["transfer_id"],
+        ),
+        private_source,
+    )
+    contract.record_qualification(
+        draft["draft_id"], draft["current_item"]["item_id"],
+        QualificationDecision.KEEP_PROPOSAL, private_source,
+    )
+    publish = FirstTransferGuideRequest(
+        **base, action="publish_and_link", draft_id=draft["draft_id"],
+    )
+    spotify_write = AgentAuthorization(
+        private_source=True, spotify_write=True,
+    )
+
+    first = contract.first_rekordbox_transfer(publish, spotify_write)
+    repeated = contract.first_rekordbox_transfer(publish, spotify_write)
+
+    assert first == repeated
+    assert first["status"] == "ready"
+    assert first["authority"] == "none"
+    assert first["next_action"] == "apply"
+    assert first["required_input"] == {
+        "kind": "action_confirmation", "action": "apply",
+    }
+    assert "next_actions" not in first
+    assert spotify.playlist_writes == 1
+
+
+def test_first_transfer_applies_draft_without_creating_approval(tmp_path):
+    spotify = FirstTransferSpotify()
+    contract = AgentTransferContract(Transfer(
+        source=BoundedSource(),
+        spotify=spotify,
+        matching_knowledge=EmptyKnowledge(),
+        publishing_guards=AccountPublishingGuards(tmp_path / "locks"),
+        publication_storage=FilePublicationStorage(tmp_path / "publications.json"),
+        transfer_storage=FileTransferStorage(tmp_path / "transfers.json"),
+    ))
+    base = dict(
+        spotify_configured=True,
+        spotify_authenticated=True,
+        rekordbox_configured=True,
+        rekordbox_available=True,
+        playlist_reference="Private/Selection",
+        local_audio_identity=False,
+    )
+    private_source = AgentAuthorization(private_source=True)
+    spotify_write = AgentAuthorization(
+        private_source=True, spotify_write=True,
+    )
+    preview = contract.first_rekordbox_transfer(
+        FirstTransferGuideRequest(**base, action="preview"), private_source,
+    )
+    draft = contract.first_rekordbox_transfer(
+        FirstTransferGuideRequest(
+            **base, action="qualify", transfer_id=preview["transfer_id"],
+        ),
+        private_source,
+    )
+    contract.record_qualification(
+        draft["draft_id"], draft["current_item"]["item_id"],
+        QualificationDecision.KEEP_PROPOSAL, private_source,
+    )
+    contract.first_rekordbox_transfer(
+        FirstTransferGuideRequest(
+            **base, action="publish_and_link", draft_id=draft["draft_id"],
+        ),
+        spotify_write,
+    )
+    apply = FirstTransferGuideRequest(
+        **base, action="apply", draft_id=draft["draft_id"],
+    )
+
+    first = contract.first_rekordbox_transfer(apply, spotify_write)
+    repeated = contract.first_rekordbox_transfer(apply, spotify_write)
+
+    assert first == repeated
+    assert first == {
+        "contract_version": 2,
+        "phase": "first_rekordbox_transfer",
+        "status": "applied",
+        "draft_id": draft["draft_id"],
+        "counts": {"applied_items": 1},
+        "authority": "none",
+        "next_action": "approve",
+        "required_input": {
+            "kind": "authority_confirmation", "authority": "playlist_approval",
+        },
+    }
+
+
+def test_first_transfer_approval_is_a_final_explicit_authority_step(tmp_path):
+    spotify = FirstTransferSpotify()
+    knowledge = FirstTransferKnowledge()
+    contract = AgentTransferContract(Transfer(
+        source=BoundedSource(),
+        spotify=spotify,
+        matching_knowledge=knowledge,
+        publishing_guards=AccountPublishingGuards(tmp_path / "locks"),
+        publication_storage=FilePublicationStorage(tmp_path / "publications.json"),
+        transfer_storage=FileTransferStorage(tmp_path / "transfers.json"),
+    ))
+    base = dict(
+        spotify_configured=True,
+        spotify_authenticated=True,
+        rekordbox_configured=True,
+        rekordbox_available=True,
+        playlist_reference="Private/Selection",
+        local_audio_identity=False,
+    )
+    private_source = AgentAuthorization(private_source=True)
+    spotify_write = AgentAuthorization(
+        private_source=True, spotify_write=True,
+    )
+    preview = contract.first_rekordbox_transfer(
+        FirstTransferGuideRequest(**base, action="preview"), private_source,
+    )
+    draft = contract.first_rekordbox_transfer(
+        FirstTransferGuideRequest(
+            **base, action="qualify", transfer_id=preview["transfer_id"],
+        ),
+        private_source,
+    )
+    contract.record_qualification(
+        draft["draft_id"], draft["current_item"]["item_id"],
+        QualificationDecision.KEEP_PROPOSAL, private_source,
+    )
+    contract.first_rekordbox_transfer(
+        FirstTransferGuideRequest(
+            **base, action="publish_and_link", draft_id=draft["draft_id"],
+        ),
+        spotify_write,
+    )
+    contract.first_rekordbox_transfer(
+        FirstTransferGuideRequest(
+            **base, action="apply", draft_id=draft["draft_id"],
+        ),
+        spotify_write,
+    )
+    approval = FirstTransferGuideRequest(
+        **base, action="approve", draft_id=draft["draft_id"],
+    )
+
+    first = contract.first_rekordbox_transfer(approval, private_source)
+    repeated = contract.first_rekordbox_transfer(approval, private_source)
+
+    assert first == repeated
+    assert first == {
+        "contract_version": 2,
+        "phase": "first_rekordbox_transfer",
+        "status": "approved",
+        "draft_id": draft["draft_id"],
+        "counts": {
+            "approved": 1,
+            "rejected": 0,
+            "collisions": 0,
+            "corrections": 0,
+        },
+        "authority": "playlist_approval",
+        "retained": {
+            "approved_matches": 1,
+            "corrections": 0,
+            "rejected_matches": 0,
+        },
+        "next_action": None,
+    }
+    assert len(knowledge.approved) == 1
 
 
 def test_authorized_preview_executes_non_interactively_and_is_idempotent(tmp_path):

--- a/tests/test_agent_contract.py
+++ b/tests/test_agent_contract.py
@@ -259,7 +259,8 @@ def test_qualification_approval_is_explicit_without_spotify_write_authority():
     )
     transfer.approve_qualification.return_value = SimpleNamespace(
         status=SimpleNamespace(value="approved"),
-        approved=(), rejected=(), collisions=(), corrections=(),
+        approved_count=0, rejected_count=0, collision_count=0,
+        correction_count=0,
     )
     contract = AgentTransferContract(transfer)
     authorization = AgentAuthorization(private_source=True)
@@ -603,6 +604,7 @@ class FirstTransferSpotify(PreviewSpotify):
         self.playlists = {}
         self.heads = {}
         self.playlist_writes = 0
+        self.description_writes = 0
 
     def create_playlist(self, name, description):
         del name, description
@@ -643,6 +645,7 @@ class FirstTransferSpotify(PreviewSpotify):
 
     def set_playlist_description(self, playlist_id, description):
         del playlist_id, description
+        self.description_writes += 1
 
     def provisional_playlist_track_uris(self, playlist_id):
         return list(self.playlists[playlist_id])
@@ -1150,7 +1153,8 @@ def test_first_transfer_approval_is_a_final_explicit_authority_step(tmp_path):
     )
     contract.record_qualification(
         draft["draft_id"], draft["current_item"]["item_id"],
-        QualificationDecision.KEEP_PROPOSAL, private_source,
+        QualificationDecision.CORRECTION, private_source,
+        spotify_reference="spotify:track:replacement00000000000",
     )
     contract.first_rekordbox_transfer(
         FirstTransferGuideRequest(
@@ -1167,6 +1171,7 @@ def test_first_transfer_approval_is_a_final_explicit_authority_step(tmp_path):
     approval = FirstTransferGuideRequest(
         **base, action="approve", draft_id=draft["draft_id"],
     )
+    description_writes_before_approval = spotify.description_writes
 
     first = contract.first_rekordbox_transfer(approval, private_source)
     repeated = contract.first_rekordbox_transfer(approval, private_source)
@@ -1181,7 +1186,7 @@ def test_first_transfer_approval_is_a_final_explicit_authority_step(tmp_path):
             "approved": 1,
             "rejected": 0,
             "collisions": 0,
-            "corrections": 0,
+            "corrections": 1,
         },
         "authority": "playlist_approval",
         "effects": {
@@ -1190,12 +1195,13 @@ def test_first_transfer_approval_is_a_final_explicit_authority_step(tmp_path):
         },
         "retained": {
             "approved_matches": 1,
-            "corrections": 0,
+            "corrections": 1,
             "rejected_matches": 0,
         },
         "next_action": None,
     }
-    assert len(knowledge.approved) == 1
+    assert len(knowledge.corrected) == 1
+    assert spotify.description_writes == description_writes_before_approval
     writes = spotify.playlist_writes
 
     terminal_publish = contract.first_rekordbox_transfer(

--- a/tests/test_backup.py
+++ b/tests/test_backup.py
@@ -180,6 +180,48 @@ class TestRestorePreview:
         assert preview.valid is True
         assert preview.contents == ("transfers.json",)
 
+    def test_schema_five_approval_outcome_restores_over_version_four(
+        self, tmp_path,
+    ):
+        source = tmp_path / "source"
+        target = tmp_path / "target"
+        _write_json(source / "transfers.json", {
+            "version": 5,
+            "transfers": {},
+            "batches": {},
+            "qualifications": {
+                "draft-approved": {
+                    "draft_id": "draft-approved",
+                    "status": "approved",
+                    "decisions": {},
+                    "approval_outcome": {
+                        "status": "approved",
+                        "approved": [],
+                        "rejected": [],
+                    },
+                },
+            },
+        })
+        _write_json(target / "transfers.json", {
+            "version": 4,
+            "transfers": {},
+            "batches": {},
+            "qualifications": {},
+        })
+        archive = LocalDataBackup(source).create(tmp_path / "backups")
+        service = LocalDataBackup(target)
+
+        preview = service.preview(archive)
+        restored = service.restore(archive)
+
+        assert preview.valid is True
+        assert restored.restored is True
+        state = json.loads((target / "transfers.json").read_text())
+        assert state["version"] == 5
+        assert state["qualifications"]["draft-approved"][
+            "approval_outcome"
+        ]["status"] == "approved"
+
     @pytest.mark.parametrize("damage", ["corrupt", "unsupported-backup", "unsupported-data"])
     def test_rejects_corrupt_or_unsupported_archive(self, tmp_path, damage):
         source = tmp_path / "source"

--- a/tests/test_backup.py
+++ b/tests/test_backup.py
@@ -196,8 +196,12 @@ class TestRestorePreview:
                     "decisions": {},
                     "approval_outcome": {
                         "status": "approved",
-                        "approved": [],
-                        "rejected": [],
+                        "reviewed_at": "2026-08-10T00:00:00",
+                        "approved_count": 1,
+                        "rejected_count": 0,
+                        "collision_count": 0,
+                        "correction_count": 1,
+                        "conflict_count": 0,
                     },
                 },
             },
@@ -221,6 +225,12 @@ class TestRestorePreview:
         assert state["qualifications"]["draft-approved"][
             "approval_outcome"
         ]["status"] == "approved"
+        retained = state["qualifications"]["draft-approved"][
+            "approval_outcome"
+        ]
+        assert retained["approved_count"] == 1
+        assert retained["correction_count"] == 1
+        assert "approved" not in retained
 
     @pytest.mark.parametrize("damage", ["corrupt", "unsupported-backup", "unsupported-data"])
     def test_rejects_corrupt_or_unsupported_archive(self, tmp_path, damage):

--- a/tests/test_local_audio_identity.py
+++ b/tests/test_local_audio_identity.py
@@ -327,7 +327,7 @@ def test_completed_local_observation_is_not_recalculated_after_spotify_timeout(
 
     assert resumed.total_matched == 1
     assert local_audio.observed == ["rb-original"]
-    assert json.loads(state_path.read_text())["version"] == 4
+    assert json.loads(state_path.read_text())["version"] == 5
 
 
 def test_explicit_drift_revocation_removes_local_identity_authority(tmp_path):

--- a/tests/test_qualification.py
+++ b/tests/test_qualification.py
@@ -1333,7 +1333,7 @@ def test_schema_three_transfer_and_schema_five_manifest_apply_additively(
     )
 
     assert outcome.status == QualificationStatus.APPLIED
-    assert json.loads(transfer_path.read_text())["version"] == 4
+    assert json.loads(transfer_path.read_text())["version"] == 5
     assert json.loads(publication_path.read_text())["version"] == 6
 
 

--- a/tests/test_qualification.py
+++ b/tests/test_qualification.py
@@ -482,7 +482,7 @@ def test_duplicate_source_occurrences_remain_ordered_facts_through_approval(
     )
 
     assert outcome.status.value == "approved"
-    assert outcome.collisions == ()
+    assert outcome.collision_count == 0
     assert spotify.playlists[report.playlists[0].spotify_playlist_id] == [
         _proposal("repeat")["uri"], _proposal("repeat")["uri"],
     ]

--- a/tests/test_transfer.py
+++ b/tests/test_transfer.py
@@ -2034,6 +2034,21 @@ class TestRekordboxBatchExecution:
 
 
 class TestTransferPublicationLifecycle:
+    def test_transfer_state_schema_four_remains_readable(self, tmp_path):
+        state_path = tmp_path / "transfers.json"
+        state_path.write_text(json.dumps({
+            "version": 4,
+            "transfers": {},
+            "batches": {},
+            "qualifications": {},
+        }))
+
+        storage = FileTransferStorage(state_path)
+
+        assert storage.transfers == {}
+        assert storage.batches == {}
+        assert storage.qualifications == {}
+
     @pytest.mark.parametrize("stored", [
         '{"version": 99, "transfers": {"private": {}}}',
         '{"version": 4, "qualifications": {"private": {"draft_id": "x"}}}',

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -56,6 +56,89 @@ def test_web_outcome_exposes_aggregate_local_audio_counts():
     assert rendered["local_audio_reused"] == 1
 
 
+def test_first_transfer_web_route_is_a_thin_agent_contract_rendering():
+    transfer = MagicMock()
+    transfer.local_audio_capability.return_value = MagicMock(
+        available=False,
+    )
+    web = create_app(
+        rekordbox_transfer_factory=lambda request, authorized: transfer,
+    )
+
+    response = TestClient(web).post("/rekordbox/first-transfer", json={
+        "spotify_configured": True,
+        "spotify_authenticated": True,
+        "rekordbox_configured": True,
+        "rekordbox_available": True,
+        "xml_path": "/private/library.xml",
+        "playlist_reference": "Private/Selection",
+    })
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "contract_version": 2,
+        "phase": "first_rekordbox_transfer",
+        "status": "decision_required",
+        "next_action": "choose_local_audio_identity",
+        "required_input": {"kind": "boolean", "default": False},
+        "local_audio_identity": {
+            "available": False,
+            "scope": "selected_tracks_only",
+            "uploads": "none",
+            "file_changes": "none",
+            "first_run_spotify_search_reduction": False,
+            "future_reuse": "exact_approved_match_after_approval",
+            "approval_authority": "none",
+            "audition": "separate",
+        },
+    }
+    assert "Private/Selection" not in response.text
+
+
+def test_first_transfer_web_route_forwards_only_explicit_authority():
+    transfer = MagicMock()
+    transfer.authorization_requirement.side_effect = (
+        lambda request, authorization, phase: Transfer.authorization_requirement(
+            request, authorization, phase=phase,
+        )
+    )
+    transfer.plan_batch.return_value = BatchPlan((PlaylistPreflight(
+        name="Private Selection",
+        reference="Private/Selection",
+        total_tracks=2,
+        approved_match_hits=1,
+        cache_hits=0,
+        expected_uncached_lookups=1,
+        selection_token="opaque",
+    ),), preview=True)
+    calls = []
+
+    def factory(request, authorized):
+        calls.append((request, authorized))
+        return transfer
+
+    web = create_app(rekordbox_transfer_factory=factory)
+    response = TestClient(web).post("/rekordbox/first-transfer", json={
+        "spotify_configured": True,
+        "spotify_authenticated": True,
+        "rekordbox_configured": True,
+        "rekordbox_available": True,
+        "xml_path": "/private/library.xml",
+        "playlist_reference": "Private/Selection",
+        "local_audio_identity": False,
+        "authorize_private_source": True,
+    })
+
+    assert response.status_code == 200
+    assert response.json()["next_action"] == "preview"
+    assert calls[0][0].whole_library is False
+    assert calls[0][0].playlists == ["Private/Selection"]
+    assert calls[0][0].authorize_private_source is True
+    assert calls[0][0].authorize_spotify_write is False
+    assert calls[0][1] is False
+    assert "Private/Selection" not in response.text
+
+
 def _agent_web_transfer(plan, report=None):
     transfer = MagicMock()
     transfer.authorization_requirement.side_effect = (

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -10,6 +10,7 @@ import pytest
 from fastapi.testclient import TestClient
 
 from djsupport.report import PlaylistReport, SyncReport
+from djsupport.readiness import FirstTransferReadiness
 from djsupport.rekordbox import Track
 from djsupport.local_audition import LocalSourceAudition
 from djsupport.transfer import (
@@ -63,13 +64,12 @@ def test_first_transfer_web_route_is_a_thin_agent_contract_rendering():
     )
     web = create_app(
         rekordbox_transfer_factory=lambda request, authorized: transfer,
+        first_transfer_readiness=lambda path, authorized: FirstTransferReadiness(
+            True, True, True, True, path,
+        ),
     )
 
     response = TestClient(web).post("/rekordbox/first-transfer", json={
-        "spotify_configured": True,
-        "spotify_authenticated": True,
-        "rekordbox_configured": True,
-        "rekordbox_available": True,
         "xml_path": "/private/library.xml",
         "playlist_reference": "Private/Selection",
     })
@@ -95,6 +95,27 @@ def test_first_transfer_web_route_is_a_thin_agent_contract_rendering():
     assert "Private/Selection" not in response.text
 
 
+def test_first_transfer_web_route_ignores_caller_asserted_readiness():
+    transfer = MagicMock()
+    web = create_app(
+        rekordbox_transfer_factory=lambda request, authorized: transfer,
+        first_transfer_readiness=lambda path, authorized: FirstTransferReadiness(
+            False, False, False, False, None,
+        ),
+    )
+
+    response = TestClient(web).post("/rekordbox/first-transfer", json={
+        "spotify_configured": True,
+        "spotify_authenticated": True,
+        "rekordbox_configured": True,
+        "rekordbox_available": True,
+        "playlist_reference": "Private/Selection",
+    })
+
+    assert response.json()["next_action"] == "configure_spotify"
+    transfer.assert_not_called()
+
+
 def test_first_transfer_web_route_forwards_only_explicit_authority():
     transfer = MagicMock()
     transfer.authorization_requirement.side_effect = (
@@ -117,12 +138,13 @@ def test_first_transfer_web_route_forwards_only_explicit_authority():
         calls.append((request, authorized))
         return transfer
 
-    web = create_app(rekordbox_transfer_factory=factory)
+    web = create_app(
+        rekordbox_transfer_factory=factory,
+        first_transfer_readiness=lambda path, authorized: FirstTransferReadiness(
+            True, True, True, True, path,
+        ),
+    )
     response = TestClient(web).post("/rekordbox/first-transfer", json={
-        "spotify_configured": True,
-        "spotify_authenticated": True,
-        "rekordbox_configured": True,
-        "rekordbox_available": True,
         "xml_path": "/private/library.xml",
         "playlist_reference": "Private/Selection",
         "local_audio_identity": False,


### PR DESCRIPTION
## Summary
- add a single-next-action first Rekordbox Transfer guide across the public agent contract, CLI, and local web adapter
- derive presence-only readiness without reading credentials or private source content before authorization
- guide Preview, Qualification, bounded Spotify publication, Apply, and authority-only Approval with durable replay and fail-closed interruption handling
- retain aggregate Approval counts only and reuse Approved Matches through optional exact local audio identity
- document the first journey, schema 5 compatibility, and the shared readiness module

## Verification
- 708 offline tests pass
- Python compilation and diff validation pass
- source distribution and wheel build successfully
- clean wheel install exposes djsupport and first-transfer help
- Standards review: zero findings
- Spec review: zero findings

Closes #105