### PR TITLE
Refactor CLI construction through Runtime Assembly

### DIFF
--- a/.claude/docs/architectural_patterns.md
+++ b/.claude/docs/architectural_patterns.md
@@ -39,20 +39,22 @@ Files:
 
 ## Dependency injection via parameters
 
-External dependencies are passed through the Transfer constructor or function
-parameters—never global singletons.
+External dependencies are passed through Runtime Assembly, the Transfer
+constructor, or function parameters—never global singletons.
 
 - `match_track(sp, track, threshold)` — receives Spotify client as `sp`
 - `match_track_cached(sp, track, cache, ...)` — receives both `sp` and `cache`
-- CLI and web adapters construct `Transfer` with source, Spotify, matching
-  knowledge, publication, and durable-state adapters.
+- `RuntimeAssembly` receives an injectable Spotify-adapter factory and selects
+  paths, matching knowledge, persistence, guards, and local-audio adapters.
+- CLI and Agent Client paths provide source and authorized phase facts to
+  Runtime Assembly; the web adapter retains its direct construction seam.
 
 Files:
 - `matcher.py:154` — `match_track(sp, track, threshold)`
 - `matcher.py:225-228` — `match_track_cached(sp, track, cache, ...)`
 - `spotify.py:106-113` — `create_or_update_playlist(sp, ..., state_manager=None)`
 - `spotify.py:176-183` — `incremental_update_playlist(sp, ..., state_manager=None)`
-- `cli.py:162-178` — wiring in `sync` command
+- `runtime.py` — private production graph assembly for CLI and Agent Clients
 
 ## Error handling
 

--- a/.release-notes/runtime-assembly.md
+++ b/.release-notes/runtime-assembly.md
@@ -1,0 +1,6 @@
+---
+bump: patch
+section: Changed
+---
+
+Keep CLI and Agent Client production wiring consistent through one private Runtime Assembly without changing Transfer behavior or local storage formats.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,6 +27,7 @@ every flag.
 ```text
 djsupport/
   transfer.py    Durable Transfer policy, planning, checkpoints, and publication
+  runtime.py     Private production assembly for Transfer client adapters
   agent.py       Versioned, harness-neutral Transfer contract rendering
   readiness.py   Shared presence-only readiness for CLI and web adapters
   cli.py         Thin Click command-line adapter

--- a/djsupport/cli.py
+++ b/djsupport/cli.py
@@ -19,16 +19,19 @@ from djsupport.report import (
     save_report,
     save_review_csv,
 )
-from djsupport.spotify import RateLimitError, get_client
-from djsupport.transfer import (
-    AccountPublishingGuards,
-    default_matching_knowledge_path,
-    default_publication_manifest_path,
+from djsupport.runtime import (
+    MatchingKnowledgeUnavailable,
+    RuntimeAssembly,
+    RuntimePaths,
+    RuntimeSettings,
+    SpotifyAccess,
 )
+from djsupport.spotify import RateLimitError
 
 
-DEFAULT_MATCHING_KNOWLEDGE_PATH = str(default_matching_knowledge_path())
-DEFAULT_PUBLICATION_MANIFEST_PATH = str(default_publication_manifest_path())
+DEFAULT_RUNTIME_PATHS = RuntimePaths.defaults()
+DEFAULT_MATCHING_KNOWLEDGE_PATH = str(DEFAULT_RUNTIME_PATHS.matching_knowledge)
+DEFAULT_PUBLICATION_MANIFEST_PATH = str(DEFAULT_RUNTIME_PATHS.publication_state)
 
 
 @click.group()
@@ -42,11 +45,10 @@ def cli():
 def capabilities(as_json: bool) -> None:
     """Inspect optional capabilities without reading a library or Spotify."""
     from djsupport.agent import capability_document
-    from djsupport.local_audio import ChromaprintLocalAudio
-    from djsupport.local_audition import LocalSourceAudition
 
+    transfer = RuntimeAssembly().capability_transfer()
     document = capability_document(
-        ChromaprintLocalAudio().capability(), LocalSourceAudition().capability(),
+        transfer.local_audio_capability(), transfer.local_audition_capability(),
     )
     if as_json:
         click.echo(json.dumps(document, sort_keys=True))
@@ -89,46 +91,28 @@ def _first_transfer_contract(
 ):
     """Build the public contract only as deeply as the current phase needs."""
     from djsupport.agent import AgentTransferContract
-    from djsupport.cache import MatchCache
-    from djsupport.local_audio import ChromaprintLocalAudio
-    from djsupport.transfer import (
-        EphemeralMatchingKnowledge,
-        FilePublicationStorage,
-        FileTransferStorage,
-        MatchCacheKnowledge,
-        RekordboxPlaylistSource,
-        SpotifyMatcher,
-        Transfer,
-    )
+    from djsupport.transfer import RekordboxPlaylistSource
 
-    local_audio = ChromaprintLocalAudio()
+    assembly = RuntimeAssembly()
     if not activate:
-        return AgentTransferContract(Transfer(
-            source=object(),
-            spotify=object(),
-            matching_knowledge=EphemeralMatchingKnowledge(),
-            publishing_guards=AccountPublishingGuards(),
-            local_audio=local_audio,
-        ))
+        return AgentTransferContract(assembly.capability_transfer())
 
     if xml_path is None:
         raise ValueError("Rekordbox XML is unavailable")
-    cache = MatchCache(cache_path)
-    cache.load()
-    publication_path = Path(state_path)
-    return AgentTransferContract(Transfer(
-        source=RekordboxPlaylistSource(
+    graph = assembly.assemble(
+        RekordboxPlaylistSource(
             xml_path, include_locations=bool(local_audio_identity),
         ),
-        spotify=(SpotifyMatcher(get_client()) if spotify_access else object()),
-        matching_knowledge=MatchCacheKnowledge(cache),
-        publishing_guards=AccountPublishingGuards(),
-        publication_storage=FilePublicationStorage(publication_path),
-        transfer_storage=FileTransferStorage(
-            publication_path.with_suffix(".transfers.json")
+        RuntimeSettings(
+            paths=RuntimePaths.selected(cache_path, state_path),
+            spotify_access=(
+                SpotifyAccess.REQUIRED
+                if spotify_access else SpotifyAccess.DISABLED
+            ),
+            local_audio_identity=bool(local_audio_identity),
         ),
-        local_audio=(local_audio if local_audio_identity else None),
-    ))
+    )
+    return AgentTransferContract(graph.transfer)
 
 
 @cli.command("first-transfer")
@@ -533,20 +517,12 @@ def sync(
             "Use explicit --playlist selections or --whole-library, not both."
         )
 
-    from djsupport.cache import MatchCache
     from djsupport.transfer import (
         BatchPlanRequest,
-        EphemeralMatchingKnowledge,
-        FilePublicationStorage,
-        FileTransferStorage,
-        MatchCacheKnowledge,
         RekordboxPlaylistSource,
-        SpotifyMatcher,
         Transfer,
         TransferAuthorization,
     )
-    from djsupport.local_audio import ChromaprintLocalAudio
-    from djsupport.local_audition import LocalSourceAudition
 
     request = BatchPlanRequest(
         playlist_references=playlist,
@@ -603,11 +579,30 @@ def sync(
         ))
         raise click.exceptions.Exit(2) from exc
 
-    cache = None if no_cache else MatchCache(cache_path)
+    execute_authorized = Transfer.authorization_requirement(
+        request, authorization, phase="execute",
+    ) is None
     try:
-        if cache is not None:
-            cache.load()
-    except (OSError, ValueError) as exc:
+        graph = RuntimeAssembly().assemble(
+            RekordboxPlaylistSource(
+                xml_path,
+                include_locations=(
+                    local_audio_identity or local_audio_audition
+                ),
+            ),
+            RuntimeSettings(
+                paths=RuntimePaths.selected(cache_path, state_path),
+                spotify_access=(
+                    SpotifyAccess.REQUIRED
+                    if execute_authorized else SpotifyAccess.DISABLED
+                ),
+                retain_matching_knowledge=not no_cache,
+                retain_publications=not dry_run,
+                local_audio_identity=local_audio_identity,
+                local_audio_audition=local_audio_audition,
+            ),
+        )
+    except MatchingKnowledgeUnavailable as exc:
         if not agent_json:
             raise click.ClickException(str(exc)) from exc
         from djsupport.agent import error_document
@@ -616,32 +611,7 @@ def sync(
             error_document("plan", "matching_knowledge_unavailable"), sort_keys=True,
         ))
         raise click.exceptions.Exit(2) from exc
-    execute_authorized = Transfer.authorization_requirement(
-        request, authorization, phase="execute",
-    ) is None
-    transfer = Transfer(
-        source=RekordboxPlaylistSource(
-            xml_path,
-            include_locations=(local_audio_identity or local_audio_audition),
-        ),
-        spotify=(
-            SpotifyMatcher(get_client())
-            if execute_authorized else object()
-        ),
-        publishing_guards=AccountPublishingGuards(),
-        matching_knowledge=(
-            EphemeralMatchingKnowledge() if cache is None
-            else MatchCacheKnowledge(cache)
-        ),
-        publication_storage=(
-            None if dry_run else FilePublicationStorage(state_path)
-        ),
-        transfer_storage=FileTransferStorage(
-            str(Path(state_path).with_suffix(".transfers.json"))
-        ),
-        local_audio=(ChromaprintLocalAudio() if local_audio_identity else None),
-        local_audition=(LocalSourceAudition() if local_audio_audition else None),
-    )
+    transfer = graph.transfer
     if agent_json:
         from djsupport.agent import AgentTransferContract
 
@@ -764,18 +734,10 @@ def qualification_command(
         authorization_required_document,
         error_document,
     )
-    from djsupport.cache import MatchCache
-    from djsupport.local_audition import LocalSourceAudition
     from djsupport.transfer import (
-        EphemeralMatchingKnowledge,
-        FilePublicationStorage,
-        FileTransferStorage,
-        MatchCacheKnowledge,
         QualificationDecision,
         QualificationRequest,
         RekordboxPlaylistSource,
-        SpotifyMatcher,
-        Transfer,
         TransferAuthorization,
     )
 
@@ -831,9 +793,9 @@ def qualification_command(
         spotify_write=authorize_spotify_write,
     )
     try:
-        transfer_storage = FileTransferStorage(
-            str(Path(state_path).with_suffix(".transfers.json"))
-        )
+        paths = RuntimePaths.selected(cache_path, state_path)
+        assembly = RuntimeAssembly()
+        transfer_storage = assembly.transfer_storage(paths)
         if draft_id is not None:
             stored_draft = transfer_storage.load_qualification(draft_id)
             stored_state = (
@@ -869,25 +831,18 @@ def qualification_command(
             no_cache = not bool(
                 stored_state.request.get("retain_matching_knowledge", True)
             )
-        cache = None if no_cache else MatchCache(cache_path)
-        if cache is not None:
-            cache.load()
-        transfer = Transfer(
-            source=RekordboxPlaylistSource(
+        graph = assembly.assemble(
+            RekordboxPlaylistSource(
                 selected_xml_path, include_locations=local_audio_audition,
             ),
-            spotify=SpotifyMatcher(get_client()),
-            publishing_guards=AccountPublishingGuards(),
-            matching_knowledge=(
-                EphemeralMatchingKnowledge()
-                if cache is None else MatchCacheKnowledge(cache)
-            ),
-            publication_storage=FilePublicationStorage(state_path),
-            transfer_storage=transfer_storage,
-            local_audition=(
-                LocalSourceAudition() if local_audio_audition else None
+            RuntimeSettings(
+                paths=paths,
+                spotify_access=SpotifyAccess.REQUIRED,
+                retain_matching_knowledge=not no_cache,
+                local_audio_audition=local_audio_audition,
             ),
         )
+        transfer = graph.transfer
         contract = AgentTransferContract(transfer)
         if draft_id is None:
             assert transfer_id is not None and playlist is not None
@@ -1009,30 +964,20 @@ def approve(
     playlist_id: str, state_path: str, cache_path: str, review_csv: str | None,
 ) -> None:
     """Approve one Provisional Playlist after reviewing it in Spotify."""
-    from djsupport.cache import MatchCache
     from djsupport.transfer import (
         BeatportChartSource,
-        FilePublicationStorage,
-        FileTransferStorage,
-        MatchCacheKnowledge,
         SpotifyPlaylistChanged,
         SpotifyPlaylistReviewRequired,
-        SpotifyMatcher,
-        Transfer,
     )
 
-    cache = MatchCache(cache_path)
-    cache.load()
-    transfer = Transfer(
-        source=BeatportChartSource(),
-        spotify=SpotifyMatcher(get_client()),
-        publishing_guards=AccountPublishingGuards(),
-        matching_knowledge=MatchCacheKnowledge(cache),
-        publication_storage=FilePublicationStorage(state_path),
-        transfer_storage=FileTransferStorage(
-            str(Path(state_path).with_suffix(".transfers.json"))
+    graph = RuntimeAssembly().assemble(
+        BeatportChartSource(),
+        RuntimeSettings(
+            paths=RuntimePaths.selected(cache_path, state_path),
+            spotify_access=SpotifyAccess.REQUIRED,
         ),
     )
+    transfer = graph.transfer
     try:
         if review_csv is None:
             review = transfer.approve(playlist_id)
@@ -1114,16 +1059,9 @@ def beatport(
     )
     from djsupport.beatport_export import BeatportExportError
 
-    from djsupport.cache import MatchCache
     from djsupport.transfer import (
         BeatportChartSource,
         BeatportExportSource,
-        EphemeralMatchingKnowledge,
-        FilePublicationStorage,
-        FileTransferStorage,
-        MatchCacheKnowledge,
-        SpotifyMatcher,
-        Transfer,
         TransferMode,
         TransferRequest,
     )
@@ -1144,27 +1082,19 @@ def beatport(
         if isinstance(source, BeatportExportSource) else (url or "")
     )
 
-    cache = None if no_cache else MatchCache(cache_path)
-    if cache is not None:
-        cache.load()
     if resume_id and abandon_id:
         raise click.UsageError("Use either --resume or --abandon, not both.")
-    transfer_storage = FileTransferStorage(
-        str(Path(state_path).with_suffix(".transfers.json"))
-    )
-    transfer = Transfer(
-        source=source,
-        spotify=SpotifyMatcher(get_client()),
-        publishing_guards=AccountPublishingGuards(),
-        matching_knowledge=(
-            EphemeralMatchingKnowledge()
-            if cache is None else MatchCacheKnowledge(cache)
+    graph = RuntimeAssembly().assemble(
+        source,
+        RuntimeSettings(
+            paths=RuntimePaths.selected(cache_path, state_path),
+            spotify_access=SpotifyAccess.REQUIRED,
+            retain_matching_knowledge=not no_cache,
+            retain_publications=not dry_run,
         ),
-        publication_storage=(
-            None if dry_run else FilePublicationStorage(state_path)
-        ),
-        transfer_storage=transfer_storage,
     )
+    transfer = graph.transfer
+    transfer_storage = graph.transfer_storage
     if abandon_id:
         transfer.abandon(abandon_id)
         click.echo(f"Transfer {abandon_id} abandoned.")
@@ -1346,40 +1276,27 @@ def label(
         else:
             click.echo(f"{unique_count} tracks (newest first).")
 
-    from djsupport.cache import MatchCache
     from djsupport.transfer import (
         BeatportLabelSource,
-        EphemeralMatchingKnowledge,
-        FilePublicationStorage,
-        FileTransferStorage,
-        MatchCacheKnowledge,
-        SpotifyMatcher,
-        Transfer,
         TransferMode,
         TransferRequest,
     )
 
-    cache = None if no_cache else MatchCache(cache_path)
-    if cache is not None:
-        cache.load()
     if resume_id and abandon_id:
         raise click.UsageError("Use either --resume or --abandon, not both.")
-    transfer_storage = FileTransferStorage(
-        str(Path(state_path).with_suffix(".transfers.json"))
-    )
-    transfer = Transfer(
-        source=BeatportLabelSource(
+    graph = RuntimeAssembly().assemble(
+        BeatportLabelSource(
             fetcher=fetcher, on_deduplicated=on_deduplicated,
         ),
-        spotify=SpotifyMatcher(get_client()),
-        publishing_guards=AccountPublishingGuards(),
-        matching_knowledge=(
-            EphemeralMatchingKnowledge()
-            if cache is None else MatchCacheKnowledge(cache)
+        RuntimeSettings(
+            paths=RuntimePaths.selected(cache_path, state_path),
+            spotify_access=SpotifyAccess.REQUIRED,
+            retain_matching_knowledge=not no_cache,
+            retain_publications=not dry_run,
         ),
-        publication_storage=None if dry_run else FilePublicationStorage(state_path),
-        transfer_storage=transfer_storage,
     )
+    transfer = graph.transfer
+    transfer_storage = graph.transfer_storage
     if abandon_id:
         transfer.abandon(abandon_id)
         click.echo(f"Transfer {abandon_id} abandoned.")

--- a/djsupport/runtime.py
+++ b/djsupport/runtime.py
@@ -1,0 +1,213 @@
+"""Private production assembly for Transfer clients.
+
+Clients provide source and phase facts. This module owns the corresponding
+production adapters without taking matching, authorization, persistence, or
+publication policy away from :class:`djsupport.transfer.Transfer`.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+from pathlib import Path
+from typing import Callable
+
+from djsupport.cache import MatchCache
+from djsupport.local_audio import ChromaprintLocalAudio
+from djsupport.local_audition import LocalSourceAudition
+from djsupport.spotify import get_client
+from djsupport.transfer import (
+    AccountPublishingGuards,
+    EphemeralMatchingKnowledge,
+    FilePublicationStorage,
+    FileTransferStorage,
+    MatchCacheKnowledge,
+    SourceAdapter,
+    SpotifyAdapter,
+    SpotifyMatcher,
+    Transfer,
+    TransferMode,
+    default_matching_knowledge_path,
+    default_publication_manifest_path,
+)
+
+
+class RuntimeDependencyUnavailable(RuntimeError):
+    """A phase tried to cross a production seam it did not enable."""
+
+
+class MatchingKnowledgeUnavailable(ValueError):
+    """Durable matching knowledge could not be assembled safely."""
+
+
+class SpotifyAccess(str, Enum):
+    """Whether this already-authorized phase may construct Spotify access."""
+
+    DISABLED = "disabled"
+    REQUIRED = "required"
+
+
+@dataclass(frozen=True)
+class RuntimePaths:
+    """One coherent set of private application-data paths."""
+
+    matching_knowledge: Path
+    publication_state: Path
+
+    @classmethod
+    def defaults(cls) -> RuntimePaths:
+        return cls(
+            matching_knowledge=default_matching_knowledge_path(),
+            publication_state=default_publication_manifest_path(),
+        )
+
+    @classmethod
+    def selected(
+        cls,
+        matching_knowledge: str | Path,
+        publication_state: str | Path,
+    ) -> RuntimePaths:
+        return cls(Path(matching_knowledge), Path(publication_state))
+
+    @property
+    def transfer_state(self) -> Path:
+        return self.publication_state.with_suffix(".transfers.json")
+
+
+@dataclass(frozen=True)
+class RuntimeSettings:
+    """Policy-neutral facts selecting adapters for one active Transfer."""
+
+    paths: RuntimePaths
+    spotify_access: SpotifyAccess = SpotifyAccess.DISABLED
+    retain_matching_knowledge: bool = True
+    retain_publications: bool = True
+    local_audio_identity: bool = False
+    local_audio_audition: bool = False
+
+
+@dataclass(frozen=True)
+class RuntimeGraph:
+    """The assembled Transfer and its shared durable-state adapter."""
+
+    transfer: Transfer
+    transfer_storage: FileTransferStorage
+
+
+class _UnavailableSource:
+    source_label = "unavailable"
+    default_mode = TransferMode.SNAPSHOT
+
+    def consume(self, reference: str):
+        del reference
+        raise RuntimeDependencyUnavailable(
+            "Private source access is unavailable in this runtime phase"
+        )
+
+    def consume_batch(self, references, whole_library):
+        del references, whole_library
+        raise RuntimeDependencyUnavailable(
+            "Private source access is unavailable in this runtime phase"
+        )
+
+
+class _UnavailableSpotify:
+    def _unavailable(self, *args, **kwargs):
+        del args, kwargs
+        raise RuntimeDependencyUnavailable(
+            "Spotify access is unavailable in this runtime phase"
+        )
+
+    account_id = _unavailable
+    add_items = _unavailable
+    create_playlist = _unavailable
+    delete_playlist = _unavailable
+    delete_provisional_snapshot = _unavailable
+    find_recovery_playlist = _unavailable
+    match = _unavailable
+    ordered_playlist_items = _unavailable
+    playlist_head = _unavailable
+    provisional_playlist_track_uris = _unavailable
+    publish_provisional_snapshot = _unavailable
+    replace_items = _unavailable
+    replace_provisional_playlist_tracks = _unavailable
+    set_playlist_description = _unavailable
+    spotify_track = _unavailable
+
+
+def _production_spotify() -> SpotifyAdapter:
+    return SpotifyMatcher(get_client())
+
+
+class RuntimeAssembly:
+    """Assemble the production graph behind one private client seam."""
+
+    def __init__(
+        self,
+        spotify_factory: Callable[[], SpotifyAdapter] = _production_spotify,
+    ) -> None:
+        self._spotify_factory = spotify_factory
+        self._transfer_storages: dict[Path, FileTransferStorage] = {}
+
+    def capability_transfer(self) -> Transfer:
+        """Build a graph that inspects local capabilities and nothing private."""
+        return Transfer(
+            source=_UnavailableSource(),
+            spotify=_UnavailableSpotify(),
+            matching_knowledge=EphemeralMatchingKnowledge(),
+            publishing_guards=AccountPublishingGuards(),
+            local_audio=ChromaprintLocalAudio(),
+            local_audition=LocalSourceAudition(),
+        )
+
+    def assemble(
+        self,
+        source: SourceAdapter,
+        settings: RuntimeSettings,
+    ) -> RuntimeGraph:
+        """Build one active Transfer from explicit, policy-owned phase facts."""
+        matching_knowledge = self._matching_knowledge(settings)
+        transfer_storage = self.transfer_storage(settings.paths)
+        spotify = (
+            self._spotify_factory()
+            if settings.spotify_access == SpotifyAccess.REQUIRED
+            else _UnavailableSpotify()
+        )
+        transfer = Transfer(
+            source=source,
+            spotify=spotify,
+            matching_knowledge=matching_knowledge,
+            publishing_guards=AccountPublishingGuards(),
+            publication_storage=(
+                FilePublicationStorage(settings.paths.publication_state)
+                if settings.retain_publications else None
+            ),
+            transfer_storage=transfer_storage,
+            local_audio=(
+                ChromaprintLocalAudio()
+                if settings.local_audio_identity else None
+            ),
+            local_audition=(
+                LocalSourceAudition()
+                if settings.local_audio_audition else None
+            ),
+        )
+        return RuntimeGraph(transfer, transfer_storage)
+
+    def transfer_storage(self, paths: RuntimePaths) -> FileTransferStorage:
+        """Return the shared Transfer-state adapter for one path family."""
+        path = paths.transfer_state
+        if path not in self._transfer_storages:
+            self._transfer_storages[path] = FileTransferStorage(path)
+        return self._transfer_storages[path]
+
+    @staticmethod
+    def _matching_knowledge(settings: RuntimeSettings):
+        if not settings.retain_matching_knowledge:
+            return EphemeralMatchingKnowledge()
+        cache = MatchCache(settings.paths.matching_knowledge)
+        try:
+            cache.load()
+        except (OSError, ValueError) as exc:
+            raise MatchingKnowledgeUnavailable(str(exc)) from exc
+        return MatchCacheKnowledge(cache)

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -74,6 +74,7 @@ flowchart TB
         AGENT["agent.py"]
     end
 
+    RUNTIME["Private Runtime Assembly<br/>production construction"]
     INTERFACE["Transfer public interface"]
 
     subgraph TransferModule["transfer.py implementation"]
@@ -102,6 +103,9 @@ flowchart TB
     CLI --> INTERFACE
     WEB --> INTERFACE
     AGENT --> INTERFACE
+    CLI -. phase facts .-> RUNTIME
+    AGENT -. production graph .-> RUNTIME
+    RUNTIME -. assembles .-> INTERFACE
     INTERFACE --> PLAN
     INTERFACE --> MATCH
     INTERFACE --> PUBLISH
@@ -130,13 +134,17 @@ The boxes inside `transfer.py` are responsibilities hidden behind one public
 interface, not new public modules. They illustrate why Transfer is deep: the
 same policy pays back across three clients and synthetic high-level tests.
 This diagram intentionally omits individual methods, state fields, and report
-rendering.
+rendering. Runtime Assembly is a separate private construction seam: CLI and
+Agent Client paths provide explicit phase facts, while Transfer remains their
+only public policy interface. The web adapter retains its direct construction
+path.
 
 ### Production source map
 
 | Role | Owning source |
 | --- | --- |
 | Client adapters | [`cli.py`](../djsupport/cli.py), [`web.py`](../djsupport/web.py), and [`agent.py`](../djsupport/agent.py) |
+| CLI and Agent Client production assembly | [`runtime.py`](../djsupport/runtime.py) |
 | Rekordbox intake | [`rekordbox.py`](../djsupport/rekordbox.py) |
 | Beatport intake | [`beatport.py`](../djsupport/beatport.py) and [`label.py`](../djsupport/label.py) |
 | Spotify adapter and effects | [`SpotifyMatcher`](../djsupport/transfer.py) |

--- a/tests/test_agent_cli.py
+++ b/tests/test_agent_cli.py
@@ -175,7 +175,7 @@ def test_capabilities_json_does_not_require_xml_or_spotify(monkeypatch):
 
 def test_sync_json_requires_explicit_private_source_authorization(monkeypatch):
     monkeypatch.setattr(
-        "djsupport.cli.get_client",
+        "djsupport.runtime.get_client",
         lambda: (_ for _ in ()).throw(AssertionError("Spotify must stay untouched")),
     )
 
@@ -201,7 +201,7 @@ def test_authorized_publish_returns_bounded_plan_before_spotify_write_authority(
     monkeypatch, tmp_path,
 ):
     monkeypatch.setattr(
-        "djsupport.cli.get_client",
+        "djsupport.runtime.get_client",
         lambda: (_ for _ in ()).throw(AssertionError("Spotify must stay untouched")),
     )
 
@@ -273,9 +273,9 @@ def test_authorized_sync_json_returns_only_structured_outcome(
             }
 
     spotify = Spotify()
-    monkeypatch.setattr("djsupport.cli.get_client", lambda: object())
+    monkeypatch.setattr("djsupport.runtime.get_client", lambda: object())
     monkeypatch.setattr(
-        "djsupport.transfer.SpotifyMatcher", lambda client: spotify,
+        "djsupport.runtime.SpotifyMatcher", lambda client: spotify,
     )
 
     result = CliRunner().invoke(cli, [
@@ -322,9 +322,9 @@ def test_audition_intent_is_independent_and_compatible_with_no_cache(
                 "score": 95.0, "match_type": "exact",
             }
 
-    monkeypatch.setattr("djsupport.cli.get_client", lambda: object())
+    monkeypatch.setattr("djsupport.runtime.get_client", lambda: object())
     monkeypatch.setattr(
-        "djsupport.transfer.SpotifyMatcher", lambda client: Spotify(),
+        "djsupport.runtime.SpotifyMatcher", lambda client: Spotify(),
     )
 
     result = CliRunner().invoke(cli, [
@@ -390,7 +390,7 @@ def test_authorized_qualification_source_error_stays_structured_and_redacted(
 ):
     private_path = tmp_path / "owner-library-name.xml"
     monkeypatch.setattr(
-        "djsupport.cli.get_client",
+        "djsupport.runtime.get_client",
         lambda: (_ for _ in ()).throw(
             AssertionError("Spotify must stay untouched")
         ),

--- a/tests/test_beatport_export.py
+++ b/tests/test_beatport_export.py
@@ -250,7 +250,7 @@ def test_invalid_export_is_rejected_before_spotify_access(tmp_path, monkeypatch)
     invalid["track_count"] = 99
     export_path.write_text(json.dumps(invalid))
     monkeypatch.setattr(
-        "djsupport.cli.get_client",
+        "djsupport.runtime.get_client",
         lambda: (_ for _ in ()).throw(AssertionError("Spotify accessed")),
     )
 
@@ -434,8 +434,8 @@ def test_beatport_cli_selects_a_v2_file_without_passing_its_path_to_transfer(
                 source_label="Beatport",
             )
 
-    monkeypatch.setattr("djsupport.transfer.Transfer", CapturingTransfer)
-    monkeypatch.setattr("djsupport.cli.get_client", lambda: object())
+    monkeypatch.setattr("djsupport.runtime.Transfer", CapturingTransfer)
+    monkeypatch.setattr("djsupport.runtime.get_client", lambda: object())
     result = CliRunner().invoke(cli, [
         "beatport", "--export-file", str(export_path), "--dry-run",
     ])

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -1,0 +1,216 @@
+"""Production graph tests at the private Runtime Assembly interface."""
+
+import json
+
+import pytest
+
+from djsupport.agent import AgentTransferContract
+from djsupport.rekordbox import Track
+from djsupport.runtime import (
+    MatchingKnowledgeUnavailable,
+    RuntimeAssembly,
+    RuntimeDependencyUnavailable,
+    RuntimePaths,
+    RuntimeSettings,
+    SpotifyAccess,
+)
+from djsupport.transfer import (
+    BatchPlanRequest,
+    SourceSelection,
+    TransferMode,
+    TransferRequest,
+)
+
+
+class SyntheticSource:
+    source_label = "Synthetic"
+    default_mode = TransferMode.SNAPSHOT
+
+    def consume(self, reference):
+        return SourceSelection(
+            "Synthetic Selection",
+            reference,
+            [
+                Track(
+                    track_id="synthetic-1",
+                    artist="Synthetic Artist",
+                    name="Synthetic Track",
+                    album="Synthetic Release",
+                    remixer="",
+                    label="Synthetic Label",
+                    genre="Electronic",
+                    date_added="",
+                    duration=180,
+                )
+            ],
+        )
+
+
+class SyntheticSpotify:
+    def account_id(self):
+        return "synthetic-account"
+
+    def match(self, track, threshold):
+        del threshold
+        return {
+            "uri": "spotify:track:abcdefghijklmnopqrstuv",
+            "name": track.name,
+            "artist": track.artist,
+            "album": track.album,
+            "duration_ms": track.duration * 1000,
+            "score": 100.0,
+            "match_type": "exact",
+            "score_reasons": [],
+        }
+
+    def publish_provisional_snapshot(
+        self, name, track_uris, description, publication_key,
+    ):
+        del name, track_uris, description, publication_key
+        return "synthetic-playlist"
+
+
+def selected_paths(tmp_path):
+    return RuntimePaths.selected(
+        tmp_path / "matching-knowledge.json",
+        tmp_path / "publication-manifests.json",
+    )
+
+
+class TestRuntimeAssembly:
+    def test_capability_graph_never_constructs_spotify_or_reads_a_source(self):
+        def forbidden_spotify():
+            raise AssertionError("Spotify must stay untouched")
+
+        transfer = RuntimeAssembly(
+            spotify_factory=forbidden_spotify,
+        ).capability_transfer()
+
+        document = AgentTransferContract(transfer).capabilities()
+
+        assert document["phase"] == "capability"
+        assert (
+            document["capabilities"]["local_audio_audition"]["available"]
+            is True
+        )
+        with pytest.raises(
+            RuntimeDependencyUnavailable,
+            match="Private source access is unavailable",
+        ):
+            transfer.plan_batch(BatchPlanRequest(
+                playlist_references=("private-selection",), preview=True,
+            ))
+
+    def test_disabled_spotify_fails_without_constructing_the_adapter(
+        self, tmp_path,
+    ):
+        def forbidden_spotify():
+            raise AssertionError("Spotify must stay untouched")
+
+        graph = RuntimeAssembly(spotify_factory=forbidden_spotify).assemble(
+            SyntheticSource(),
+            RuntimeSettings(
+                paths=selected_paths(tmp_path),
+                spotify_access=SpotifyAccess.DISABLED,
+                retain_matching_knowledge=False,
+                retain_publications=False,
+            ),
+        )
+
+        with pytest.raises(
+            RuntimeDependencyUnavailable,
+            match="Spotify access is unavailable",
+        ):
+            graph.transfer.execute(TransferRequest(
+                source="synthetic-selection", preview=True,
+            ))
+
+    def test_active_graph_preserves_json_paths_and_storage_formats(
+        self, tmp_path,
+    ):
+        paths = selected_paths(tmp_path)
+        assembly = RuntimeAssembly(spotify_factory=SyntheticSpotify)
+        graph = assembly.assemble(
+            SyntheticSource(),
+            RuntimeSettings(
+                paths=paths,
+                spotify_access=SpotifyAccess.REQUIRED,
+            ),
+        )
+
+        report = graph.transfer.execute(TransferRequest(
+            source="synthetic-selection",
+        ))
+
+        assert report.total_matched == 1
+        assert graph.transfer_storage.path == paths.transfer_state
+        assert assembly.transfer_storage(paths) is graph.transfer_storage
+        assert json.loads(paths.matching_knowledge.read_text())["version"] == 3
+        assert json.loads(paths.publication_state.read_text())["version"] == 7
+        assert json.loads(paths.transfer_state.read_text())["version"] == 6
+
+    def test_ephemeral_preview_omits_knowledge_and_publication_files(
+        self, tmp_path,
+    ):
+        paths = selected_paths(tmp_path)
+        graph = RuntimeAssembly(spotify_factory=SyntheticSpotify).assemble(
+            SyntheticSource(),
+            RuntimeSettings(
+                paths=paths,
+                spotify_access=SpotifyAccess.REQUIRED,
+                retain_matching_knowledge=False,
+                retain_publications=False,
+            ),
+        )
+
+        report = graph.transfer.execute(TransferRequest(
+            source="synthetic-selection",
+            preview=True,
+            retain_matching_knowledge=False,
+        ))
+
+        assert report.total_matched == 1
+        assert not paths.matching_knowledge.exists()
+        assert not paths.publication_state.exists()
+        assert paths.transfer_state.exists()
+
+    def test_local_audio_adapters_follow_only_explicit_facts(
+        self, monkeypatch, tmp_path,
+    ):
+        monkeypatch.setattr(
+            "djsupport.local_audio.shutil.which", lambda name: None,
+        )
+        paths = selected_paths(tmp_path)
+
+        disabled = RuntimeAssembly().assemble(
+            SyntheticSource(),
+            RuntimeSettings(
+                paths=paths,
+                retain_matching_knowledge=False,
+                retain_publications=False,
+            ),
+        ).transfer
+        enabled = RuntimeAssembly().assemble(
+            SyntheticSource(),
+            RuntimeSettings(
+                paths=paths,
+                retain_matching_knowledge=False,
+                retain_publications=False,
+                local_audio_identity=True,
+                local_audio_audition=True,
+            ),
+        ).transfer
+
+        assert disabled.local_audio_capability().reason == "not_configured"
+        assert disabled.local_audition_capability().reason == "not_configured"
+        assert enabled.local_audio_capability().reason == "binary_unavailable"
+        assert enabled.local_audition_capability().available is True
+
+    def test_unsupported_knowledge_schema_has_a_runtime_error(self, tmp_path):
+        paths = selected_paths(tmp_path)
+        paths.matching_knowledge.write_text('{"version": 999}')
+
+        with pytest.raises(MatchingKnowledgeUnavailable):
+            RuntimeAssembly().assemble(
+                SyntheticSource(), RuntimeSettings(paths=paths),
+            )

--- a/tests/test_transfer.py
+++ b/tests/test_transfer.py
@@ -3429,7 +3429,7 @@ class TestSpotifyApprovalAdapter:
 class TestBeatportCliTransfer:
 
     @patch("djsupport.transfer.Transfer.execute")
-    @patch("djsupport.cli.get_client", return_value=MagicMock())
+    @patch("djsupport.runtime.get_client", return_value=MagicMock())
     def test_cli_beatport_dry_run_enters_transfer_interface(
         self, mock_client, execute,
     ):
@@ -3451,7 +3451,7 @@ class TestBeatportCliTransfer:
 
 
     @patch("djsupport.transfer.Transfer.execute")
-    @patch("djsupport.cli.get_client", return_value=MagicMock())
+    @patch("djsupport.runtime.get_client", return_value=MagicMock())
     def test_cli_beatport_publish_enters_transfer_interface(
         self, mock_client, execute, tmp_path,
     ):
@@ -3477,7 +3477,7 @@ class TestBeatportCliTransfer:
         assert request.mode == TransferMode.SNAPSHOT
 
     @patch("djsupport.transfer.Transfer.execute")
-    @patch("djsupport.cli.get_client", return_value=MagicMock())
+    @patch("djsupport.runtime.get_client", return_value=MagicMock())
     def test_cli_beatport_can_explicitly_choose_mirror(
         self, mock_client, execute, tmp_path,
     ):
@@ -3496,7 +3496,7 @@ class TestBeatportCliTransfer:
         assert execute.call_args.args[0].mode == TransferMode.MIRROR
 
     @patch("djsupport.transfer.Transfer.execute")
-    @patch("djsupport.cli.get_client", return_value=MagicMock())
+    @patch("djsupport.runtime.get_client", return_value=MagicMock())
     def test_cli_label_defaults_to_snapshot_through_transfer(
         self, mock_client, execute, tmp_path,
     ):
@@ -3518,7 +3518,7 @@ class TestBeatportCliTransfer:
 
     @patch("djsupport.transfer.FileTransferStorage.load_transfer")
     @patch("djsupport.transfer.Transfer.execute")
-    @patch("djsupport.cli.get_client", return_value=MagicMock())
+    @patch("djsupport.runtime.get_client", return_value=MagicMock())
     def test_cli_can_resume_a_visible_transfer_id(
         self, mock_client, execute, load_transfer, tmp_path,
     ):
@@ -3539,7 +3539,7 @@ class TestBeatportCliTransfer:
         assert execute.call_args.args[0].transfer_id == "resume-me"
 
     @patch("djsupport.transfer.Transfer.abandon")
-    @patch("djsupport.cli.get_client", return_value=MagicMock())
+    @patch("djsupport.runtime.get_client", return_value=MagicMock())
     def test_cli_can_explicitly_abandon_a_transfer(
         self, mock_client, abandon, tmp_path,
     ):
@@ -3553,8 +3553,8 @@ class TestBeatportCliTransfer:
         assert "Transfer stop-me abandoned" in result.output
 
     @patch("djsupport.transfer.Transfer.approve")
-    @patch("djsupport.transfer.FileTransferStorage")
-    @patch("djsupport.cli.get_client", return_value=MagicMock())
+    @patch("djsupport.runtime.FileTransferStorage")
+    @patch("djsupport.runtime.get_client", return_value=MagicMock())
     def test_cli_approves_one_provisional_playlist(
         self, mock_client, transfer_storage, approve, tmp_path,
     ):
@@ -3574,13 +3574,13 @@ class TestBeatportCliTransfer:
         assert result.exit_code == 0, result.output
         approve.assert_called_once_with("snapshot-1")
         transfer_storage.assert_called_once_with(
-            str((tmp_path / "state.json").with_suffix(".transfers.json"))
+            (tmp_path / "state.json").with_suffix(".transfers.json")
         )
         assert "1 approved" in result.output
         assert "2 rejected" in result.output
 
     @patch("djsupport.transfer.Transfer.approve")
-    @patch("djsupport.cli.get_client", return_value=MagicMock())
+    @patch("djsupport.runtime.get_client", return_value=MagicMock())
     def test_cli_applies_an_edited_review_csv(
         self, mock_client, approve, tmp_path,
     ):
@@ -3605,10 +3605,10 @@ class TestBeatportCliTransfer:
 class TestRekordboxCliTransfer:
     @patch("djsupport.transfer.Transfer.execute_batch")
     @patch("djsupport.transfer.Transfer.plan_batch")
-    @patch("djsupport.transfer.FileTransferStorage")
-    @patch("djsupport.transfer.FilePublicationStorage")
-    @patch("djsupport.cache.MatchCache")
-    @patch("djsupport.cli.get_client", return_value=MagicMock())
+    @patch("djsupport.runtime.FileTransferStorage")
+    @patch("djsupport.runtime.FilePublicationStorage")
+    @patch("djsupport.runtime.MatchCache")
+    @patch("djsupport.runtime.get_client", return_value=MagicMock())
     def test_cli_defaults_to_shared_application_data_storage(
         self, mock_client, match_cache, publication_storage, transfer_storage,
         plan_batch, execute_batch,
@@ -3629,19 +3629,19 @@ class TestRekordboxCliTransfer:
         ])
 
         assert result.exit_code == 0, result.output
-        match_cache.assert_called_once_with(DEFAULT_MATCHING_KNOWLEDGE_PATH)
+        match_cache.assert_called_once_with(Path(DEFAULT_MATCHING_KNOWLEDGE_PATH))
         publication_storage.assert_called_once_with(
-            DEFAULT_PUBLICATION_MANIFEST_PATH
+            Path(DEFAULT_PUBLICATION_MANIFEST_PATH)
         )
         transfer_storage.assert_called_once_with(
-            str(Path(DEFAULT_PUBLICATION_MANIFEST_PATH).with_suffix(
+            Path(DEFAULT_PUBLICATION_MANIFEST_PATH).with_suffix(
                 ".transfers.json"
-            ))
+            )
         )
 
     @patch("djsupport.transfer.Transfer.execute_batch")
     @patch("djsupport.transfer.Transfer.plan_batch")
-    @patch("djsupport.cli.get_client", return_value=MagicMock())
+    @patch("djsupport.runtime.get_client", return_value=MagicMock())
     def test_cli_selected_playlist_enters_transfer_batch(
         self, mock_client, plan_batch, execute_batch, tmp_path,
     ):
@@ -3667,7 +3667,7 @@ class TestRekordboxCliTransfer:
 
     @patch("djsupport.transfer.Transfer.execute_batch")
     @patch("djsupport.transfer.Transfer.plan_batch")
-    @patch("djsupport.cli.get_client", return_value=MagicMock())
+    @patch("djsupport.runtime.get_client", return_value=MagicMock())
     def test_cli_preview_is_owned_by_transfer_batch(
         self, mock_client, plan_batch, execute_batch, tmp_path,
     ):


### PR DESCRIPTION
Closes #135

## Summary

- add one private `RuntimeAssembly` seam for production paths, matching knowledge, JSON stores, Spotify gating, publishing guards, and optional local-audio adapters
- migrate all seven CLI and CLI-hosted Agent Client construction paths while leaving web construction for #137
- replace ambiguous `object()` placeholders in migrated paths with explicit fail-fast unavailable adapters
- document the new construction seam and add focused production-graph tests

## Why

Production graph construction was repeated across client call sites. The new module concentrates that implementation while `Transfer` remains the sole public policy interface.

## Impact

No user-visible behavior, JSON schema, application-data path, authority, migration, or live-service behavior changes. A patch-level `Changed` release record transparently documents the behavior-preserving internal refactor required by the repository’s distributable-change gate.

## Validation

- `pytest` — 751 passed
- `python3 -m compileall -q djsupport tests`
- `git diff --check`
- `python3 scripts/release_records.py check 2a39acf7ad43629cda25854a5b94604c73bcceba HEAD`
- focused Runtime Assembly, Agent/privacy, Transfer, and documentation suites
- independent Standards review — 0 findings
- independent Spec review — pass