### PR TITLE
fix: validate automated version pull requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,7 @@ name: CI
 
 'on':
   pull_request:
+  workflow_dispatch:
   push:
     branches:
       - main
@@ -16,7 +17,7 @@ concurrency:
 jobs:
   release-record:
     name: Release record
-    if: github.event_name == 'pull_request'
+    if: github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     steps:
       - name: Check out source
@@ -25,7 +26,9 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
       - name: Require release record for distributable changes
-        run: python scripts/release_records.py check "${{ github.event.pull_request.base.sha }}" "${{ github.sha }}"
+        env:
+          RELEASE_RECORD_BASE: ${{ github.event.pull_request.base.sha || 'origin/main' }}
+        run: python scripts/release_records.py check "$RELEASE_RECORD_BASE" "${{ github.sha }}"
 
   test:
     name: Python ${{ matrix.python-version }}

--- a/.github/workflows/version-pr.yml
+++ b/.github/workflows/version-pr.yml
@@ -10,6 +10,7 @@ concurrency:
   cancel-in-progress: false
 
 permissions:
+  actions: write
   contents: write
   pull-requests: write
 
@@ -48,3 +49,4 @@ jobs:
           else
             gh pr create --base main --head release/version --title "chore: version DJ Support $VERSION" --body "Automated version PR from pending release records. Merging updates version metadata and the changelog; it does not authorize a tag, GitHub Release, or package publication."
           fi
+          gh workflow run ci.yml --ref release/version

--- a/tests/test_release_channels.py
+++ b/tests/test_release_channels.py
@@ -65,8 +65,10 @@ def test_ci_is_a_least_privilege_offline_release_gate():
     errors = []
 
     triggers = workflow.get("on", {})
-    if set(triggers) != {"push", "pull_request"}:
-        errors.append("CI must run only for pushes and pull requests")
+    if set(triggers) != {"push", "pull_request", "workflow_dispatch"}:
+        errors.append(
+            "CI must run only for pushes, pull requests, and explicit dispatches"
+        )
     if triggers.get("push", {}).get("branches") != ["main"]:
         errors.append("push CI must be limited to main")
     if workflow.get("permissions") != {"contents": "read"}:
@@ -148,11 +150,21 @@ def test_ci_is_a_least_privilege_offline_release_gate():
 
 
 def test_version_pr_automation_cannot_publish_a_release():
-    workflow = (REPOSITORY_ROOT / ".github" / "workflows" / "version-pr.yml").read_text()
-    normalized = workflow.casefold()
+    version_workflow = (
+        REPOSITORY_ROOT / ".github" / "workflows" / "version-pr.yml"
+    ).read_text()
+    ci_workflow = (
+        REPOSITORY_ROOT / ".github" / "workflows" / "ci.yml"
+    ).read_text()
+    normalized = version_workflow.casefold()
 
-    assert "scripts/release_records.py prepare" in workflow
-    assert "release/version" in workflow
-    assert "pull-requests: write" in workflow
+    assert "scripts/release_records.py prepare" in version_workflow
+    assert "release/version" in version_workflow
+    assert "pull-requests: write" in version_workflow
+    assert "actions: write" in version_workflow
+    assert "gh workflow run ci.yml --ref release/version" in version_workflow
+    assert "workflow_dispatch:" in ci_workflow
+    assert "github.event_name == 'workflow_dispatch'" in ci_workflow
+    assert "RELEASE_RECORD_BASE" in ci_workflow
     for forbidden in ("git tag", "gh release create", "twine", "pypi", "spotify", "beatport"):
         assert forbidden not in normalized


### PR DESCRIPTION
## Summary

- add an explicit `workflow_dispatch` entry point to the existing least-privilege CI workflow
- validate release records against `origin/main` when CI is dispatched for the generated version branch
- grant the version workflow only the additional `actions: write` permission needed to dispatch CI on `release/version`
- extend contract tests for the dispatch path and publication boundary

## Why

GitHub intentionally suppresses recursive workflow events for pull requests created with `GITHUB_TOKEN`. The automated 0.6 version PR (#153) was created successfully but received no checks, so it cannot satisfy #134 or the canonical release checklist. This repair dispatches the same CI workflow explicitly after the bot creates or updates that PR.

This changes no package behavior and does not authorize tagging, GitHub Releases, package publication, live services, or owner-data access.

## Validation

- `python3 -m pytest` — 745 passed
- `python3 -m compileall -q djsupport tests`
- focused release-channel and release-record tests — 10 passed

Part of #134.