### PR TITLE
Keep internal research out of consumer release records

### DIFF
--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -17,8 +17,10 @@ authorize any tag, GitHub Release, or package publication.
       documentation adds one `.release-notes/*.md` file.
 - [ ] Set `bump` to `patch`, `minor`, or `major`; set `section` to a Keep a
       Changelog heading; describe the consumer-visible effect.
-- [ ] Internal-only changes to tests, release machinery, or this checklist do
-      not require a release record.
+- [ ] Internal-only changes to tests, release machinery, research notes under
+      `docs/research/`, or this checklist do not require a release record. If
+      the same pull request changes distributable behavior or user guidance,
+      that change still requires a release record.
 
 ## 2. Review the automated version PR
 

--- a/scripts/release_records.py
+++ b/scripts/release_records.py
@@ -66,7 +66,9 @@ def load_records() -> list[ReleaseRecord]:
 
 def _is_distributable(path: str) -> bool:
     return path.startswith("djsupport/") or path in {"README.md", "pyproject.toml"} or (
-        path.startswith("docs/") and path != "docs/releasing.md"
+        path.startswith("docs/")
+        and path != "docs/releasing.md"
+        and not path.startswith("docs/research/")
     )
 
 

--- a/tests/test_release_records.py
+++ b/tests/test_release_records.py
@@ -14,6 +14,26 @@ sys.modules[SPEC.name] = release_records
 SPEC.loader.exec_module(release_records)
 
 
+def test_distributable_paths_exclude_internal_research_only():
+    distributable = (
+        "djsupport/transfer.py",
+        "README.md",
+        "pyproject.toml",
+        "docs/architecture.md",
+        "docs/storage.md",
+        "docs/backup-and-restore.md",
+    )
+    internal = (
+        "docs/releasing.md",
+        "docs/research/operational-store-contract.md",
+        "tests/test_transfer.py",
+        ".github/workflows/ci.yml",
+    )
+
+    assert all(release_records._is_distributable(path) for path in distributable)
+    assert not any(release_records._is_distributable(path) for path in internal)
+
+
 def test_release_record_parser_requires_bump_section_and_summary(tmp_path):
     record = tmp_path / "change.md"
     record.write_text(


### PR DESCRIPTION
Closes #161.

## What changed

- exempt only the canonical internal `docs/research/**` route from consumer release records
- keep product code, README, package metadata, architecture, storage, and other user-facing docs distributable
- document the boundary in the maintainer checklist
- contract both sides of the classifier in tests

## Why

The prior all-`docs/` rule contradicted issue-level policy when research changed no product behavior. It forced #131's evidence note back out of Git and would require false changelog records for the Operational Store research contracts.

## Validation

- `python3 -m pytest tests/test_release_records.py tests/test_release_channels.py -q` — 12 passed
- `python3 -m pytest` — 761 passed
- `python3 -m pytest tests/test_repository_privacy.py -q` — 18 passed
- `python3 -m compileall -q djsupport tests scripts`
- `python3 scripts/release_records.py check origin/main HEAD` — no distributable changes
- `git diff --check`

## Boundaries

Privacy and packaging checks remain unchanged. No tag, GitHub Release, package publication, live service, or owner data.
