### PR TITLE
Fix version PR recreation after merge

### DIFF
--- a/.github/workflows/version-pr.yml
+++ b/.github/workflows/version-pr.yml
@@ -44,8 +44,9 @@ jobs:
           git add pyproject.toml CHANGELOG.md .release-notes
           git commit -m "chore: version DJ Support $VERSION"
           git push --force-with-lease origin release/version
-          if gh pr view release/version --json number >/dev/null 2>&1; then
-            gh pr edit release/version --title "chore: version DJ Support $VERSION" --body "Automated version PR from pending release records. Merging updates version metadata and the changelog; it does not authorize a tag, GitHub Release, or package publication."
+          open_pr="$(gh pr list --base main --head release/version --state open --json number --jq '.[0].number // empty')"
+          if [[ -n "$open_pr" ]]; then
+            gh pr edit "$open_pr" --title "chore: version DJ Support $VERSION" --body "Automated version PR from pending release records. Merging updates version metadata and the changelog; it does not authorize a tag, GitHub Release, or package publication."
           else
             gh pr create --base main --head release/version --title "chore: version DJ Support $VERSION" --body "Automated version PR from pending release records. Merging updates version metadata and the changelog; it does not authorize a tag, GitHub Release, or package publication."
           fi

--- a/tests/test_release_channels.py
+++ b/tests/test_release_channels.py
@@ -168,3 +168,16 @@ def test_version_pr_automation_cannot_publish_a_release():
     assert "RELEASE_RECORD_BASE" in ci_workflow
     for forbidden in ("git tag", "gh release create", "twine", "pypi", "spotify", "beatport"):
         assert forbidden not in normalized
+
+
+def test_version_pr_automation_ignores_prior_merged_pull_requests():
+    version_workflow = (
+        REPOSITORY_ROOT / ".github" / "workflows" / "version-pr.yml"
+    ).read_text()
+
+    assert "gh pr list" in version_workflow
+    assert "--base main" in version_workflow
+    assert "--head release/version" in version_workflow
+    assert "--state open" in version_workflow
+    assert 'gh pr edit "$open_pr"' in version_workflow
+    assert "gh pr view release/version" not in version_workflow


### PR DESCRIPTION
Closes #157.

## What changed

- discover only open `release/version` pull requests into `main`
- edit the exact open PR number when one exists
- create a fresh PR after every prior branch PR has merged or closed
- contract the behavior in the offline release-channel tests

## Why

Workflow run `31913984765` successfully prepared remote commit `71c7bda276f15c6580bdd72a752a75cb4608a1a6`, but branch-only `gh pr view` matched merged PR #153 and left the new version update without a review route.

## Validation

- `python3 -m pytest tests/test_release_channels.py -q` — 6 passed
- `python3 -m pytest` — 760 passed
- `python3 -m pytest tests/test_repository_privacy.py -q` — 18 passed
- `python3 -m compileall -q djsupport tests`
- `python3 scripts/release_records.py check origin/main HEAD` — no distributable changes
- `git diff --check`

## Boundaries

No tag, GitHub Release, package publication, storage behavior, live service, or owner-data operation.
