### PR TITLE
Move web construction behind Runtime Assembly

### DIFF
--- a/.claude/docs/architectural_patterns.md
+++ b/.claude/docs/architectural_patterns.md
@@ -46,15 +46,15 @@ constructor, or function parameters—never global singletons.
 - `match_track_cached(sp, track, cache, ...)` — receives both `sp` and `cache`
 - `RuntimeAssembly` receives an injectable Spotify-adapter factory and selects
   paths, matching knowledge, persistence, guards, and local-audio adapters.
-- CLI and Agent Client paths provide source and authorized phase facts to
-  Runtime Assembly; the web adapter retains its direct construction seam.
+- CLI, web, and Agent Client paths provide source and authorized phase facts to
+  Runtime Assembly.
 
 Files:
 - `matcher.py:154` — `match_track(sp, track, threshold)`
 - `matcher.py:225-228` — `match_track_cached(sp, track, cache, ...)`
 - `spotify.py:106-113` — `create_or_update_playlist(sp, ..., state_manager=None)`
 - `spotify.py:176-183` — `incremental_update_playlist(sp, ..., state_manager=None)`
-- `runtime.py` — private production graph assembly for CLI and Agent Clients
+- `runtime.py` — private production graph assembly for all Transfer clients
 
 ## Error handling
 

--- a/.release-notes/runtime-assembly.md
+++ b/.release-notes/runtime-assembly.md
@@ -3,4 +3,4 @@ bump: patch
 section: Changed
 ---
 
-Keep CLI, web, and Agent Client production wiring consistent through one private Runtime Assembly without changing Transfer behavior or local storage formats.
+Keep CLI and Agent Client production wiring consistent through one private Runtime Assembly without changing Transfer behavior or local storage formats.

--- a/.release-notes/runtime-assembly.md
+++ b/.release-notes/runtime-assembly.md
@@ -3,4 +3,4 @@ bump: patch
 section: Changed
 ---
 
-Keep CLI and Agent Client production wiring consistent through one private Runtime Assembly without changing Transfer behavior or local storage formats.
+Keep CLI, web, and Agent Client production wiring consistent through one private Runtime Assembly without changing Transfer behavior or local storage formats.

--- a/.release-notes/web-runtime-assembly.md
+++ b/.release-notes/web-runtime-assembly.md
@@ -1,0 +1,6 @@
+---
+bump: patch
+section: Changed
+---
+
+Keep web, CLI, and Agent Client flows on one production runtime path, including fresh Transfer state when multiple clients use the same private store.

--- a/djsupport/runtime.py
+++ b/djsupport/runtime.py
@@ -212,6 +212,8 @@ class RuntimeAssembly:
         path = paths.transfer_state
         if path not in self._transfer_storages:
             self._transfer_storages[path] = FileTransferStorage(path)
+        else:
+            self._transfer_storages[path].refresh()
         return self._transfer_storages[path]
 
     @staticmethod

--- a/djsupport/runtime.py
+++ b/djsupport/runtime.py
@@ -78,7 +78,7 @@ class RuntimePaths:
 class RuntimeSettings:
     """Policy-neutral facts selecting adapters for one active Transfer."""
 
-    paths: RuntimePaths
+    paths: RuntimePaths | None = None
     spotify_access: SpotifyAccess = SpotifyAccess.DISABLED
     retain_matching_knowledge: bool = True
     retain_publications: bool = True
@@ -145,9 +145,18 @@ class RuntimeAssembly:
     def __init__(
         self,
         spotify_factory: Callable[[], SpotifyAdapter] = _production_spotify,
+        default_paths: RuntimePaths | None = None,
+        local_audition: LocalSourceAudition | None = None,
     ) -> None:
         self._spotify_factory = spotify_factory
+        self._default_paths = default_paths or RuntimePaths.defaults()
+        self._local_audition = local_audition or LocalSourceAudition()
         self._transfer_storages: dict[Path, FileTransferStorage] = {}
+
+    @property
+    def local_audition(self) -> LocalSourceAudition:
+        """Return the process-local audition adapter shared by clients."""
+        return self._local_audition
 
     def capability_transfer(self) -> Transfer:
         """Build a graph that inspects local capabilities and nothing private."""
@@ -157,7 +166,7 @@ class RuntimeAssembly:
             matching_knowledge=EphemeralMatchingKnowledge(),
             publishing_guards=AccountPublishingGuards(),
             local_audio=ChromaprintLocalAudio(),
-            local_audition=LocalSourceAudition(),
+            local_audition=self._local_audition,
         )
 
     def assemble(
@@ -166,8 +175,9 @@ class RuntimeAssembly:
         settings: RuntimeSettings,
     ) -> RuntimeGraph:
         """Build one active Transfer from explicit, policy-owned phase facts."""
-        matching_knowledge = self._matching_knowledge(settings)
-        transfer_storage = self.transfer_storage(settings.paths)
+        paths = settings.paths or self._default_paths
+        matching_knowledge = self._matching_knowledge(settings, paths)
+        transfer_storage = self.transfer_storage(paths)
         spotify = (
             self._spotify_factory()
             if settings.spotify_access == SpotifyAccess.REQUIRED
@@ -179,7 +189,7 @@ class RuntimeAssembly:
             matching_knowledge=matching_knowledge,
             publishing_guards=AccountPublishingGuards(),
             publication_storage=(
-                FilePublicationStorage(settings.paths.publication_state)
+                FilePublicationStorage(paths.publication_state)
                 if settings.retain_publications else None
             ),
             transfer_storage=transfer_storage,
@@ -188,24 +198,29 @@ class RuntimeAssembly:
                 if settings.local_audio_identity else None
             ),
             local_audition=(
-                LocalSourceAudition()
+                self._local_audition
                 if settings.local_audio_audition else None
             ),
         )
         return RuntimeGraph(transfer, transfer_storage)
 
-    def transfer_storage(self, paths: RuntimePaths) -> FileTransferStorage:
+    def transfer_storage(
+        self, paths: RuntimePaths | None = None,
+    ) -> FileTransferStorage:
         """Return the shared Transfer-state adapter for one path family."""
+        paths = paths or self._default_paths
         path = paths.transfer_state
         if path not in self._transfer_storages:
             self._transfer_storages[path] = FileTransferStorage(path)
         return self._transfer_storages[path]
 
     @staticmethod
-    def _matching_knowledge(settings: RuntimeSettings):
+    def _matching_knowledge(
+        settings: RuntimeSettings, paths: RuntimePaths,
+    ):
         if not settings.retain_matching_knowledge:
             return EphemeralMatchingKnowledge()
-        cache = MatchCache(settings.paths.matching_knowledge)
+        cache = MatchCache(paths.matching_knowledge)
         try:
             cache.load()
         except (OSError, ValueError) as exc:

--- a/djsupport/web.py
+++ b/djsupport/web.py
@@ -32,6 +32,7 @@ from djsupport.readiness import (
     FirstTransferReadiness,
     inspect_first_transfer_readiness,
 )
+from djsupport.runtime import RuntimeAssembly, RuntimeSettings, SpotifyAccess
 from djsupport.spotify import SCOPES
 from djsupport.local_audition import (
     AuditionHandleUnavailable,
@@ -39,27 +40,19 @@ from djsupport.local_audition import (
     LocalSourceAudition,
 )
 from djsupport.transfer import (
-    AccountPublishingGuards,
     BatchPlanRequest,
     BeatportChartSource,
     BeatportLabelSource,
-    EphemeralMatchingKnowledge,
-    FilePublicationStorage,
-    FileTransferStorage,
-    MatchCacheKnowledge,
     QualificationDecision,
     QualificationRequest,
     QualificationView,
     RekordboxPlaylistSource,
     SpotifyPlaylistChanged,
     SpotifyPlaylistReviewRequired,
-    SpotifyMatcher,
     Transfer,
     TransferAuthorization,
     TransferMode,
     TransferRequest,
-    default_matching_knowledge_path,
-    default_publication_manifest_path,
 )
 
 logger = logging.getLogger(__name__)
@@ -198,80 +191,13 @@ def _url_error() -> str:
     )
 
 
-def _default_transfer_factory(url_type: str, request: SyncRequest) -> Transfer:
-    from djsupport.cache import MatchCache
-    from djsupport.spotify import get_client
-
-    cache = None if request.no_cache else MatchCache(default_matching_knowledge_path())
-    if cache is not None:
-        cache.load()
-    publication_path = default_publication_manifest_path()
-    return Transfer(
-        source=(BeatportChartSource() if url_type == "chart" else BeatportLabelSource()),
-        spotify=SpotifyMatcher(get_client()),
-        publishing_guards=AccountPublishingGuards(),
-        matching_knowledge=(
-            EphemeralMatchingKnowledge() if cache is None else MatchCacheKnowledge(cache)
-        ),
-        publication_storage=(
-            None if request.dry_run else FilePublicationStorage(publication_path)
-        ),
-        transfer_storage=FileTransferStorage(
-            publication_path.with_suffix(".transfers.json")
-        ),
-    )
-
-
-def _default_rekordbox_transfer_factory(
-    request: RekordboxBatchRequest, execute_authorized: bool,
-    *, local_audition: LocalSourceAudition | None = None,
-) -> Transfer:
-    from djsupport.cache import MatchCache
-    from djsupport.local_audio import ChromaprintLocalAudio
-    from djsupport.spotify import get_client
-
-    cache = None if request.no_cache else MatchCache(
-        default_matching_knowledge_path(),
-    )
-    if cache is not None:
-        cache.load()
-    publication_path = default_publication_manifest_path()
-    return Transfer(
-        source=RekordboxPlaylistSource(
-            request.xml_path,
-            include_locations=(
-                request.local_audio_identity or request.local_audio_audition
-            ),
-        ),
-        spotify=(
-            SpotifyMatcher(get_client()) if execute_authorized else object()
-        ),
-        publishing_guards=AccountPublishingGuards(),
-        matching_knowledge=(
-            EphemeralMatchingKnowledge()
-            if cache is None else MatchCacheKnowledge(cache)
-        ),
-        publication_storage=(
-            None if request.preview else FilePublicationStorage(publication_path)
-        ),
-        transfer_storage=FileTransferStorage(
-            publication_path.with_suffix(".transfers.json")
-        ),
-        local_audio=(
-            ChromaprintLocalAudio() if request.local_audio_identity else None
-        ),
-        local_audition=(
-            local_audition if request.local_audio_audition else None
-        ),
-    )
-
-
 def _thread_runner(target: Callable, args: tuple) -> None:
     threading.Thread(target=target, args=args, daemon=True).start()
 
 
 def create_app(
     *,
+    runtime_assembly: RuntimeAssembly | None = None,
     transfer_factory: Callable[[str, SyncRequest], Transfer] | None = None,
     rekordbox_transfer_factory: Callable[
         [RekordboxBatchRequest, bool], Transfer
@@ -286,14 +212,47 @@ def create_app(
     """Create the web adapter with replaceable external-boundary wiring."""
     web_app = FastAPI(title="djsupport", lifespan=lifespan)
     web_app.mount("/static", StaticFiles(directory=str(STATIC_DIR)), name="static")
-    make_transfer = transfer_factory or _default_transfer_factory
-    audition = local_audition or LocalSourceAudition()
+    assembly = runtime_assembly or RuntimeAssembly(
+        local_audition=local_audition,
+    )
+    if transfer_factory is None:
+        def make_transfer(url_type, request):
+            return assembly.assemble(
+                (
+                    BeatportChartSource()
+                    if url_type == "chart" else BeatportLabelSource()
+                ),
+                RuntimeSettings(
+                    spotify_access=SpotifyAccess.REQUIRED,
+                    retain_matching_knowledge=not request.no_cache,
+                    retain_publications=not request.dry_run,
+                ),
+            ).transfer
+    else:
+        make_transfer = transfer_factory
+    audition = assembly.local_audition
     uses_default_rekordbox_wiring = rekordbox_transfer_factory is None
     if rekordbox_transfer_factory is None:
         def make_rekordbox_transfer(request, execute_authorized):
-            return _default_rekordbox_transfer_factory(
-                request, execute_authorized, local_audition=audition,
-            )
+            return assembly.assemble(
+                RekordboxPlaylistSource(
+                    request.xml_path,
+                    include_locations=(
+                        request.local_audio_identity
+                        or request.local_audio_audition
+                    ),
+                ),
+                RuntimeSettings(
+                    spotify_access=(
+                        SpotifyAccess.REQUIRED
+                        if execute_authorized else SpotifyAccess.DISABLED
+                    ),
+                    retain_matching_knowledge=not request.no_cache,
+                    retain_publications=not request.preview,
+                    local_audio_identity=request.local_audio_identity,
+                    local_audio_audition=request.local_audio_audition,
+                ),
+            ).transfer
     else:
         make_rekordbox_transfer = rekordbox_transfer_factory
     run_background = background_runner or _thread_runner
@@ -408,10 +367,11 @@ def create_app(
     @web_app.get("/capabilities")
     def capabilities():
         from djsupport.agent import capability_document
-        from djsupport.local_audio import ChromaprintLocalAudio
 
+        transfer = assembly.capability_transfer()
         return capability_document(
-            ChromaprintLocalAudio().capability(), audition.capability(),
+            transfer.local_audio_capability(),
+            transfer.local_audition_capability(),
         )
 
     @web_app.get("/auth/status")
@@ -552,7 +512,6 @@ def create_app(
             FirstTransferGuideRequest,
             error_document,
         )
-        from djsupport.local_audio import ChromaprintLocalAudio
 
         readiness = inspect_readiness(
             request.xml_path, request.authorize_private_source,
@@ -585,13 +544,7 @@ def create_app(
         )
         try:
             if uses_default_rekordbox_wiring and not activate:
-                transfer = Transfer(
-                    source=object(),
-                    spotify=object(),
-                    matching_knowledge=EphemeralMatchingKnowledge(),
-                    publishing_guards=AccountPublishingGuards(),
-                    local_audio=ChromaprintLocalAudio(),
-                )
+                transfer = assembly.capability_transfer()
             else:
                 transfer = make_rekordbox_transfer(
                     adapter_request, spotify_access,
@@ -631,10 +584,7 @@ def create_app(
             return None
         from djsupport.config import ConfigManager
 
-        publication_path = default_publication_manifest_path()
-        storage = FileTransferStorage(
-            publication_path.with_suffix(".transfers.json")
-        )
+        storage = assembly.transfer_storage()
         draft = storage.load_qualification(draft_id)
         if draft is None:
             return None
@@ -666,10 +616,7 @@ def create_app(
         """Derive adapter wiring from durable Transfer intent, not web input."""
         if not uses_default_rekordbox_wiring:
             return request
-        publication_path = default_publication_manifest_path()
-        storage = FileTransferStorage(
-            publication_path.with_suffix(".transfers.json")
-        )
+        storage = assembly.transfer_storage()
         batch = storage.load_batch(request.transfer_id)
         transfer_id = request.transfer_id
         if batch is not None:
@@ -705,10 +652,7 @@ def create_app(
             context = qualification_contexts.get(draft_id)
         if context is None:
             if uses_default_rekordbox_wiring:
-                publication_path = default_publication_manifest_path()
-                storage = FileTransferStorage(
-                    publication_path.with_suffix(".transfers.json")
-                )
+                storage = assembly.transfer_storage()
                 if storage.load_qualification(draft_id) is not None:
                     raise HTTPException(
                         status_code=409,

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -104,7 +104,8 @@ flowchart TB
     WEB --> INTERFACE
     AGENT --> INTERFACE
     CLI -. phase facts .-> RUNTIME
-    AGENT -. production graph .-> RUNTIME
+    WEB -. phase facts .-> RUNTIME
+    AGENT -. phase facts .-> RUNTIME
     RUNTIME -. assembles .-> INTERFACE
     INTERFACE --> PLAN
     INTERFACE --> MATCH
@@ -134,17 +135,16 @@ The boxes inside `transfer.py` are responsibilities hidden behind one public
 interface, not new public modules. They illustrate why Transfer is deep: the
 same policy pays back across three clients and synthetic high-level tests.
 This diagram intentionally omits individual methods, state fields, and report
-rendering. Runtime Assembly is a separate private construction seam: CLI and
-Agent Client paths provide explicit phase facts, while Transfer remains their
-only public policy interface. The web adapter retains its direct construction
-path.
+rendering. Runtime Assembly is a separate private construction seam: CLI, web,
+and Agent Client paths provide explicit phase facts, while Transfer remains
+their only public policy interface.
 
 ### Production source map
 
 | Role | Owning source |
 | --- | --- |
 | Client adapters | [`cli.py`](../djsupport/cli.py), [`web.py`](../djsupport/web.py), and [`agent.py`](../djsupport/agent.py) |
-| CLI and Agent Client production assembly | [`runtime.py`](../djsupport/runtime.py) |
+| Client production assembly | [`runtime.py`](../djsupport/runtime.py) |
 | Rekordbox intake | [`rekordbox.py`](../djsupport/rekordbox.py) |
 | Beatport intake | [`beatport.py`](../djsupport/beatport.py) and [`label.py`](../djsupport/label.py) |
 | Spotify adapter and effects | [`SpotifyMatcher`](../djsupport/transfer.py) |

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -111,6 +111,29 @@ class TestRuntimeAssembly:
         assert storage.path == paths.transfer_state
         assert assembly.transfer_storage() is storage
 
+    def test_shared_transfer_storage_refreshes_after_an_external_write(
+        self, tmp_path,
+    ):
+        paths = selected_paths(tmp_path)
+        reader = RuntimeAssembly(default_paths=paths)
+        cached = reader.transfer_storage()
+        writer = RuntimeAssembly(
+            spotify_factory=SyntheticSpotify,
+            default_paths=paths,
+        ).assemble(
+            SyntheticSource(),
+            RuntimeSettings(spotify_access=SpotifyAccess.REQUIRED),
+        )
+
+        report = writer.transfer.execute(TransferRequest(
+            source="synthetic-selection",
+        ))
+
+        assert cached.load_transfer(report.transfer_id) is None
+        current = reader.transfer_storage()
+        assert current is cached
+        assert current.load_transfer(report.transfer_id) is not None
+
     def test_capability_graph_never_constructs_spotify_or_reads_a_source(self):
         def forbidden_spotify():
             raise AssertionError("Spotify must stay untouched")

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -78,6 +78,39 @@ def selected_paths(tmp_path):
 
 
 class TestRuntimeAssembly:
+    def test_clients_can_use_one_assembly_owned_default_path_family(
+        self, tmp_path,
+    ):
+        paths = selected_paths(tmp_path)
+        assembly = RuntimeAssembly(
+            spotify_factory=SyntheticSpotify,
+            default_paths=paths,
+        )
+
+        graph = assembly.assemble(
+            SyntheticSource(),
+            RuntimeSettings(spotify_access=SpotifyAccess.REQUIRED),
+        )
+        report = graph.transfer.execute(TransferRequest(
+            source="synthetic-selection",
+        ))
+
+        assert report.total_matched == 1
+        assert graph.transfer_storage.path == paths.transfer_state
+        assert paths.matching_knowledge.exists()
+        assert paths.publication_state.exists()
+
+    def test_clients_share_the_assembly_owned_default_transfer_storage(
+        self, tmp_path,
+    ):
+        paths = selected_paths(tmp_path)
+        assembly = RuntimeAssembly(default_paths=paths)
+
+        storage = assembly.transfer_storage()
+
+        assert storage.path == paths.transfer_state
+        assert assembly.transfer_storage() is storage
+
     def test_capability_graph_never_constructs_spotify_or_reads_a_source(self):
         def forbidden_spotify():
             raise AssertionError("Spotify must stay untouched")

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -13,6 +13,12 @@ from djsupport.report import PlaylistReport, SyncReport
 from djsupport.readiness import FirstTransferReadiness
 from djsupport.rekordbox import Track
 from djsupport.local_audition import LocalSourceAudition
+from djsupport.runtime import (
+    RuntimeAssembly,
+    RuntimeGraph,
+    RuntimePaths,
+    SpotifyAccess,
+)
 from djsupport.transfer import (
     AccountPublishingGuards,
     BatchPlan,
@@ -116,6 +122,34 @@ def test_first_transfer_web_route_ignores_caller_asserted_readiness():
     transfer.assert_not_called()
 
 
+def test_default_first_transfer_uses_the_runtime_capability_graph(tmp_path):
+    delegate = RuntimeAssembly(default_paths=RuntimePaths.selected(
+        tmp_path / "matching-knowledge.json",
+        tmp_path / "publication-manifests.json",
+    ))
+    capability_calls = []
+
+    class SyntheticRuntimeAssembly:
+        local_audition = delegate.local_audition
+
+        def capability_transfer(self):
+            capability_calls.append(True)
+            return delegate.capability_transfer()
+
+    web = create_app(
+        runtime_assembly=SyntheticRuntimeAssembly(),
+        first_transfer_readiness=lambda path, authorized: FirstTransferReadiness(
+            False, False, False, False, None,
+        ),
+    )
+
+    response = TestClient(web).post("/rekordbox/first-transfer", json={})
+
+    assert response.status_code == 200
+    assert response.json()["next_action"] == "configure_spotify"
+    assert capability_calls == [True]
+
+
 def test_first_transfer_web_route_forwards_only_explicit_authority():
     transfer = MagicMock()
     transfer.authorization_requirement.side_effect = (
@@ -213,6 +247,80 @@ def test_rekordbox_web_plan_exposes_explicit_local_audio_opt_in_without_spotify(
     assert factory_calls[0][0].local_audio_identity is True
     assert factory_calls[0][1] is False
     assert "synthetic-library" not in response.text
+
+
+def test_default_rekordbox_web_plan_crosses_the_runtime_assembly_seam():
+    plan = BatchPlan((PlaylistPreflight(
+        name="Synthetic Selection",
+        reference="Synthetic/Selection",
+        total_tracks=1,
+        approved_match_hits=0,
+        cache_hits=0,
+        expected_uncached_lookups=1,
+        selection_token="opaque-selection-token",
+    ),), preview=True)
+    calls = []
+
+    class SyntheticRuntimeAssembly:
+        local_audition = LocalSourceAudition()
+
+        def assemble(self, source, settings):
+            calls.append((source, settings))
+            return RuntimeGraph(_agent_web_transfer(plan), MagicMock())
+
+    web = create_app(runtime_assembly=SyntheticRuntimeAssembly())
+    response = TestClient(web).post("/rekordbox/batches/plan", json={
+        "xml_path": "/private/does-not-exist.xml",
+        "playlists": ["Synthetic/Selection"],
+        "preview": True,
+        "no_cache": True,
+        "authorize_private_source": True,
+    })
+
+    assert response.status_code == 200
+    assert response.json()["phase"] == "plan"
+    assert response.json()["counts"]["playlists"] == 1
+    source, settings = calls[0]
+    assert source.source_label == "Rekordbox"
+    assert settings.spotify_access == SpotifyAccess.DISABLED
+    assert settings.retain_matching_knowledge is False
+    assert settings.retain_publications is False
+    assert "does-not-exist" not in response.text
+
+
+def test_default_beatport_web_start_crosses_the_runtime_assembly_seam():
+    transfer = MagicMock()
+    calls = []
+
+    class SyntheticRuntimeAssembly:
+        local_audition = LocalSourceAudition()
+
+        def assemble(self, source, settings):
+            calls.append((source, settings))
+            return RuntimeGraph(transfer, MagicMock())
+
+    manager = MagicMock()
+    manager.get_cached_token.return_value = {"access_token": "synthetic"}
+    manager.is_token_expired.return_value = False
+    web = create_app(
+        runtime_assembly=SyntheticRuntimeAssembly(),
+        auth_manager=lambda: manager,
+        background_runner=lambda target, args: None,
+    )
+
+    response = TestClient(web).post("/sync", json={
+        "url": "https://www.beatport.com/chart/synthetic/123",
+        "dry_run": True,
+        "no_cache": True,
+    })
+
+    assert response.status_code == 200
+    source, settings = calls[0]
+    assert source.source_label == "Beatport"
+    assert settings.spotify_access == SpotifyAccess.REQUIRED
+    assert settings.retain_matching_knowledge is False
+    assert settings.retain_publications is False
+    transfer.prepare.assert_called_once()
 
 
 def test_rekordbox_web_execute_returns_aggregate_local_audio_outcome():
@@ -369,6 +477,29 @@ def test_capabilities_are_available_without_spotify_or_private_source(monkeypatc
         "requires_local_audio_identity": False,
         "requires_durable_matching_knowledge": False,
     }
+
+
+def test_capabilities_cross_the_runtime_assembly_seam(tmp_path):
+    delegate = RuntimeAssembly(default_paths=RuntimePaths.selected(
+        tmp_path / "matching-knowledge.json",
+        tmp_path / "publication-manifests.json",
+    ))
+    capability_calls = []
+
+    class SyntheticRuntimeAssembly:
+        local_audition = delegate.local_audition
+
+        def capability_transfer(self):
+            capability_calls.append(True)
+            return delegate.capability_transfer()
+
+    response = TestClient(create_app(
+        runtime_assembly=SyntheticRuntimeAssembly(),
+    )).get("/capabilities")
+
+    assert response.status_code == 200
+    assert response.json()["phase"] == "capability"
+    assert capability_calls == [True]
 
 
 def _qualification_view() -> QualificationView:
@@ -659,6 +790,39 @@ def test_local_media_route_supports_bounded_ranges_without_filename(tmp_path):
         assert "private-owner-name" not in str(denied.headers)
 
 
+def test_web_streams_from_the_runtime_assembly_owned_audition(tmp_path):
+    media = tmp_path / "private-owner-name.mp3"
+    media.write_bytes(b"0123456789")
+    audition = LocalSourceAudition(max_range_bytes=4)
+    opened = audition.open("transfer-1", "item-1", Track(
+        track_id="1", name="Synthetic", artist="Artist", album="", remixer="",
+        label="", genre="", date_added="", location=media.as_uri(),
+    ))
+
+    def forbidden_spotify():
+        raise AssertionError("Spotify must stay untouched")
+
+    assembly = RuntimeAssembly(
+        spotify_factory=forbidden_spotify,
+        default_paths=RuntimePaths.selected(
+            tmp_path / "matching-knowledge.json",
+            tmp_path / "publication-manifests.json",
+        ),
+        local_audition=audition,
+    )
+    client = TestClient(create_app(runtime_assembly=assembly))
+
+    response = client.get(
+        f"/rekordbox/qualification/media/{opened.handle}",
+        headers={"Range": "bytes=2-5"},
+    )
+
+    assert response.status_code == 206
+    assert response.content == b"2345"
+    assert response.headers["cache-control"] == "private, no-store"
+    assert "private-owner-name" not in str(response.headers)
+
+
 def test_qualification_routes_reject_remote_peer_rebinding_host_and_origin():
     web = create_app()
     remote = TestClient(
@@ -730,14 +894,16 @@ def test_durable_draft_with_missing_source_is_review_required_not_missing(
         TransferAuthorization(private_source=True),
     )
     monkeypatch.setattr(
-        "djsupport.web.default_publication_manifest_path",
-        lambda: publication_path,
-    )
-    monkeypatch.setattr(
         "djsupport.config.ConfigManager.get_rekordbox_xml_path",
         lambda self: str(tmp_path / "missing-source.xml"),
     )
-    web = create_app(auth_manager=_authenticated_manager)
+    web = create_app(
+        runtime_assembly=RuntimeAssembly(default_paths=RuntimePaths.selected(
+            tmp_path / "matching-knowledge.json",
+            publication_path,
+        )),
+        auth_manager=_authenticated_manager,
+    )
 
     response = TestClient(web).get(
         f"/rekordbox/qualification/drafts/{draft.draft_id}",

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -122,34 +122,6 @@ def test_first_transfer_web_route_ignores_caller_asserted_readiness():
     transfer.assert_not_called()
 
 
-def test_default_first_transfer_uses_the_runtime_capability_graph(tmp_path):
-    delegate = RuntimeAssembly(default_paths=RuntimePaths.selected(
-        tmp_path / "matching-knowledge.json",
-        tmp_path / "publication-manifests.json",
-    ))
-    capability_calls = []
-
-    class SyntheticRuntimeAssembly:
-        local_audition = delegate.local_audition
-
-        def capability_transfer(self):
-            capability_calls.append(True)
-            return delegate.capability_transfer()
-
-    web = create_app(
-        runtime_assembly=SyntheticRuntimeAssembly(),
-        first_transfer_readiness=lambda path, authorized: FirstTransferReadiness(
-            False, False, False, False, None,
-        ),
-    )
-
-    response = TestClient(web).post("/rekordbox/first-transfer", json={})
-
-    assert response.status_code == 200
-    assert response.json()["next_action"] == "configure_spotify"
-    assert capability_calls == [True]
-
-
 def test_first_transfer_web_route_forwards_only_explicit_authority():
     transfer = MagicMock()
     transfer.authorization_requirement.side_effect = (
@@ -208,6 +180,164 @@ def _agent_web_transfer(plan, report=None):
     return transfer
 
 
+class _RecordingRuntimeAssembly:
+    def __init__(
+        self,
+        *,
+        transfer=None,
+        capability_delegate=None,
+        local_audition=None,
+    ):
+        self._transfer = transfer
+        self._capability_delegate = capability_delegate
+        self.local_audition = local_audition or (
+            capability_delegate.local_audition
+            if capability_delegate is not None
+            else LocalSourceAudition()
+        )
+        self.assemble_calls = []
+        self.capability_calls = 0
+
+    def assemble(self, source, settings):
+        if self._transfer is None:
+            raise AssertionError("No synthetic Transfer was configured")
+        self.assemble_calls.append((source, settings))
+        return RuntimeGraph(self._transfer, MagicMock())
+
+    def capability_transfer(self):
+        if self._capability_delegate is None:
+            raise AssertionError("No capability delegate was configured")
+        self.capability_calls += 1
+        return self._capability_delegate.capability_transfer()
+
+
+class TestWebRuntimeAssembly:
+    def test_default_first_transfer_uses_the_capability_graph(self, tmp_path):
+        delegate = RuntimeAssembly(default_paths=RuntimePaths.selected(
+            tmp_path / "matching-knowledge.json",
+            tmp_path / "publication-manifests.json",
+        ))
+        assembly = _RecordingRuntimeAssembly(capability_delegate=delegate)
+        web = create_app(
+            runtime_assembly=assembly,
+            first_transfer_readiness=lambda path, authorized: FirstTransferReadiness(
+                False, False, False, False, None,
+            ),
+        )
+
+        response = TestClient(web).post("/rekordbox/first-transfer", json={})
+
+        assert response.status_code == 200
+        assert response.json()["next_action"] == "configure_spotify"
+        assert assembly.capability_calls == 1
+
+    def test_default_rekordbox_plan_crosses_the_assembly_seam(self):
+        plan = BatchPlan((PlaylistPreflight(
+            name="Synthetic Selection",
+            reference="Synthetic/Selection",
+            total_tracks=1,
+            approved_match_hits=0,
+            cache_hits=0,
+            expected_uncached_lookups=1,
+            selection_token="opaque-selection-token",
+        ),), preview=True)
+        assembly = _RecordingRuntimeAssembly(
+            transfer=_agent_web_transfer(plan),
+        )
+        web = create_app(runtime_assembly=assembly)
+
+        response = TestClient(web).post("/rekordbox/batches/plan", json={
+            "xml_path": "/private/does-not-exist.xml",
+            "playlists": ["Synthetic/Selection"],
+            "preview": True,
+            "no_cache": True,
+            "authorize_private_source": True,
+        })
+
+        assert response.status_code == 200
+        assert response.json()["phase"] == "plan"
+        assert response.json()["counts"]["playlists"] == 1
+        source, settings = assembly.assemble_calls[0]
+        assert source.source_label == "Rekordbox"
+        assert settings.spotify_access == SpotifyAccess.DISABLED
+        assert settings.retain_matching_knowledge is False
+        assert settings.retain_publications is False
+        assert "does-not-exist" not in response.text
+
+    def test_default_beatport_start_crosses_the_assembly_seam(self):
+        transfer = MagicMock()
+        assembly = _RecordingRuntimeAssembly(transfer=transfer)
+        manager = MagicMock()
+        manager.get_cached_token.return_value = {"access_token": "synthetic"}
+        manager.is_token_expired.return_value = False
+        web = create_app(
+            runtime_assembly=assembly,
+            auth_manager=lambda: manager,
+            background_runner=lambda target, args: None,
+        )
+
+        response = TestClient(web).post("/sync", json={
+            "url": "https://www.beatport.com/chart/synthetic/123",
+            "dry_run": True,
+            "no_cache": True,
+        })
+
+        assert response.status_code == 200
+        source, settings = assembly.assemble_calls[0]
+        assert source.source_label == "Beatport"
+        assert settings.spotify_access == SpotifyAccess.REQUIRED
+        assert settings.retain_matching_knowledge is False
+        assert settings.retain_publications is False
+        transfer.prepare.assert_called_once()
+
+    def test_capabilities_cross_the_assembly_seam(self, tmp_path):
+        delegate = RuntimeAssembly(default_paths=RuntimePaths.selected(
+            tmp_path / "matching-knowledge.json",
+            tmp_path / "publication-manifests.json",
+        ))
+        assembly = _RecordingRuntimeAssembly(capability_delegate=delegate)
+
+        response = TestClient(create_app(
+            runtime_assembly=assembly,
+        )).get("/capabilities")
+
+        assert response.status_code == 200
+        assert response.json()["phase"] == "capability"
+        assert assembly.capability_calls == 1
+
+    def test_media_uses_the_assembly_owned_audition(self, tmp_path):
+        media = tmp_path / "private-owner-name.mp3"
+        media.write_bytes(b"0123456789")
+        audition = LocalSourceAudition(max_range_bytes=4)
+        opened = audition.open("transfer-1", "item-1", Track(
+            track_id="1", name="Synthetic", artist="Artist", album="", remixer="",
+            label="", genre="", date_added="", location=media.as_uri(),
+        ))
+
+        def forbidden_spotify():
+            raise AssertionError("Spotify must stay untouched")
+
+        assembly = RuntimeAssembly(
+            spotify_factory=forbidden_spotify,
+            default_paths=RuntimePaths.selected(
+                tmp_path / "matching-knowledge.json",
+                tmp_path / "publication-manifests.json",
+            ),
+            local_audition=audition,
+        )
+        client = TestClient(create_app(runtime_assembly=assembly))
+
+        response = client.get(
+            f"/rekordbox/qualification/media/{opened.handle}",
+            headers={"Range": "bytes=2-5"},
+        )
+
+        assert response.status_code == 206
+        assert response.content == b"2345"
+        assert response.headers["cache-control"] == "private, no-store"
+        assert "private-owner-name" not in str(response.headers)
+
+
 def test_rekordbox_web_plan_exposes_explicit_local_audio_opt_in_without_spotify():
     plan = BatchPlan((PlaylistPreflight(
         name="Private Selection",
@@ -247,80 +377,6 @@ def test_rekordbox_web_plan_exposes_explicit_local_audio_opt_in_without_spotify(
     assert factory_calls[0][0].local_audio_identity is True
     assert factory_calls[0][1] is False
     assert "synthetic-library" not in response.text
-
-
-def test_default_rekordbox_web_plan_crosses_the_runtime_assembly_seam():
-    plan = BatchPlan((PlaylistPreflight(
-        name="Synthetic Selection",
-        reference="Synthetic/Selection",
-        total_tracks=1,
-        approved_match_hits=0,
-        cache_hits=0,
-        expected_uncached_lookups=1,
-        selection_token="opaque-selection-token",
-    ),), preview=True)
-    calls = []
-
-    class SyntheticRuntimeAssembly:
-        local_audition = LocalSourceAudition()
-
-        def assemble(self, source, settings):
-            calls.append((source, settings))
-            return RuntimeGraph(_agent_web_transfer(plan), MagicMock())
-
-    web = create_app(runtime_assembly=SyntheticRuntimeAssembly())
-    response = TestClient(web).post("/rekordbox/batches/plan", json={
-        "xml_path": "/private/does-not-exist.xml",
-        "playlists": ["Synthetic/Selection"],
-        "preview": True,
-        "no_cache": True,
-        "authorize_private_source": True,
-    })
-
-    assert response.status_code == 200
-    assert response.json()["phase"] == "plan"
-    assert response.json()["counts"]["playlists"] == 1
-    source, settings = calls[0]
-    assert source.source_label == "Rekordbox"
-    assert settings.spotify_access == SpotifyAccess.DISABLED
-    assert settings.retain_matching_knowledge is False
-    assert settings.retain_publications is False
-    assert "does-not-exist" not in response.text
-
-
-def test_default_beatport_web_start_crosses_the_runtime_assembly_seam():
-    transfer = MagicMock()
-    calls = []
-
-    class SyntheticRuntimeAssembly:
-        local_audition = LocalSourceAudition()
-
-        def assemble(self, source, settings):
-            calls.append((source, settings))
-            return RuntimeGraph(transfer, MagicMock())
-
-    manager = MagicMock()
-    manager.get_cached_token.return_value = {"access_token": "synthetic"}
-    manager.is_token_expired.return_value = False
-    web = create_app(
-        runtime_assembly=SyntheticRuntimeAssembly(),
-        auth_manager=lambda: manager,
-        background_runner=lambda target, args: None,
-    )
-
-    response = TestClient(web).post("/sync", json={
-        "url": "https://www.beatport.com/chart/synthetic/123",
-        "dry_run": True,
-        "no_cache": True,
-    })
-
-    assert response.status_code == 200
-    source, settings = calls[0]
-    assert source.source_label == "Beatport"
-    assert settings.spotify_access == SpotifyAccess.REQUIRED
-    assert settings.retain_matching_knowledge is False
-    assert settings.retain_publications is False
-    transfer.prepare.assert_called_once()
 
 
 def test_rekordbox_web_execute_returns_aggregate_local_audio_outcome():
@@ -477,29 +533,6 @@ def test_capabilities_are_available_without_spotify_or_private_source(monkeypatc
         "requires_local_audio_identity": False,
         "requires_durable_matching_knowledge": False,
     }
-
-
-def test_capabilities_cross_the_runtime_assembly_seam(tmp_path):
-    delegate = RuntimeAssembly(default_paths=RuntimePaths.selected(
-        tmp_path / "matching-knowledge.json",
-        tmp_path / "publication-manifests.json",
-    ))
-    capability_calls = []
-
-    class SyntheticRuntimeAssembly:
-        local_audition = delegate.local_audition
-
-        def capability_transfer(self):
-            capability_calls.append(True)
-            return delegate.capability_transfer()
-
-    response = TestClient(create_app(
-        runtime_assembly=SyntheticRuntimeAssembly(),
-    )).get("/capabilities")
-
-    assert response.status_code == 200
-    assert response.json()["phase"] == "capability"
-    assert capability_calls == [True]
 
 
 def _qualification_view() -> QualificationView:
@@ -788,39 +821,6 @@ def test_local_media_route_supports_bounded_ranges_without_filename(tmp_path):
         )
         assert denied.headers["x-content-type-options"] == "nosniff"
         assert "private-owner-name" not in str(denied.headers)
-
-
-def test_web_streams_from_the_runtime_assembly_owned_audition(tmp_path):
-    media = tmp_path / "private-owner-name.mp3"
-    media.write_bytes(b"0123456789")
-    audition = LocalSourceAudition(max_range_bytes=4)
-    opened = audition.open("transfer-1", "item-1", Track(
-        track_id="1", name="Synthetic", artist="Artist", album="", remixer="",
-        label="", genre="", date_added="", location=media.as_uri(),
-    ))
-
-    def forbidden_spotify():
-        raise AssertionError("Spotify must stay untouched")
-
-    assembly = RuntimeAssembly(
-        spotify_factory=forbidden_spotify,
-        default_paths=RuntimePaths.selected(
-            tmp_path / "matching-knowledge.json",
-            tmp_path / "publication-manifests.json",
-        ),
-        local_audition=audition,
-    )
-    client = TestClient(create_app(runtime_assembly=assembly))
-
-    response = client.get(
-        f"/rekordbox/qualification/media/{opened.handle}",
-        headers={"Range": "bytes=2-5"},
-    )
-
-    assert response.status_code == 206
-    assert response.content == b"2345"
-    assert response.headers["cache-control"] == "private, no-store"
-    assert "private-owner-name" not in str(response.headers)
 
 
 def test_qualification_routes_reject_remote_peer_rebinding_host_and_origin():


### PR DESCRIPTION
## Summary

- route Beatport and Rekordbox web construction through the shared private Runtime Assembly
- use the assembly-owned capability graph, default private paths, durable Transfer storage, and local audition adapter across web flows
- refresh reused Transfer storage before direct reads so CLI, web, and Agent Client writes remain visible across processes
- remove the duplicate web production factories and update architecture guidance

## Why

The web adapter still owned production construction details already centralized for the CLI and Agent Client. This completes the shared construction seam while keeping Transfer as the only public policy interface.

Closes #137.

## Impact

Transfer policy and local JSON storage formats are unchanged. The change is limited to production assembly and preserves authorization, privacy, and live-service boundaries. No owner data or live Spotify/Beatport calls were used during implementation.

## Validation

- `python3 -m pytest -q` — 759 passed
- `python3 -m pytest tests/test_runtime.py tests/test_web.py -q` — 47 passed
- `python3 -m pytest tests/test_repository_privacy.py -q` — 18 passed
- `python3 -m pytest tests/test_release_records.py -q` — 5 passed
- `python3 -m compileall -q djsupport`
- `python3 scripts/release_records.py check origin/main HEAD`
- `git diff --check origin/main...HEAD`
- final Standards review — clean
- final Spec review — clean
