### PR TITLE
Front-load Operational Store implementation research

### DIFF
--- a/docs/research/2026-08-16-operational-store-issue-frontier.md
+++ b/docs/research/2026-08-16-operational-store-issue-frontier.md
@@ -1,0 +1,304 @@
+# Operational Store issue frontier
+
+**Date:** 2026-08-16
+
+**Status:** implementation-readiness research; no authority switch or release action
+
+**Baseline:** [`origin/main` at `6b04a70`](https://github.com/spontain112/djsupport/commit/6b04a70eb65681b97b104de8cc1eac6cef49713b)
+
+## Decision summary
+
+The next product implementation is [#138](https://github.com/spontain112/djsupport/issues/138), but it is not executable yet: its remaining blocker is the human-owned final-0.6 publication and return-to-development gate in [#136](https://github.com/spontain112/djsupport/issues/136). Its other blocker, [#137](https://github.com/spontain112/djsupport/issues/137), is closed on the baseline above. Public Releases still identify `v0.5.0` as Latest, while source metadata is `0.6.0`; #136 explicitly owns the final tag/Latest Release and the subsequent development-version commit ([Releases](https://github.com/spontain112/djsupport/releases), [`pyproject.toml`](../../pyproject.toml), [release policy](../releasing.md#9-promote-a-final-release-deliberately)). A `ready-for-agent` label therefore means the issue is specified, not that its declared blocker may be bypassed.
+
+The storage program should be delivered through the bounded #138–#147 slices rather than by claiming the broad architecture umbrellas [#127](https://github.com/spontain112/djsupport/issues/127) or [#128](https://github.com/spontain112/djsupport/issues/128) as one change. That is an inference from the issue topology: #127 forbids a production switch, #128 defines the eventual sole authority, #138 starts with one non-authoritative Preview, and #146 performs the explicit cutover. The parent [#125](https://github.com/spontain112/djsupport/issues/125) fixes the invariants: one local SQLite store, one internal interface, no ORM without separate justification, no dual-write, an Effect Journal around external effects, rebuildable events rather than analytics authority, and private local operation only.
+
+One architecture integration preflight remains visible: #125 names an ADR 0005 draft on the separate `djsupport/operational-store-architecture` branch, while current `origin/main` contains ADRs 0001–0003 only ([ADR directory](../adr/)). Do not independently recreate or reinterpret that concurrent architecture work. Before #138 writes a schema, confirm the accepted ADR has a stable integrated route; until then, the public issue decisions above are the authoritative contract available on main.
+
+Release automation also needs deliberate sequencing. Two Runtime Assembly release records are already pending, but they are not storage records or an 0.7 candidate ([pending records](../../.release-notes)). Let the storage records accumulate behind normal review, and do not treat an automated version PR as the exact `0.7.0rc1` freeze: #149 and the one-use candidate override own that later gate ([#149](https://github.com/spontain112/djsupport/issues/149), [version workflow](../releasing.md#2-review-the-automated-version-pr)).
+
+The highest-leverage implementation move is to preserve the public [`Transfer`](../../djsupport/transfer.py#L2093) seam and convert its existing behavior tests into Operational Store adapter-conformance tests. Today Transfer receives three persistence collaborators—matching knowledge, publication storage, and Transfer storage—and the storage guide explicitly says their JSON documents are independently authoritative and cannot form one transaction ([constructor](../../djsupport/transfer.py#L2093-L2117), [current storage relationships](../storage.md#storage-relationships), [current write semantics](../storage.md#write-and-concurrency-behavior)). The program is not a policy rewrite: the domain and lifecycle invariants already live above serialization and must remain unchanged ([domain model](../domain-model.md#core-invariants), [lifecycles](../lifecycles.md)).
+
+## Current reusable foundation
+
+- Exact Source Occurrence identity, order, and duplicate preservation already exist in the value model and high-level tests; these are the canonical facts the two new adapters must round-trip ([source facts](../../djsupport/source_facts.py#L181-L205), [duplicate Approval test](../../tests/test_qualification.py#L443-L490)).
+- Transfer, Batch, and Qualification state already carry optimistic revisions, and file storage reloads under a lock before rejecting stale writes. Matching knowledge and publication state do not yet have the same per-entity contract ([state values](../../djsupport/transfer.py#L292-L430), [file-store concurrency](../../djsupport/transfer.py#L1171-L1347), [storage comparison](../storage.md#write-and-concurrency-behavior)).
+- Publication recovery already has stable publication keys, retained playlist identity, chunk identities, and changed-head stop conditions. It is a useful behavioral baseline, but it is not an Effect Journal because intent is not committed before every external call ([publication path](../../djsupport/transfer.py#L5822-L5997), [checkpointed effects](../../djsupport/transfer.py#L6033-L6098), [durable lifecycle](../lifecycles.md#durable-transfer-and-batch-states)).
+- Qualification and Mirror behavior is already heavily specified through Transfer. SQLite work should parameterize these tests over stores rather than move their authority rules into persistence ([Qualification tests](../../tests/test_qualification.py), [Mirror tests](../../tests/test_transfer.py#L882-L1568), [engineering convention](../../CONTRIBUTING.md#engineering-conventions)).
+- Existing backup/migration code supplies reusable archive-path, hash, redaction, preview, and rollback patterns, but it operates on JSON members and is not a transactionally consistent SQLite snapshot implementation ([backup reader](../../djsupport/backup.py#L159-L221), [restore commit](../../djsupport/backup.py#L444-L477), [migration ownership](../storage.md#migration-ownership)).
+- The current focused baseline is green: `python3 -m pytest tests/test_runtime.py tests/test_transfer.py tests/test_qualification.py tests/test_backup.py tests/test_migration.py tests/test_repository_privacy.py` completed with 227 passed and three pre-existing warnings. This is a regression baseline, not evidence that any SQLite criterion is complete.
+
+## Acceptance frontier
+
+Status meanings: **present** is authoritative current behavior that must be preserved; **partial** is reusable evidence but does not satisfy the issue; **missing** requires implementation; **gate** cannot be claimed yet.
+
+### [#138 — Persist and resume one Transfer Preview through SQLite](https://github.com/spontain112/djsupport/issues/138)
+
+| AC | Current evidence and gap | Status |
+| --- | --- | --- |
+| One Operational Store interface; callers do not coordinate separate adapters | Transfer currently receives three collaborators and Runtime Assembly constructs three file-backed paths/adapters ([Transfer constructor](../../djsupport/transfer.py#L2093-L2117), [Runtime Assembly](../../djsupport/runtime.py#L172-L205)). | **Missing** |
+| In-memory and SQLite adapters pass the same conformance tests | `EphemeralMatchingKnowledge` and test-local `InMemoryStorage` cover narrower old protocols; there is no complete in-memory Operational Store or shared adapter suite ([test fake](../../tests/test_transfer.py#L137-L235), [current protocols](../../djsupport/transfer.py#L914-L938)). | **Missing** |
+| Source Selection identity, occurrence order, and duplicates round-trip exactly | Exact occurrence values and duplicate-through-Approval coverage exist, but not through either proposed Operational Store adapter ([source occurrence](../../djsupport/source_facts.py#L181-L205), [duplicate test](../../tests/test_qualification.py#L443-L490)). | **Partial** |
+| Preview retains proposals/failures, Batch and Transfer progress, resumable checkpoints, and compact Operational Events | Current JSON schemas retain all listed operational state except Operational Events; the storage inventory has no event category ([storage contents](../storage.md#file-contents-by-category), [Transfer state](../../djsupport/transfer.py#L696-L737)). | **Partial** |
+| Explicit migration registry; Python `sqlite3`; no ORM | The package has no SQLite module, migration registry, or ORM dependency; current migration code is JSON-specific ([project dependencies](../../pyproject.toml), [legacy migration](../../djsupport/migration.py)). | **Missing** |
+| Configuration and Spotipy credentials stay outside the database | This boundary is already canonical and must remain so ([storage boundary](../storage.md#configuration-and-credentials), [paths](../../djsupport/paths.py)). | **Present** |
+| Scale: 100,000 Source Occurrences and 10,000 Transfers | No such scale fixture or verification exists in the current test inventory ([tests map](../../CONTRIBUTING.md#repository-map)). | **Missing** |
+| Database, WAL, and SHM documented and ignored; repository/package privacy covers them | Current ignore and privacy tests cover reports, credentials, XML, playlist JSON, and regressions, but not database/sidecar/snapshot/staging patterns ([`.gitignore`](../../.gitignore), [privacy tests](../../tests/test_repository_privacy.py)). | **Missing** |
+| Existing JSON remains production authority; no dual-write or cutover | Runtime Assembly still selects JSON adapters, so this guard currently holds. #138 must add an isolated Preview path without silently changing production selection ([Runtime Assembly](../../djsupport/runtime.py#L172-L217), [storage inventory](../storage.md#current-schema-owners)). | **Present guard** |
+| Release-note record | The two pending records describe Runtime Assembly, not #138; the repository requires one record for a distributable implementation ([pending records](../../.release-notes), [release policy](../releasing.md#1-record-distributable-changes)). | **Missing** |
+
+### [#139 — Reject stale concurrent Transfer writes safely](https://github.com/spontain112/djsupport/issues/139)
+
+| AC | Current evidence and gap | Status |
+| --- | --- | --- |
+| Two independent connections safely update distinct work | File storage has process/thread locking, but no SQLite connection-conformance test exists ([file locking](../../djsupport/transfer.py#L1171-L1215)). | **Missing** |
+| Stale Transfer, Batch, or matching-knowledge revision fails closed | Transfer/Batch/Qualification file entities reject stale revisions; matching knowledge and publication state explicitly lack that contract, and none is tested through SQLite ([file save](../../djsupport/transfer.py#L1278-L1347), [storage comparison](../storage.md#write-and-concurrency-behavior)). | **Partial** |
+| WAL, short transactions, bounded busy handling, integrity checks | No SQLite implementation exists in the current production/storage map ([source map](../architecture.md#production-source-map), [project dependencies](../../pyproject.toml)). | **Missing** |
+| Crash before/during/after commit yields the previous or complete next state | Existing file and restore tests provide failure-injection patterns, but not SQLite transaction crash points ([restore rollback test surface](../../tests/test_backup.py#L388-L638), [file-store save](../../djsupport/transfer.py#L1331-L1369)). | **Partial** |
+| No database transaction spans an external service call | There is no database transaction to inspect yet; the future test must assert the synthetic Spotify adapter is invoked only with no store transaction active ([Spotify seam](../../djsupport/transfer.py#L885-L911)). | **Missing** |
+| macOS, Linux, Windows; Python 3.10 and 3.14 edges on Linux | CI currently runs both Python edges only on Ubuntu; macOS and Windows persistence jobs are absent ([CI matrix](../../.github/workflows/ci.yml#L33-L55)). | **Partial** |
+| CLI/web/Agent privacy-redacted behavior unchanged | The three clients now share Runtime Assembly and existing agent contracts are privacy-redacted; post-change regression is still required ([architecture](../architecture.md#module-architecture), [Agent decision](../adr/0002-make-transfer-agent-native.md)). | **Present baseline** |
+| Release-note record | Required by the issue and repository policy; no #139 record exists ([pending records](../../.release-notes)). | **Missing** |
+
+### [#140 — Publish one Snapshot through the Effect Journal](https://github.com/spontain112/djsupport/issues/140)
+
+| AC | Current evidence and gap | Status |
+| --- | --- | --- |
+| Commit intent before Spotify; commit observed result afterward | Current playlist creation is followed by local retention; there is no pre-call Effect Journal intent record ([publication path](../../djsupport/transfer.py#L5822-L5869)). | **Missing** |
+| No transaction across Spotify | Must be proved at the new store boundary; current code offers a synthetic Spotify seam but no database transaction ([Spotify protocol](../../djsupport/transfer.py#L885-L911)). | **Missing** |
+| Manifest and ordered items retain exact proposed facts | The current manifest/value model and duplicate tests are reusable, but must move through the Operational Store ([manifest model](../../djsupport/transfer.py#L751-L827), [domain rule](../domain-model.md#relationship-summary)). | **Partial** |
+| Resume distinguishes not attempted, observed complete, and uncertain effects | Current state distinguishes matching/retaining/completed and retains mutation snapshots, but has no explicit journal categories for uncertain effects ([lifecycle](../lifecycles.md#durable-transfer-and-batch-states), [Transfer state](../../djsupport/transfer.py#L696-L724)). | **Partial** |
+| Stable identity prevents duplicate Snapshot creation when completion is provable | `publication_key`, recovery lookup, and retained playlist ID already supply the behavior to port ([checkpointed publication](../../djsupport/transfer.py#L6033-L6063), [recovery tests](../../tests/test_transfer.py#L2378-L2478)). | **Partial** |
+| Crash immediately before/after call and before result retention is deterministic | Current tests cover important recovery points but not the complete three-state journal matrix ([publication lifecycle tests](../../tests/test_transfer.py#L2037-L2478)). | **Partial** |
+| Preview creates no mutation-authorizing journal entry | Preview already forbids playlist and playlist-state mutation; the future store must make the same invariant observable in journal rows ([domain invariant](../domain-model.md#core-invariants)). | **Present baseline** |
+| Exercise through Transfer with synthetic Spotify | High-level Transfer tests already use synthetic adapters and are the required seam ([engineering convention](../../CONTRIBUTING.md#engineering-conventions), [Snapshot tests](../../tests/test_transfer.py#L824-L881)). | **Present seam** |
+| Release-note record | No #140 record exists ([pending records](../../.release-notes)). | **Missing** |
+
+### [#141 — Approve one Provisional Playlist atomically](https://github.com/spontain112/djsupport/issues/141)
+
+| AC | Current evidence and gap | Status |
+| --- | --- | --- |
+| Compare exact playlist head with account-scoped manifest | Current Approval reloads stores, scopes the manifest by account, and reads a stable head around ordered items ([Approval path](../../djsupport/transfer.py#L4563-L4758)). | **Present baseline** |
+| Surviving/removed/Correction outcomes become the right authority | Existing Approval classifies these outcomes and checkpoints matching knowledge ([Approval classification](../../djsupport/transfer.py#L4797-L4967), [lifecycle](../lifecycles.md#approval-outcomes)). | **Present baseline** |
+| Collisions and conflicts remain review-required | Current domain rules and tests forbid silent success ([domain invariants](../domain-model.md#core-invariants), [Approval tests](../../tests/test_transfer.py#L2784-L3372)). | **Present baseline** |
+| Approval, publication, knowledge, Corrections, conflicts commit in one transaction | Current implementation checkpoints knowledge, optionally writes Mirror state, then appends Approval through independent adapters; the storage guide explicitly says separate files are not one transaction ([Approval writes](../../djsupport/transfer.py#L4898-L4980), [storage limitation](../storage.md#write-and-concurrency-behavior)). | **Missing** |
+| Approval stays separate from publication and draft application | This is canonical and tested through Transfer ([authority ladder](../domain-model.md#authority-ladder), [Qualification lifecycle](../lifecycles.md#qualification-draft-states)). | **Present** |
+| Repeat is idempotent; stale playlist or manifest revisions fail closed | Stable-head and changed-manifest checks exist for Qualification Approval; there is no single Operational Store revision/idempotency proof for every Approval fact ([Approval checks](../../djsupport/transfer.py#L4681-L4758), [Qualification idempotency tests](../../tests/test_agent_contract.py#L1122-L1265)). | **Partial** |
+| Compact Operational Events retain categories without authority | There is no Operational Event category in the current storage model ([storage inventory](../storage.md#current-schema-owners)). | **Missing** |
+| Transfer test proves rollback on injected failure | Existing tests exercise failures around Approval, but separate file writes cannot prove one local transaction rollback ([Approval tests](../../tests/test_transfer.py#L2784-L3372)). | **Missing** |
+| Release-note record | No #141 record exists ([pending records](../../.release-notes)). | **Missing** |
+
+### [#142 — Resume and apply one Qualification Draft](https://github.com/spontain112/djsupport/issues/142)
+
+| AC | Current evidence and gap | Status |
+| --- | --- | --- |
+| Draft binds Transfer, manifest, account, playlist head, and selected occurrences | The current draft stores those identities/digests and item IDs; the port must prove exact round-trip through both new adapters ([draft state](../../djsupport/transfer.py#L381-L430), [domain relationship](../domain-model.md#relationship-summary)). | **Partial** |
+| Keep, Correction, deferred, exclusion, rejection persist with revisions and no authority | Current decision recording and explicit deferred exclusion already enforce this, but only through JSON storage ([decision path](../../djsupport/transfer.py#L3604-L3715), [lifecycle table](../lifecycles.md#qualification)). | **Partial** |
+| Discard/successor atomic; stale revisions fail closed | File storage already saves both successor sides under one lock and rejects stale revision; this is a direct adapter-conformance case ([successor save](../../djsupport/transfer.py#L1300-L1329), [stale test](../../tests/test_qualification.py#L1175-L1249)). | **Partial** |
+| Digests and account-scoped Local Audio associations round-trip without paths, filenames, or audition handles | Current draft fields and storage docs enforce the privacy boundary; SQLite schema/adapter proof is missing ([draft state](../../djsupport/transfer.py#L381-L430), [storage boundary](../storage.md#transfer-state), [local-audio convention](../../CONTRIBUTING.md#engineering-conventions)). | **Partial** |
+| Application uses Effect Journal and remains separate from Approval | Separation exists; Effect Journal does not ([Qualification lifecycle](../lifecycles.md#qualification-draft-states), [current chunk checkpoints](../../djsupport/transfer.py#L4501-L4561)). | **Partial** |
+| Browser-origin selections remain reviewed in Spotify | Current behavior explicitly refuses a Qualification Draft for the browser-origin Snapshot path ([test](../../tests/test_qualification.py#L669-L703)). | **Present** |
+| Scale: 1,000 Qualification Drafts | No scale fixture/test exists in the current Qualification suite ([tests](../../tests/test_qualification.py)). | **Missing** |
+| Interruption and recovery through Transfer | Existing high-level tests cover paused/resumed draft application; adapter/journal coverage remains missing ([recovery tests](../../tests/test_qualification.py#L746-L945)). | **Partial** |
+| Release-note record | No #142 record exists ([pending records](../../.release-notes)). | **Missing** |
+
+### [#143 — Maintain one Mirror through the Operational Store](https://github.com/spontain112/djsupport/issues/143)
+
+| AC | Current evidence and gap | Status |
+| --- | --- | --- |
+| Mirror identity scopes account, source type/reference, and playlist | Current `MirrorRelationship` carries account, source label/reference, and playlist identity ([model](../../djsupport/transfer.py#L829-L840), [domain relationship](../domain-model.md#relationship-summary)). | **Present baseline** |
+| Initial/replacement state retains ordered items, manifest, revision, journal state | Ordered managed items and manifests exist; Mirror has no optimistic revision and there is no Effect Journal ([manifest/Mirror models](../../djsupport/transfer.py#L751-L840)). | **Partial** |
+| Resume reconciles replacement, description, relink, and removal without guessing | Current publication chunks have recovery checkpoints, while relink/removal paths do not have the accepted journal model ([checkpointed effects](../../djsupport/transfer.py#L6033-L6098), [Mirror lifecycle tests](../../tests/test_transfer.py#L882-L1568)). | **Partial** |
+| Drift permits only restore or Approved Match revocation | Canonical behavior and high-level tests already enforce the explicit choices ([Mirror lifecycle](../lifecycles.md#mirror-drift-and-orphaning), [drift tests](../../tests/test_transfer.py#L1213-L1426)). | **Present** |
+| Orphan remains untouched until keep/relink/delete | Canonical behavior and tests already enforce it ([lifecycle](../lifecycles.md#mirror-drift-and-orphaning), [orphan tests](../../tests/test_transfer.py#L883-L1212)). | **Present** |
+| No destructive action inferred from absence or conversation | Repository and Agent Client policy already forbid this ([AGENTS boundaries](../../AGENTS.md#boundaries), [Agent decision](../adr/0002-make-transfer-agent-native.md)). | **Present** |
+| Complete lifecycle through Transfer with synthetic adapters | The current test group is a strong baseline; it must be parameterized through the new store and journal ([Mirror tests](../../tests/test_transfer.py#L882-L1568)). | **Partial** |
+| Release-note record | No #143 record exists ([pending records](../../.release-notes)). | **Missing** |
+
+### [#144 — Preview and exactly verify JSON-to-SQLite migration](https://github.com/spontain112/djsupport/issues/144)
+
+| AC | Current evidence and gap | Status |
+| --- | --- | --- |
+| Read-only importer accepts every supported JSON schema version | The supported version inventory exists, but no current-authority JSON-to-SQLite importer exists ([schema inventory](../storage.md#supported-backup-and-restore-schemas), [backup constants](../../djsupport/backup.py#L21-L32)). | **Missing** |
+| Import every named authority/operational category into a temporary database | Current state is distributed across the three JSON documents and migration markers; Operational Events and Effect Journal do not exist yet ([current schemas](../storage.md#current-schema-owners)). | **Missing** |
+| Verify exact identities, occurrence order/duplicates, relationships, authority, revisions, evidence, incomplete effects | The domain supplies the identity rules, but there is no whole-store verifier ([identity layers](../domain-model.md#identity-layers)). | **Missing** |
+| Malformed, unsupported, ambiguous, or unverifiable input fails closed with no switch | Existing schema readers and legacy migration provide reusable fail-closed patterns, not the required verifier ([migration ownership](../storage.md#migration-ownership), [migration tests](../../tests/test_migration.py)). | **Partial** |
+| Preview excludes secrets, paths, metadata, identifiers, fingerprints, SQL, raw exceptions | Current migration/Agent outputs use aggregate privacy-safe facts; a new verification document and denylist test are required ([Agent privacy contract](../adr/0002-make-transfer-agent-native.md#L26-L31), [legacy migration tests](../../tests/test_migration.py#L32-L112)). | **Partial** |
+| Crash before/during/after import leaves original JSON untouched | Current legacy migration leaves sources unchanged and tests commit failure, which is a reusable fixture pattern ([legacy migration](../../djsupport/migration.py#L60-L118), [failure tests](../../tests/test_migration.py#L351-L474)). | **Partial** |
+| Configuration and Spotipy credentials are not imported/copied | Configuration and credentials are canonically separate; note that current generic backups include `config.json`, so this importer needs a narrower explicit member set ([configuration boundary](../storage.md#configuration-and-credentials), [backup members](../../djsupport/backup.py#L21-L32)). | **Present boundary / missing proof** |
+| Tests use only synthetic data | Repository policy already requires invented fixtures and forbids owner data ([contribution policy](../../CONTRIBUTING.md#protect-local-dj-data), [ADR-0001](../adr/0001-keep-user-data-out-of-the-repository.md)). | **Present guard** |
+| Release-note record | No #144 record exists ([pending records](../../.release-notes)). | **Missing** |
+
+### [#145 — Back up and restore the SQLite Operational Store](https://github.com/spontain112/djsupport/issues/145)
+
+| AC | Current evidence and gap | Status |
+| --- | --- | --- |
+| Transactionally consistent snapshot; no unsafe WAL/SHM copy | Current backup copies individual JSON bytes; no SQLite snapshot exists ([backup creation](../../djsupport/backup.py#L78-L125)). | **Missing** |
+| Manifest records store schema/hash and excludes credentials | Current archive manifest records per-member schema/hash and screens credential fields; it is a reusable contract, not a database manifest ([backup manifest](../../djsupport/backup.py#L98-L124)). | **Partial** |
+| Restore validates paths, members, hashes, DB integrity/schema before redacted Preview | Path/member/hash/schema validation exists for ZIP/JSON; database integrity and store schema validation do not ([archive reader](../../djsupport/backup.py#L190-L221)). | **Partial** |
+| Apply is atomic or leaves previous complete store | Current multi-file restore has staged rollback; a database replacement/activation proof is missing ([restore commit](../../djsupport/backup.py#L444-L477)). | **Partial** |
+| 0.7 rollback window without silently deleting legacy JSON | Current migration guidance preserves legacy sources, but the 0.7 window and SQLite rollback behavior do not exist ([migration ownership](../storage.md#migration-ownership), [upgrade guide](../upgrading.md)). | **Partial** |
+| Snapshots/backups/staging/extracted copies documented and ignored | Current documentation and ignore rules do not enumerate the database family ([storage privacy](../storage.md), [`.gitignore`](../../.gitignore)). | **Missing** |
+| Repository/package checks reject all such artifacts | Current checks do not include database, WAL/SHM, snapshot, or staging names ([privacy tests](../../tests/test_repository_privacy.py), [package inspection](../../.github/workflows/ci.yml#L57-L162)). | **Missing** |
+| Cross-platform tests use synthetic application data | Existing backup tests are synthetic, but CI runs them only on Ubuntu ([backup tests](../../tests/test_backup.py), [CI matrix](../../.github/workflows/ci.yml#L33-L55)). | **Partial** |
+| Release-note record | No #145 record exists ([pending records](../../.release-notes)). | **Missing** |
+
+### [#146 — Apply the verified SQLite production cutover](https://github.com/spontain112/djsupport/issues/146)
+
+| AC | Current evidence and gap | Status |
+| --- | --- | --- |
+| Create and verify a complete current-state backup first | Current migrations use backup-first patterns; no complete SQLite/JSON transition backup contract exists ([Foundation migration](../../djsupport/migration.py#L427-L471)). | **Partial** |
+| Stage import, pass #144 exact verification, install complete DB before authority change | This depends on [#144](https://github.com/spontain112/djsupport/issues/144); current migration stages JSON writes rather than a verified database ([migration commit](../../djsupport/migration.py#L386-L417)). | **Missing** |
+| Runtime Assembly selects store for every client only after activation | All clients now share Runtime Assembly, which is the right switch seam, but it is hard-coded to file adapters ([Runtime Assembly](../../djsupport/runtime.py#L142-L217), [architecture](../architecture.md#module-architecture)). | **Partial** |
+| Failure before activation leaves JSON authority; success leaves SQLite authority | No activation state machine exists; Runtime Assembly selects file paths/adapters directly ([Runtime Assembly](../../djsupport/runtime.py#L172-L217)). | **Missing** |
+| No dual-write, partial client cutover, or silent fallback | Shared Runtime Assembly can prevent partial client selection, but no accepted activation/fail-closed implementation exists ([Runtime Assembly](../../djsupport/runtime.py#L172-L205)). | **Partial** |
+| Original JSON stays untouched for rollback window | Existing migration policy preserves sources; 0.7 cutover/retention is missing ([migration ownership](../storage.md#migration-ownership)). | **Partial** |
+| Configuration and Spotipy credentials remain outside DB | Canonical boundary already exists ([storage configuration](../storage.md#configuration-and-credentials)). | **Present** |
+| Crash injection at every apply/activation phase proves deterministic authority | Existing migration fault tests do not cover a SQLite activation state machine ([migration tests](../../tests/test_migration.py#L351-L474)). | **Missing** |
+| Live services, owner data, tags, publication remain separately gated | Repository instructions already impose this boundary ([AGENTS boundaries](../../AGENTS.md#boundaries), [release checklist](../releasing.md)). | **Present guard** |
+| Release-note record | No #146 record exists ([pending records](../../.release-notes)). | **Missing** |
+
+### [#147 — Retire JSON production writers](https://github.com/spontain112/djsupport/issues/147)
+
+| AC | Current evidence and gap | Status |
+| --- | --- | --- |
+| No production JSON adapter/fallback for authority state | Current production is explicitly JSON-backed, the opposite of the target ([storage owners](../storage.md#current-schema-owners), [Runtime Assembly](../../djsupport/runtime.py#L172-L205)). | **Missing** |
+| Transfer and Runtime Assembly expose only Operational Store interface | Transfer and Runtime Assembly expose separate old adapters today ([Transfer constructor](../../djsupport/transfer.py#L2093-L2117), [Runtime graph](../../djsupport/runtime.py#L89-L95)). | **Missing** |
+| Legacy JSON readable only through migration/rollback | Runtime still reads/writes JSON; explicit read-only legacy routing is missing ([Runtime Assembly](../../djsupport/runtime.py#L172-L217), [storage owners](../storage.md#current-schema-owners)). | **Missing** |
+| Remove obsolete locks, temp paths, duplicate schema constants, old-interface tests | These are still active in `FileTransferStorage`, `FilePublicationStorage`, and cache code ([file adapters](../../djsupport/transfer.py#L941-L1369), [cache](../../djsupport/cache.py)). | **Missing** |
+| Interface conformance replaces old adapter-specific tests without weaker behavior | No Operational Store conformance suite exists; current high-level behavior tests must remain ([testing convention](../../CONTRIBUTING.md#engineering-conventions)). | **Missing** |
+| Privacy/package checks reject all database and legacy artifact categories | Current checks lack most enumerated patterns ([privacy tests](../../tests/test_repository_privacy.py), [package job](../../.github/workflows/ci.yml#L57-L162)). | **Missing** |
+| Architecture/storage docs identify SQLite as sole authority and every ignored category | Current docs intentionally identify three JSON documents as authority ([architecture source map](../architecture.md#production-source-map), [storage owners](../storage.md#current-schema-owners)). | **Missing** |
+| Complete offline and packaging suites pass | The commands/gates exist and are green as a baseline, but only the final #147 commit can satisfy this criterion ([contributing](../../CONTRIBUTING.md#development-setup), [release validation](../releasing.md#4-run-the-complete-release-validation)). | **Future gate** |
+| Release-note record | No #147 record exists ([pending records](../../.release-notes)). | **Missing** |
+
+### [#148 — Publish 0.7 migration/recovery guidance in djsupport-docs](https://github.com/spontain112/djsupport/issues/148)
+
+| AC | Current evidence and gap | Status |
+| --- | --- | --- |
+| Implementation is in `djsupport-docs` and linked to the ticket | Product-repo edits cannot satisfy this; [#148](https://github.com/spontain112/djsupport/issues/148) is blocked by [#147](https://github.com/spontain112/djsupport/issues/147). | **Gate** |
+| Cover preflight, backup, Preview, apply, interrupted recovery, restore, rollback | Current product docs explain the JSON-era workflows and can source stable concepts; final commands must wait for #147 behavior ([current backup guide](../backup-and-restore.md), [current upgrade guide](../upgrading.md)). | **Partial source / gate** |
+| Commands/outcomes match final behavior without duplicating internal architecture | The product repo owns internal architecture and executable CLI truth; docs-site content must link rather than fork it ([documentation ownership](../../AGENTS.md#what-goes-where), [CLI truth](../../CONTRIBUTING.md#development-setup)). | **Present boundary / gate** |
+| Private-data section covers every database/legacy/generated category | Current storage docs do not yet contain the final SQLite inventory; #147 must establish it first ([storage privacy](../storage.md)). | **Gate** |
+| Explain gitignore is a guardrail and private data never enters Git | This wording already exists in the engineering guide and can be reused after behavior freezes ([privacy guidance](../../CONTRIBUTING.md#protect-local-dj-data)). | **Present source** |
+| Config and Spotipy credentials outside store | Stable source exists now ([storage configuration](../storage.md#configuration-and-credentials)). | **Present source** |
+| No owner data, paths, credentials, screenshots | Repository policy already forbids these; docs-site verification remains future work ([ADR-0001](../adr/0001-keep-user-data-out-of-the-repository.md), [AGENTS boundaries](../../AGENTS.md#boundaries)). | **Present guard / gate** |
+| Documentation build/link checks pass | Must run in `djsupport-docs`; the product repository explicitly assigns stable public guidance there ([documentation ownership](../../AGENTS.md#what-goes-where)). | **Gate** |
+
+### [#149 — Prepare and freeze exact 0.7.0rc1](https://github.com/spontain112/djsupport/issues/149)
+
+| AC | Current evidence and gap | Status |
+| --- | --- | --- |
+| Complete records and generated changelog identify candidate | Release-record automation exists; the 0.7 records and exact override/candidate do not ([release records](../../.release-notes/README.md), [release workflow](../releasing.md#2-review-the-automated-version-pr)). | **Partial infrastructure** |
+| Full offline/compile/privacy/migration/backup/restore/crash/diagnostics/cross-platform/package/archive/clean-install gates on exact commit | Current CI covers offline/compile on Linux 3.10/3.14 plus package/archive/clean install. SQLite migration, restore, crash, diagnostics, and macOS/Windows gates are missing ([CI](../../.github/workflows/ci.yml)). | **Partial** |
+| Source/wheel contain no private data and include required public policy/notices | Archive inspection exists and `LICENSE` is tracked; the exact candidate still needs content and privacy proof ([package job](../../.github/workflows/ci.yml#L57-L162), [`LICENSE`](../../LICENSE)). | **Future gate** |
+| Disposable installs verify Preview, cutover, resume, restore, rollback, diagnostics with synthetic data | Current clean-install job verifies import and `djsupport --help` only ([clean install](../../.github/workflows/ci.yml#L149-L162)). | **Missing** |
+| Record exact candidate commit/evidence for pre-release publication | #134 provides the public evidence pattern for 0.6; no 0.7 candidate exists ([#134](https://github.com/spontain112/djsupport/issues/134)). | **Missing** |
+| No tag, Release, package publication, live service, or owner-data operation | This is already the repository boundary and must stay separately gated ([AGENTS boundaries](../../AGENTS.md#boundaries), [release policy](../releasing.md#6-publish-an-exact-release-candidate)). | **Present guard** |
+| Main stays explicit development unless a reviewed candidate version commit is required | Current main is stable `0.6.0`, and #136 owns returning it to development before storage work proceeds ([`pyproject.toml`](../../pyproject.toml), [#136](https://github.com/spontain112/djsupport/issues/136)). | **Current blocker / future gate** |
+
+### [#132 — Rebuildable private local diagnostics](https://github.com/spontain112/djsupport/issues/132)
+
+#132 is specified but blocked by #147. The future surface may consume only the accepted read-only event-query interface; it must not change Transfer persistence.
+
+| AC | Current evidence and gap | Status |
+| --- | --- | --- |
+| Views answer Transfer outcomes/pause/failure, Spotify request cost, proposed-to-Approved progression, resume/incomplete effects, and match reasons | No current code defines Operational Events or SQL views; current Transfer reports are not rebuildable analytics projections ([current storage inventory](../storage.md#current-schema-owners), [report model](../../djsupport/report.py)). | **Missing** |
+| Joined private identities never leak through diagnostics | Agent Client output has a reusable privacy-redaction discipline, but no diagnostics interface exists ([Agent privacy decision](../adr/0002-make-transfer-agent-native.md#L26-L31), [agent tests](../../tests/test_agent_contract.py)). | **Partial test model** |
+| Exclude paths, source metadata, playlist/track/account IDs, fingerprints, credentials, SQL, and raw exceptions | Existing repository and Agent privacy tests cover subsets of this denylist; the diagnostics-document contract is missing ([privacy tests](../../tests/test_repository_privacy.py), [Agent decision](../adr/0002-make-transfer-agent-native.md)). | **Partial test model** |
+| Inspect categories/counts and explicitly delete analytics without deleting authority | The current storage model has no analytics-history store, projection rebuild, or independent deletion operation ([storage inventory](../storage.md#current-schema-owners)). | **Missing** |
+| JSON is experimental in 0.7 and not a stable Agent contract | No diagnostics JSON exists; the separation from the Agent contract is an explicit future guard ([Agent architecture](../adr/0002-make-transfer-agent-native.md)). | **Missing** |
+| 1,000,000 compact events and deterministic rebuild | No event scale fixture or rebuild test exists in the current test map ([tests map](../../CONTRIBUTING.md#repository-map)). | **Missing** |
+| No engagement score, productivity ranking, musical-quality judgment, or telemetry | These are issue guardrails, not implemented behavior; current repository CI also forbids credentialed/live service capability ([CI policy test](../../tests/test_release_channels.py#L61-L149)). | **Present guard** |
+| Release-note record | No #132 record exists ([pending records](../../.release-notes)). | **Missing** |
+
+## Dependency order and parallel-safe lanes
+
+```text
+human gate #136 ──┐
+closed #137 ──────┴─> #138 -> #139 -> #140 -> #141
+                                            |
+                                            +-> #142 --+
+                                            +-> #143 --+  (sequence, not parallel)
+                                                       |
+                                                       +-> #144 --+
+                                                       +-> #145 --+  (sequence, not parallel)
+                                                                  |
+                                                                  -> #146 -> #147
+                                                                              |
+                                               +------------------------------+-------------------+
+                                               |                              |                   |
+                                             #130                           #132                #148
+                                               +------------------------------+-------------------+
+                                                                              |
+                                                          closed #131 --------+-> #149
+```
+
+Although #142/#143 and #144/#145 are sibling dependencies, each issue declares the **Operational authority** lane and forbids concurrent work that changes Transfer persistence or the Operational Store interface. Implement one at a time, with either sibling order acceptable, then integrate. #146 is an explicit integration gate and starts only when Runtime Assembly and Operational Store lanes are idle at accepted commits. After #147, [#130](https://github.com/spontain112/djsupport/issues/130), #132, and #148 can run in parallel because they occupy Operational-authority review, read-only diagnostics, and separate public-documentation lanes respectively; [#131](https://github.com/spontain112/djsupport/issues/131) is already closed. #149 waits for all four named dependencies.
+
+## TDD seams that should be reused
+
+| Ticket(s) | First failing test seam | Reusable current evidence |
+| --- | --- | --- |
+| #138 | One parameterized Operational Store conformance suite, instantiated with in-memory and temp-file SQLite adapters; drive a Preview through `Transfer`, close/reopen, and compare exact aggregate state including duplicate occurrences and events. | [`Transfer` tests](../../tests/test_transfer.py), [source occurrence model](../../djsupport/source_facts.py) |
+| #139 | Two independent SQLite connections: distinct-entity writes both survive; same-entity stale expected revision returns the stable reload-before-retry failure; injected commit faults leave old/next complete state; synthetic Spotify asserts no open local transaction at callback. | [file stale-write logic](../../djsupport/transfer.py#L1300-L1347), [runtime cross-client refresh](../../tests/test_runtime.py#L103-L135) |
+| #140 | Table-drive `before_call`, `after_call`, and `before_result_retention` crashes through Transfer and a recording Spotify fake; reopen the store and assert journal classification plus at-most-one provable playlist identity. | [publication recovery tests](../../tests/test_transfer.py#L2378-L2478), [checkpointed publication](../../djsupport/transfer.py#L6033-L6098) |
+| #141 | Inject a local commit failure after every staged Approval category and assert no authority-bearing row changes; then repeat the same completed Approval and stale manifest/head variants. | [Approval tests](../../tests/test_transfer.py#L2784-L3372), [Qualification Approval tests](../../tests/test_agent_contract.py#L1122-L1265) |
+| #142 | Parameterize current Qualification lifecycle/recovery tests over stores; add 1,000 synthetic drafts and direct absence checks for paths, filenames, fingerprints, and audition handles. | [`test_qualification.py`](../../tests/test_qualification.py), [draft state](../../djsupport/transfer.py#L381-L430) |
+| #143 | Parameterize the complete Mirror/Drift/orphan suite; inject interruption at create/replace/description/relink/remove journal boundaries and assert no inferred destructive choice. | [Mirror tests](../../tests/test_transfer.py#L882-L1568), [Mirror lifecycle](../lifecycles.md#mirror-drift-and-orphaning) |
+| #144 | Build a synthetic fixture matrix for every version in `SUPPORTED_SCHEMAS`; hash source bytes before/after Preview and injected faults; compare a normalized whole-store identity projection and a redacted report. | [supported schemas](../../djsupport/backup.py#L21-L32), [migration tests](../../tests/test_migration.py) |
+| #145 | Keep an active WAL-backed writer while taking a backup, validate a reopened snapshot, tamper each archive layer, inject replacement failure, and run platform-path cases with invented data only. | [backup tests](../../tests/test_backup.py), [archive reader](../../djsupport/backup.py#L190-L221) |
+| #146 | Table-drive every staging/verification/install/activation crash point; reconstruct Runtime Assembly after each and assert exactly one authority, no dual writes, and no fallback. | [Runtime Assembly tests](../../tests/test_runtime.py), [current assembly seam](../../djsupport/runtime.py#L142-L217) |
+| #147 | Deletion tests first: production import graph contains no JSON writer; old locks/temp paths/schema constants disappear; interface conformance plus public Transfer tests remain green; privacy/package filename corpus is exhaustive. | [architecture source map](../architecture.md#production-source-map), [privacy tests](../../tests/test_repository_privacy.py) |
+| #132 | Populate deterministic synthetic events, rebuild every SQL view twice, compare results, test deletion independent of authority rows, and run the denylist over the experimental JSON at 1,000,000 events. | [Agent redaction contract](../adr/0002-make-transfer-agent-native.md#L26-L31) |
+| #148 | In `djsupport-docs`, use only commands frozen by #147; build and link-check the site and scan the diff for private paths/data. Product-repo tests cannot substitute for that repository's gates. | [documentation ownership](../../AGENTS.md#what-goes-where), [#148](https://github.com/spontain112/djsupport/issues/148) |
+| #149 | Install the exact wheel in disposable environments and execute synthetic Preview, cutover, resume, restore, rollback, and diagnostics; never rebuild a later SHA to stand in for the candidate. | [release checklist](../releasing.md), [current package job](../../.github/workflows/ci.yml#L57-L162) |
+
+## Work that can be front-loaded safely
+
+These preparations do not claim a blocked execution lane and contain no production authority switch:
+
+1. **Synthetic fixture specification.** Define invented accounts, selections, duplicate occurrences, proposals, conflicts, drafts, Mirrors, incomplete effects, and events from the canonical domain identities. Do not serialize owner-derived examples ([domain identities](../domain-model.md#identity-layers), [fixture policy](../../CONTRIBUTING.md#protect-local-dj-data)).
+2. **Legacy-version matrix.** Enumerate every supported JSON reader version from executable constants and identify the smallest synthetic fixture for each. This can be reviewed before #144, but the importer itself belongs to its Operational-authority lane ([backup constants](../../djsupport/backup.py#L21-L32)).
+3. **Crash/fault matrix.** Write the named phase table for transaction commit, each Effect Journal boundary, migration staging/verification/activation, snapshot/restore, and diagnostics rebuild. Fault hooks may land only with their owning ticket; the research matrix itself is parallel-safe.
+4. **Privacy filename corpus.** Prepare expected ignore/rejection cases for the database, `-wal`, `-shm`, snapshots, backups, restore staging/extraction, diagnostics, query exports, legacy JSON, reports, and temporary copies. Adding production patterns belongs in #138/#145/#147 as specified; no real artifact is needed ([current privacy tests](../../tests/test_repository_privacy.py)).
+5. **Cross-platform CI design.** Specify the minimum macOS/Windows persistence jobs and Linux 3.10/3.14 edges without enabling credentials or live services. Current CI is read-only and offline, which must be preserved ([CI policy](../../tests/test_release_channels.py#L61-L149)).
+6. **Diagnostics contract draft.** Define allowed aggregate categories, stable reason codes, explicit experimental versioning, deletion semantics, and the denylist before #132. Do not add telemetry, scores, or a second authority surface ([#132](https://github.com/spontain112/djsupport/issues/132)).
+7. **Public-doc outline only.** The djsupport-docs lane may outline headings and link ownership, but final commands/outcomes and implementation claims wait for #147. Do not duplicate the internal schema or use private screenshots ([#148](https://github.com/spontain112/djsupport/issues/148)).
+8. **Primary-source SQLite research packet.** Before #138 implementation, record the exact Python `sqlite3` contracts chosen for transaction boundaries, busy timeout, WAL, integrity checks, backup, supported Python versions, and platform behavior. That decision belongs in the product ADR/source tree, not in client adapters; it must not weaken #125's accepted constraints ([#125](https://github.com/spontain112/djsupport/issues/125), [architecture ownership](../../AGENTS.md#what-goes-where)).
+
+## Verification command ladder
+
+Run focused tests continuously, then the complete gates once per finished ticket. Proposed module names below become commands only after their owning ticket adds them.
+
+```bash
+# Existing regression baselines
+python3 -m pytest tests/test_runtime.py tests/test_transfer.py tests/test_qualification.py
+python3 -m pytest tests/test_migration.py tests/test_backup.py
+python3 -m pytest tests/test_repository_privacy.py tests/test_release_records.py
+
+# Proposed focused Operational Store surfaces
+python3 -m pytest tests/test_operational_store.py
+python3 -m pytest tests/test_operational_store_concurrency.py
+python3 -m pytest tests/test_effect_journal.py
+python3 -m pytest tests/test_operational_store_migration.py
+python3 -m pytest tests/test_operational_store_backup.py
+python3 -m pytest tests/test_operational_diagnostics.py
+
+# End-of-ticket product gates
+python3 -m pytest
+python3 -m compileall -q djsupport tests
+python3 scripts/release_records.py check origin/main HEAD
+python3 -m build
+```
+
+For #139, passing locally is insufficient: GitHub CI must show macOS, Windows, Linux/Python 3.10, and Linux/Python 3.14 persistence coverage on the exact commit. For #145/#149, list and inspect both built archives and install the exact wheel in a disposable environment using the canonical commands in the [release checklist](../releasing.md#4-run-the-complete-release-validation). For #148, use the djsupport-docs repository's own build and link-check commands after inspecting its current tooling; do not invent or duplicate them here.
+
+## Non-negotiable boundaries
+
+- Use invented synthetic state only. Databases, WAL/SHM sidecars, snapshots, backups, diagnostics, exports, reports, JSON authority files, paths, playlist identifiers, matching knowledge, and evidence are private user data and never repository/package content ([ADR-0001](../adr/0001-keep-user-data-out-of-the-repository.md), [storage privacy](../storage.md)).
+- No live Spotify or Beatport call, owner Rekordbox/audio read, playlist mutation, tag, GitHub Release, package publication, remote change, or user-derived export is authorized by these issues or this research ([AGENTS boundaries](../../AGENTS.md#boundaries), [#125](https://github.com/spontain112/djsupport/issues/125)).
+- Preview is non-authoritative and never authorizes Spotify mutation; Qualification remains non-authoritative until separate playlist-scoped Approval ([domain invariants](../domain-model.md#core-invariants), [authority ladder](../domain-model.md#authority-ladder)).
+- Never hold a database transaction across an external effect. Intent and observation are separate durable journal transitions; uncertain effects require reconciliation or review rather than guessed replay ([#128](https://github.com/spontain112/djsupport/issues/128), [#140](https://github.com/spontain112/djsupport/issues/140)).
+- Do not dual-write and do not retain a production JSON fallback after cutover. Before #146 activation, JSON remains authoritative; after verified activation and #147 contraction, legacy JSON is read only through explicit migration/rollback ([#138](https://github.com/spontain112/djsupport/issues/138), [#146](https://github.com/spontain112/djsupport/issues/146), [#147](https://github.com/spontain112/djsupport/issues/147)).
+- Keep configuration and Spotipy-managed credentials outside the Operational Store and every backup/migration payload ([storage configuration](../storage.md#configuration-and-credentials), [#144](https://github.com/spontain112/djsupport/issues/144)).
+- Transfer remains the only public policy authority. Operational Store, Runtime Assembly, diagnostics, docs, and clients stay internal/adaptive surfaces and do not create matching, Approval, publication, or destructive intent ([architecture](../architecture.md), [Agent decision](../adr/0002-make-transfer-agent-native.md)).

--- a/docs/research/2026-08-16-sqlite-concurrency-durability-contract.md
+++ b/docs/research/2026-08-16-sqlite-concurrency-durability-contract.md
@@ -1,0 +1,739 @@
+# SQLite concurrency and durability contract for the Operational Store
+
+**Date:** 2026-08-16
+
+**Code baseline:** `main` at `6b04a70eb65681b97b104de8cc1eac6cef49713b`
+
+**Status:** Read-only research for issues
+[#138](https://github.com/spontain112/djsupport/issues/138)–[#143](https://github.com/spontain112/djsupport/issues/143). No production authority switch, owner-data access, or live Spotify/Beatport call was performed.
+
+**Authority:** DJ Support repository requirements plus official SQLite and Python
+standard-library documentation only. Each section separates sourced behavior from
+the implementation and test implications inferred for DJ Support.
+
+## Executive decision
+
+DJ Support should use one local SQLite database, one connection per unit of work,
+and explicit SQL transaction control that behaves the same on Python 3.10 through
+3.14. Every connection should use a five-second busy timeout, `foreign_keys=ON`,
+`synchronous=FULL`, and verified WAL mode. Writes should start with
+`BEGIN IMMEDIATE`, contain only local database work, and commit or roll back before
+any Spotify call. Entity writes should use revision-qualified `UPDATE` statements
+and require exactly one affected row. Backups should use `Connection.backup()`, not
+filesystem copies of the database or its sidecars.
+
+There is one non-negotiable runtime gate. SQLite disclosed a rare WAL-reset race in
+March 2026 affecting concurrent WAL connections through 3.51.2; upstream fixes are
+3.51.3 and the 3.44.6/3.50.7 backports. The Python runtime used for this research
+reports SQLite 3.43.1, which falls in the affected range. Issue #138 can build and
+conformance-test a non-authoritative adapter, but #139 must not claim safe
+concurrent production authority until the linked SQLite library is proven to carry
+an upstream or downstream fix. SQLite itself says applications should upgrade.
+([SQLite WAL-reset bug](https://sqlite.org/wal.html#the_wal_reset_bug),
+[Python runtime version API](https://docs.python.org/3.10/library/sqlite3.html#sqlite3.sqlite_version))
+
+## 1. Project requirements that constrain the database
+
+The program decision is one SQLite Operational Store behind one internal interface,
+shared by local CLI, web, and Agent Clients. Configuration and Spotipy credentials
+stay outside it; external-effect intent and observations go in an Effect Journal;
+Operational Events are private, compact, and non-authoritative; migration is
+backup-first and Preview-first; production must not dual-write JSON and SQLite.
+([program #125](https://github.com/spontain112/djsupport/issues/125),
+[implementation map #128](https://github.com/spontain112/djsupport/issues/128))
+
+The existing file model already distinguishes matching knowledge, publication
+state, Transfer state, configuration, and credentials, and explicitly notes that
+atomic replacement of one JSON file cannot make several files one transaction.
+The Operational Store therefore earns its value only if one transaction can cover
+the whole local authority change without moving policy out of `Transfer`.
+([private-storage model](../storage.md#write-and-concurrency-behavior),
+[architecture](../architecture.md#interfaces-and-adapters))
+
+| Ticket | Database implication |
+| --- | --- |
+| [#138](https://github.com/spontain112/djsupport/issues/138) | Define one `OperationalStore` contract and a transaction/unit-of-work boundary. Make in-memory and SQLite adapters pass the same behavior tests. Preserve occurrence identity, explicit order, duplicates, proposals, failures, checkpoints, and events. Keep JSON as production authority in this ticket. |
+| [#139](https://github.com/spontain112/djsupport/issues/139) | Qualify a patched SQLite runtime, then prove two independent connections/processes, bounded contention, optimistic revision conflicts, integrity checks, and crash atomicity. |
+| [#140](https://github.com/spontain112/djsupport/issues/140) | Commit effect intent, close the transaction, call Spotify, then commit the observation. An intent without a conclusive observation is uncertain and must be reconciled, never silently replayed. |
+| [#141](https://github.com/spontain112/djsupport/issues/141) | Check playlist/manifest heads and write Approval, publication state, matching authority, Corrections, conflicts, and the compact event in one local transaction. |
+| [#142](https://github.com/spontain112/djsupport/issues/142) | Give each draft an optimistic revision. Discard plus successor creation is one transaction. Retain digests and account-scoped Local Audio Identity, never paths, filenames, or process handles. |
+| [#143](https://github.com/spontain112/djsupport/issues/143) | Revision Mirror state and journal every Spotify effect. Orphan, Drift, relink, replacement, and removal remain explicit states/actions; absence never becomes deletion authority. |
+
+## 2. WAL is a concurrency mode, not multi-writer execution
+
+### Sourced facts
+
+- WAL lets readers and a writer proceed concurrently, but there is still exactly
+  one writer at a time. A reader sees a stable end mark for its transaction. WAL
+  uses same-machine shared memory and is not suitable for clients on different
+  hosts through a network filesystem.
+  ([WAL concurrency](https://sqlite.org/wal.html#concurrency))
+- `PRAGMA journal_mode=WAL` returns the resulting mode; success is the literal
+  `wal`. WAL mode persists across connection closes and applies to every
+  connection to that database.
+  ([activating WAL](https://sqlite.org/wal.html#activating_and_configuring_wal_mode),
+  [WAL persistence](https://sqlite.org/wal.html#persistence_of_wal_mode))
+- A commit is represented by a commit record appended to the WAL. Checkpointing
+  later transfers WAL pages into the main database. SQLite normally
+  autocheckpoints at 1,000 pages. A long read transaction can prevent checkpoint
+  completion and allow the WAL to grow.
+  ([how WAL works](https://sqlite.org/wal.html#how_wal_works),
+  [checkpoint behavior](https://sqlite.org/wal.html#checkpointing),
+  [large-WAL causes](https://sqlite.org/wal.html#avoiding_excessively_large_wal_files))
+- The `-wal` file is persistent database state when present; separating it from
+  the main file can lose committed transactions or corrupt the database. The
+  `-shm` file is the shared-memory index and may also remain after an unclean
+  shutdown.
+  ([WAL file lifecycle](https://sqlite.org/wal.html#the_wal_file),
+  [WAL-mode files](https://sqlite.org/walformat.html#files_on_disk))
+
+### Implementation implications (inference)
+
+1. Put the database only in DJ Support's local application-data directory. Refuse
+   an explicitly detected network filesystem rather than implying that cloud- or
+   network-shared storage is supported.
+2. Bootstrap a new database while no other DJ Support connection is active, run
+   `PRAGMA journal_mode=WAL`, and require the returned value to be `wal`. Normal
+   connections should query and verify the mode instead of silently accepting a
+   fallback.
+3. Leave the 1,000-page autocheckpoint enabled explicitly at first. Do not launch
+   competing ad-hoc checkpoint workers. Keep read transactions short, consume or
+   close cursors promptly, and expose WAL growth as a redacted diagnostic.
+4. Treat `operational-store.sqlite3`, `operational-store.sqlite3-wal`, and
+   `operational-store.sqlite3-shm` as one private state family for documentation,
+   ignore rules, repository tests, packaging tests, backup staging, and support
+   diagnostics. Never delete a sidecar to “repair” a database.
+
+### Required tests
+
+- New database, clean reopen, and crash reopen all report `journal_mode=wal`.
+- Two independent connections can hold reads while a third commits distinct work.
+- A deliberately held read snapshot remains stable until its transaction ends,
+  then a new read sees the committed change.
+- A held reader plus enough synthetic writes demonstrates that a checkpoint may be
+  incomplete without treating this as corruption; ending the reader permits a
+  later checkpoint to progress.
+- Repository and wheel tests reject the database, `-wal`, `-shm`, copied snapshots,
+  backup files, migration staging files, query exports, diagnostics, and reports.
+
+## 3. Mandatory WAL runtime qualification
+
+### Sourced fact
+
+SQLite's current WAL documentation says the WAL-reset race is likely present from
+3.7.0 through 3.51.2 and is fixed in 3.51.3. Upstream also published backports in
+3.44.6 and 3.50.7. It requires at least two connections in different threads or
+processes and a tightly timed write/checkpoint race, but can corrupt the database;
+SQLite recommends upgrading.
+([official WAL-reset advisory](https://sqlite.org/wal.html#the_wal_reset_bug))
+
+Python exposes the runtime SQLite library separately from the Python module
+version through `sqlite3.sqlite_version` and `sqlite3.sqlite_version_info`.
+([Python 3.10 `sqlite3`](https://docs.python.org/3.10/library/sqlite3.html#sqlite3.sqlite_version))
+
+### Implementation implication (inference)
+
+Before #139 enables concurrent authority, the store should fail closed unless its
+runtime is one of:
+
+- SQLite 3.51.3 or later;
+- the 3.50 line at 3.50.7 or later;
+- the 3.44 line at 3.44.6 or later; or
+- a downstream build whose maintainer explicitly documents the same fix, recorded
+  in DJ Support's release qualification.
+
+A simple `version >= 3.44.6` comparison is unsafe because upstream identifies the
+intervening 3.45–3.49 lines and 3.51.0–3.51.2 as affected. The capability error
+must report the runtime version without printing a database path. #138 may run its
+single-process, non-authoritative conformance work on older versions, but the
+multi-client capability must remain disabled.
+
+### Required tests
+
+- Unit-test the allow/deny matrix around 3.44.5/3.44.6, 3.45.x, 3.50.6/3.50.7,
+  and 3.51.2/3.51.3.
+- Record `sys.version` and `sqlite3.sqlite_version` as non-private CI metadata on
+  macOS, Linux, and Windows, including the Python 3.10 and 3.14 Linux edges.
+- Make the concurrent-persistence suite fail, not skip, if the release runtime is
+  not proven patched. A downstream-backport exception requires explicit build
+  evidence rather than a user toggle.
+
+## 4. Cross-version Python connection contract
+
+### Sourced facts
+
+Python 3.10 opens implicit transactions unless `isolation_level=None`; that value
+leaves SQLite in its native autocommit mode and permits explicit SQL transaction
+control. `connect(timeout=...)` bounds the wait for a lock and defaults to five
+seconds. A connection defaults to `check_same_thread=True`; using it from another
+thread raises `ProgrammingError`, while disabling the check requires the caller to
+serialize writes. `executescript()` implicitly commits a pending transaction.
+([Python 3.10 connection and transaction control](https://docs.python.org/3.10/library/sqlite3.html#transaction-control))
+
+Python 3.12 added the `autocommit` argument, and Python 3.14 still defaults it to
+`LEGACY_TRANSACTION_CONTROL` while warning that the default will change. Code that
+depends on that newer argument cannot run on Python 3.10.
+([Python 3.14 transaction control](https://docs.python.org/3.14/library/sqlite3.html#transaction-control))
+
+SQLite warns not to inherit an open database connection across `fork()`; the child
+must open its own connection. Python's default thread check likewise favors
+connection ownership by one thread.
+([SQLite fork warning](https://sqlite.org/howtocorrupt.html#_carrying_an_open_database_connection_across_a_fork_),
+[Python `check_same_thread`](https://docs.python.org/3.10/library/sqlite3.html#sqlite3.connect))
+
+### Implementation implication (inference)
+
+Use a connection factory, not one Runtime Assembly-owned connection:
+
+```python
+sqlite3.connect(
+    database_path,
+    timeout=5.0,
+    isolation_level=None,
+    check_same_thread=True,
+)
+```
+
+Then configure and verify on **every** connection:
+
+```sql
+PRAGMA foreign_keys = ON;
+PRAGMA synchronous = FULL;
+PRAGMA wal_autocheckpoint = 1000;
+```
+
+Query and require `foreign_keys=1`, `synchronous=2`,
+`wal_autocheckpoint=1000`, `busy_timeout=5000`, and `journal_mode=wal`. PRAGMAs
+can be misspelled without an error, so setting without reading back is inadequate.
+([PRAGMA behavior](https://sqlite.org/pragma.html#pragma_command_syntax))
+
+Open a connection inside the thread/process that performs the unit of work and
+close it at the boundary. Never pass it to another thread, cache it across a fork,
+or expose it through the `OperationalStore` interface. This permits CLI, web, and
+Agent Clients to share the database through SQLite's file locking without sharing
+Python connection objects.
+
+Do not pass the Python 3.12-only `autocommit` keyword while Python 3.10 remains
+supported. Do not use `executescript()` inside migration transaction helpers;
+execute the registered statements individually so Python cannot introduce an
+implicit commit.
+
+### Required tests
+
+- The same connection-factory assertions run on Python 3.10 and 3.14.
+- A connection used by a different thread fails in the test harness; production
+  code creates a fresh connection in that thread instead.
+- A subprocess opens its own connection after process creation. No fixture opens a
+  parent connection and then forks.
+- Every public store operation leaves `connection.in_transaction` false on success
+  and on each injected exception.
+
+## 5. Transaction modes and exact boundaries
+
+### Sourced facts
+
+SQLite permits many simultaneous read transactions but only one write transaction.
+`BEGIN DEFERRED` does not acquire the write transaction until needed; upgrading an
+older read snapshot can fail with `SQLITE_BUSY_SNAPSHOT`. `BEGIN IMMEDIATE` starts
+the write transaction at once. If it succeeds, SQLite guarantees that later work
+through the next commit will not fail with `SQLITE_BUSY`.
+([transactions](https://sqlite.org/lang_transaction.html#deferred_immediate_and_exclusive_transactions),
+[snapshot isolation](https://sqlite.org/isolation.html#isolation_and_concurrency),
+[busy result](https://sqlite.org/rescode.html#busy))
+
+In WAL mode, `BEGIN EXCLUSIVE` and `BEGIN IMMEDIATE` have the same locking effect.
+Transactions created by `BEGIN` do not nest; savepoints provide nesting, but an
+inner `RELEASE` is not durable until the outer transaction commits.
+([transaction modes](https://sqlite.org/lang_transaction.html#deferred_immediate_and_exclusive_transactions),
+[savepoints](https://sqlite.org/lang_savepoint.html))
+
+### Implementation implication (inference)
+
+Provide one store-owned transaction helper with this semantic shape:
+
+```python
+connection.execute("BEGIN IMMEDIATE")
+try:
+    # Pure SQLite reads, validation, and writes only.
+    ...
+    connection.execute("COMMIT")
+except BaseException:
+    if connection.in_transaction:
+        connection.execute("ROLLBACK")
+    raise
+```
+
+- Use autocommit for a single fully consumed `SELECT`.
+- Use a short explicit `BEGIN` only when several reads must share one snapshot.
+- Use `BEGIN IMMEDIATE` for every read-then-write authority operation, including
+  migration, revision comparison, Approval, draft supersession, and Mirror change.
+- Do not use `BEGIN EXCLUSIVE`; it adds no WAL benefit and communicates the wrong
+  intent.
+- Let the outer Operational Store unit of work own commit. Repository helpers may
+  use savepoints only for local composition and must never imply that `RELEASE`
+  made an external effect safe.
+- Perform parsing, hashing, Spotify request construction, and other expensive pure
+  computation before `BEGIN IMMEDIATE`; revalidate revision/head facts after the
+  transaction starts.
+
+### Issue-specific boundaries
+
+Any Spotify read needed to form a playlist head, ordered review, or reconciliation
+observation happens before Transaction A. The transaction then binds that exact
+observed fact to the current local manifest/revision; it never performs the remote
+read while holding the writer transaction.
+
+| Operation | Transaction A | Outside any transaction | Transaction B |
+| --- | --- | --- | --- |
+| Preview/resume (#138) | Retain the complete local checkpoint, proposals/failures, and event | Nothing authority-bearing | Not needed |
+| Snapshot publication (#140) | Insert immutable manifest/items plus effect intent | One bounded Spotify call | Retain observed response or conclusive failure and advance state |
+| Approval (#141) | Compare exact heads/revisions and commit all Approval, publication, matching, Correction, conflict, and event changes together | Nothing | Not needed |
+| Draft apply (#142) | Retain draft-application effect intent | One bounded Spotify call | Retain observation; playlist-scoped Approval remains a later act |
+| Mirror replace/relink/remove (#143) | Retain expected Mirror revision and effect intent | One bounded Spotify call | Retain observation and advance/reconcile Mirror state |
+
+No connection, cursor, generator-backed query result, or transaction context may
+cross the Spotify adapter call.
+
+## 6. Bounded busy handling and retry semantics
+
+### Sourced facts
+
+SQLite's busy timeout sleeps repeatedly until the configured accumulated duration,
+then returns `SQLITE_BUSY`; each connection has only one busy handler. Python's
+`timeout` parameter exposes this behavior and raises `OperationalError` after the
+bound. SQLite distinguishes cross-connection `SQLITE_BUSY` from same-connection or
+shared-cache `SQLITE_LOCKED`.
+([SQLite busy timeout](https://sqlite.org/c3ref/busy_timeout.html),
+[SQLite result codes](https://sqlite.org/rescode.html#busy),
+[Python connection timeout](https://docs.python.org/3.10/library/sqlite3.html#sqlite3.connect))
+
+### Implementation implication (inference)
+
+- Production lock wait: five seconds, set once through `connect(timeout=5.0)` and
+  verified via `PRAGMA busy_timeout`. Do not replace the handler later.
+- Start writes with `BEGIN IMMEDIATE`. If it times out, roll back if necessary and
+  return a typed, privacy-redacted `StoreBusy`/“retry later” outcome.
+- Do not hide a second retry loop inside the adapter. A later user/client retry
+  opens a fresh connection and fresh transaction. This makes the total wait
+  bounded and prevents stale in-memory facts from surviving a retry.
+- A revision conflict is not lock contention and must never be retried as busy; it
+  returns reload-before-retry immediately.
+- Recovery-opening `SQLITE_BUSY` is also bounded. Never delete `-wal`/`-shm` to
+  force progress.
+
+### Required tests
+
+Inject a shorter test-only timeout (for example 50 ms), hold `BEGIN IMMEDIATE` on
+connection A, and have independent connection B attempt the same. Coordinate with
+process/thread events rather than sleeps. Assert B returns the typed busy outcome
+within a generous finite ceiling, changes nothing, and succeeds with a fresh read
+and transaction after A commits. Separately prove two connections can update
+different entities sequentially without lost updates.
+
+## 7. Optimistic revisions must be compare-and-swap writes
+
+### Sourced facts
+
+An SQLite `UPDATE` with a `WHERE` predicate affects only matching rows, and zero
+matches is not itself a SQL error. Python `Cursor.rowcount` reports the number of
+rows modified by `INSERT`, `UPDATE`, `DELETE`, and `REPLACE`.
+([SQLite `UPDATE`](https://sqlite.org/lang_update.html),
+[Python `rowcount`](https://docs.python.org/3.10/library/sqlite3.html#sqlite3.Cursor.rowcount))
+
+### Implementation implication (inference)
+
+Every mutable authority-bearing aggregate gets one integer revision. Preserve the
+current file-adapter convention: a new caller state starts at revision 0, initial
+retention creates revision 1, and each successful save increments by one.
+
+```sql
+UPDATE transfers
+   SET state_json = ?, revision = revision + 1
+ WHERE transfer_id = ? AND revision = ?;
+```
+
+Require `cursor.rowcount == 1`. A zero count means absent or stale and maps to one
+fail-closed reload-before-retry outcome; more than one is an invariant failure.
+Return a newly materialized revision after commit instead of mutating the caller's
+object before durability is known.
+
+- Transfers, Batches, matching-knowledge entities, Publication Manifests,
+  Qualification Drafts, and Mirrors need revision scopes that match their
+  independent user decisions.
+- Inserts use unique stable identities. A duplicate insert is a conflict, not an
+  update.
+- Approval and draft supersession execute all required compare-and-swap statements
+  inside one `BEGIN IMMEDIATE`; if any row count is not one, roll back every row.
+- Never use unconditional `UPDATE`, last-write-wins `UPSERT`, or
+  `INSERT OR REPLACE` for authority state.
+
+### Required tests
+
+- Two independently loaded copies at revision *n*: the first saves and returns
+  *n+1*; the second fails closed and leaves the first result byte-for-byte
+  equivalent at the domain projection level.
+- Run that test for Transfer, Batch, one matching-knowledge entity, manifest/draft,
+  and Mirror, not only one representative table.
+- Inject failure after each statement in Approval and draft supersession; no table
+  may retain a partial update and no input object's revision may change.
+- The in-memory adapter must implement the same compare-and-swap semantics rather
+  than serving as a permissive fake.
+
+## 8. Relational constraints and ordered duplicates
+
+### Sourced facts
+
+SQLite foreign-key enforcement is disabled by default and must be enabled per
+connection outside any active transaction. `PRAGMA foreign_key_check` returns one
+row per violation. Parent keys must be primary/unique keys; indexes on child keys
+are strongly recommended to avoid linear scans.
+([foreign-key PRAGMA](https://sqlite.org/pragma.html#pragma_foreign_keys),
+[foreign-key indexes](https://sqlite.org/foreignkeys.html#fk_indexes),
+[foreign-key check](https://sqlite.org/pragma.html#pragma_foreign_key_check))
+
+SQLite does not guarantee row order without `ORDER BY`. It can even reverse many
+unordered queries under `PRAGMA reverse_unordered_selects` to reveal invalid
+assumptions. SQLite's legacy primary-key behavior can permit `NULL` unless the key
+is an `INTEGER PRIMARY KEY`, `WITHOUT ROWID`, `STRICT`, or explicitly `NOT NULL`.
+([unordered result warning](https://sqlite.org/pragma.html#pragma_reverse_unordered_selects),
+[primary-key `NULL` behavior](https://sqlite.org/lang_createtable.html#the_primary_key))
+
+### Implementation implication (inference)
+
+- Declare stable text identifiers `NOT NULL` even when they participate in a
+  primary key. Use explicit `CHECK` constraints for revision non-negativity,
+  ordinals, and closed state vocabularies where compatible with migrations.
+- Give each Source Occurrence its own identity and a selection-local ordinal.
+  `UNIQUE(source_selection_id, ordinal)` protects order; **do not** make track URI,
+  source key, or metadata unique, because duplicate occurrences are valid.
+- Give Publication Items the equivalent `UNIQUE(manifest_id, ordinal)` contract.
+- Every ordered read uses `ORDER BY ordinal, occurrence_id` (or the corresponding
+  stable tie-breaker), never insertion order or rowid.
+- Use foreign keys for ownership relationships and index every child-key column.
+  Default authority relationships to `ON DELETE RESTRICT`/`NO ACTION`; do not let
+  a cascade turn source absence or aggregate deletion into playlist authority.
+- Keep all Operational Store tables in one database. WAL transactions across
+  attached databases are atomic per database, not as a set.
+  ([WAL attached-database limit](https://sqlite.org/wal.html#overview))
+
+### Required tests
+
+Round-trip repeated source facts at different occurrence identities and positions;
+turn on `reverse_unordered_selects` in a test connection; assert the public result
+remains exact. Attempt orphan rows, duplicate ordinals, null identities, invalid
+states, and deletion of referenced authority; each must fail and roll back.
+
+## 9. Integrity checks and fail-closed recovery
+
+### Sourced facts
+
+`PRAGMA integrity_check` verifies low-level formatting, pages, index entries,
+freelist use, and `UNIQUE`, `CHECK`, and `NOT NULL` constraints. Success is one row
+containing `ok`. It does **not** check foreign keys; that requires
+`PRAGMA foreign_key_check`. `quick_check` is O(N) but skips unique and index/table
+consistency checks that full `integrity_check` performs in O(N log N).
+([integrity check](https://sqlite.org/pragma.html#pragma_integrity_check),
+[quick check](https://sqlite.org/pragma.html#pragma_quick_check))
+
+### Implementation implication (inference)
+
+Use explicit check levels rather than claiming every successful query proves
+integrity:
+
+| Boundary | Required checks |
+| --- | --- |
+| Every connection | Verify connection PRAGMAs, application schema registry, and supported runtime; fail on any SQLite corruption/schema error. |
+| First adapter bootstrap and crash-recovery tests | `quick_check` plus `foreign_key_check`; fail closed on any row other than `ok`/empty violations. |
+| Before and after migration, import verification, cutover, backup, and restore | Full `integrity_check` plus `foreign_key_check`, followed by domain counts/digests and revision/state invariants. |
+| Maintainer diagnostic | Full checks on explicit request, with paths and user facts redacted from output. |
+
+Do not auto-run `REINDEX`, delete sidecars, drop rows, disable constraints, or select a
+newer-looking record when a check fails. Preserve the files, return a redacted
+repair/restore requirement, and require explicit recovery.
+
+## 10. Crash atomicity and durability
+
+### Sourced facts
+
+SQLite's recovery guarantee is that a crash in a transaction rolls back partial
+work on next access. In WAL mode, `synchronous=FULL` adds a WAL sync after every
+transaction commit and is ACID; `NORMAL` remains consistent but can lose a recent
+transaction after power or operating-system failure. SQLite recommends FULL for
+maximum reliability.
+([synchronous modes](https://sqlite.org/pragma.html#pragma_synchronous),
+[corruption and crash recovery](https://sqlite.org/howtocorrupt.html#overview))
+
+Python's progress handler can run every *n* SQLite virtual-machine instructions,
+which provides a standard-library-only subprocess seam for terminating execution
+inside `COMMIT`.
+([Python progress handler](https://docs.python.org/3.10/library/sqlite3.html#sqlite3.Connection.set_progress_handler))
+
+### Implementation implication (inference)
+
+Use `synchronous=FULL` on every connection. A transaction's domain projection must
+have exactly two valid crash outcomes: the complete previous state or the complete
+next state. “Next state” includes its revision and Operational Event; an event or
+revision without the corresponding aggregate is partial corruption at the
+application level even if SQLite's pages are structurally valid.
+
+### Deterministic crash suite
+
+Run each case in a subprocess and reopen from a new process:
+
+1. Exit before `BEGIN IMMEDIATE`: require previous state.
+2. `os._exit()` after all DML but before `COMMIT`: require previous state.
+3. Install a progress handler with interval 1 immediately before executing
+   `COMMIT`, then `os._exit()` at successive callback ordinals. First prove the
+   runtime invokes the handler during `COMMIT`; exercise every observed ordinal.
+   Accept complete previous or complete next state, never a mixture.
+4. Exit immediately after `COMMIT` returns: require complete next state.
+5. Repeat with a constraint error and an injected Python exception: require
+   previous state and `in_transaction == false` after handled rollback.
+
+After every reopen, run full integrity and foreign-key checks and compare a
+canonical domain digest. This proves application-process crash behavior across the
+supported OS/Python matrix. It does not pretend to simulate lying storage hardware;
+the power-loss durability claim comes from WAL plus FULL and still depends on the
+operating system honoring sync requests.
+
+## 11. Effect Journal: database atomicity stops at Spotify
+
+### Sourced fact
+
+SQLite transactions are atomic only for database work; they cannot make a remote
+Spotify mutation part of the commit. The project explicitly requires intent before
+the call, observation afterward, and no transaction across the network.
+([transactions](https://sqlite.org/lang_transaction.html),
+[#140](https://github.com/spontain112/djsupport/issues/140),
+[#142](https://github.com/spontain112/djsupport/issues/142),
+[#143](https://github.com/spontain112/djsupport/issues/143))
+
+### Implementation implication (inference)
+
+Each effect needs a stable local identity, aggregate identity/revision, operation
+kind, canonical request digest, state, and redacted observation. The minimum state
+machine is:
+
+```text
+prepared -> observed_complete
+         -> observed_failed
+         -> uncertain -> reconciled_complete | reconciled_not_applied | review_required
+```
+
+- Commit `prepared` with the exact Publication Manifest/items before Spotify.
+- Make one bounded call with no database transaction open.
+- Commit only facts actually observed afterward.
+- `observed_failed` is reserved for a response that proves the mutation did not
+  occur; a timeout or disconnect after dispatch is `uncertain`.
+- A crash after dispatch but before observation is `uncertain`, not “not attempted.”
+- Stable publication/effect identity enables reconciliation; it does not itself
+  prove Spotify applied or did not apply the request.
+- Automatic retry is allowed only when reconciliation proves the effect was not
+  applied or the remote operation is independently proven idempotent. Otherwise
+  require review.
+- Preview never inserts an effect intent.
+
+### Required tests
+
+At the before-call, after-call, and before-observation-retention boundaries, crash a
+worker using a synthetic Spotify adapter. Assert deterministic resume categories,
+no duplicate Snapshot creation, and no inferred authority. For #141, inject failure
+at every local Approval statement and prove the entire local transaction rolls
+back. For #143, exercise replace, description, relink, and explicit removal as
+separate journaled effects.
+
+## 12. Backup, snapshot, and restore contract
+
+### Sourced facts
+
+Copying a live SQLite file can capture old and new pages and produce a corrupt
+backup. If a WAL exists, copying or moving the main file without its matched WAL can
+lose committed transactions or corrupt the result. SQLite's Online Backup API makes
+a consistent snapshot while other clients use the source, and Python exposes it as
+`Connection.backup()`.
+([unsafe and safe backup methods](https://sqlite.org/howtocorrupt.html#_backup_or_restore_while_a_transaction_is_active),
+[SQLite Online Backup API](https://sqlite.org/backup.html),
+[Python backup API](https://docs.python.org/3.10/library/sqlite3.html#sqlite3.Connection.backup))
+
+### Implementation implication (inference)
+
+1. Open the source through the Operational Store connection factory.
+2. Open a fresh private destination file and call `source.backup(destination)` with
+   bounded busy handling.
+3. Close/reopen the destination, run full integrity and foreign-key checks, verify
+   schema registry plus domain counts/digests, then hash it into the backup manifest.
+4. Never copy or zip a live `.sqlite3`, `-wal`, and `-shm` set. Never copy just the
+   main file after a manual checkpoint and infer quiescence.
+5. Restore only while DJ Support clients are quiescent under an explicit recovery
+   gate. Validate the candidate first, preserve the current store as a verified
+   backup, then switch the database family. Do not replace an open database file.
+
+## 13. Explicit schema migration registry
+
+### Sourced facts
+
+SQLite reserves `PRAGMA user_version` as an application-controlled integer and does
+not interpret it. Python 3.10's `executescript()` can implicitly commit a pending
+transaction, so it is unsuitable inside an outer migration helper unless the script
+fully owns transaction control.
+([user version](https://sqlite.org/pragma.html#pragma_user_version),
+[Python transaction control](https://docs.python.org/3.10/library/sqlite3.html#transaction-control))
+
+### Implementation implication (inference)
+
+Use an explicit table as the canonical registry rather than an integer alone:
+
+```sql
+CREATE TABLE schema_migrations (
+    version INTEGER PRIMARY KEY CHECK (version > 0),
+    name TEXT NOT NULL UNIQUE,
+    sha256 TEXT NOT NULL
+);
+```
+
+- Code owns an immutable ordered registry of `(version, name, sha256, statements)`.
+- Bootstrap/migrate under `BEGIN IMMEDIATE`; execute each statement individually;
+  insert the registry row last; commit once.
+- Before applying, require a contiguous applied prefix and exact name/checksum
+  matches. A gap, changed checksum, duplicate, or database version newer than the
+  application fails closed.
+- Concurrent starters serialize at `BEGIN IMMEDIATE`; the second re-reads the
+  registry after acquiring the writer transaction.
+- Take and validate the backup before starting migration. Run complete integrity,
+  foreign-key, and domain verification after commit.
+- If `PRAGMA user_version` is mirrored for tooling convenience, update and verify it
+  in the same migration and treat disagreement with the registry as corruption.
+  The table remains canonical because it can prove migration identity/checksum.
+- No migration calls Spotify, reads owner source files, edits configuration, or
+  deletes legacy JSON. #138 introduces the registry without production cutover.
+
+### Required tests
+
+Fresh bootstrap, every supported prefix, concurrent bootstrap, crash at every
+statement, checksum drift, version gap, newer schema, repeated migration, and
+backup/restore must all be covered. Reopening after a crash sees either the prior
+complete registry/schema or the next complete registry/schema.
+
+## 14. Deterministic conformance and scale verification
+
+### Project scale requirements
+
+[#138](https://github.com/spontain112/djsupport/issues/138) requires 100,000 Source
+Occurrences and 10,000 Transfers; [#142](https://github.com/spontain112/djsupport/issues/142)
+requires 1,000 Qualification Drafts. The parent schema ticket additionally requires
+1,000,000 compact Operational Events.
+([#127](https://github.com/spontain112/djsupport/issues/127))
+
+### Implementation and test implications (inference)
+
+- Generate exactly 10,000 Transfers with ten ordered occurrences each. Derive all
+  IDs, account/source keys, timestamps, revisions, and facts arithmetically; do not
+  use wall clock, UUID randomness, network data, or owner fixtures.
+- Repeat the same synthetic track fact at planned adjacent ordinals so the test
+  proves occurrences are not deduplicated.
+- Derive 1,000 drafts and 1,000,000 events from stable transfer indices. Use fixed
+  compact category vocabularies; events never become authority inputs.
+- Exercise the public `OperationalStore` contract against both adapters and compare
+  canonical projections/hashes, not SQLite file bytes, rowids, query plans, or WAL
+  layout.
+- Every projection query includes explicit ordering. Verify exact counts, ordered
+  identity digests, duplicate positions, revision sums, checkpoint categories,
+  and restart/reopen equality.
+- Use deterministic bounded batches that mirror real units of work; do not wrap the
+  entire million-row fixture in one production-style transaction merely to make the
+  test fast.
+- Avoid wall-clock pass/fail thresholds across operating systems. Record duration
+  and file/WAL sizes as diagnostic evidence; correctness, bounded lock tests, and
+  absence of unbounded growth are the assertions.
+- After the scale load: close/reopen, read from a second connection, run full
+  integrity and foreign-key checks, use the Online Backup API, restore the backup,
+  and compare the same canonical digest.
+- Run ordinary conformance on every CI cell; run the full scale and crash suites on
+  the explicit macOS/Linux/Windows persistence matrix, with Python 3.10 and 3.14
+  edges on Linux.
+
+## 15. Rejected unsafe patterns
+
+| Rejected pattern | Why it is unsafe | Required replacement |
+| --- | --- | --- |
+| Long database transaction across Spotify | Holds the sole WAL writer while waiting on an unbounded external system and still cannot make the remote mutation atomic. | Commit journal intent, close transaction, call Spotify, open a new transaction for the observation. |
+| Copying the database and WAL files | A live filesystem copy can mix points in time; the WAL is matched persistent state and cannot safely be paired, omitted, or deleted by hand. | `Connection.backup()` to a fresh file, then integrity, foreign-key, schema, and domain verification. |
+| Unbounded lock waits or hidden retry loops | One writer exists; an unbounded client can freeze CLI/web/Agent work and retain stale decisions. | One five-second SQLite busy timeout, typed busy result, then a later fresh-connection retry. |
+| Silent stale overwrite | A valid SQL update can replace authority using an obsolete client view. | Revision-qualified compare-and-swap; require exactly one row; reload before retry. |
+| `BEGIN DEFERRED` for read-then-write authority | Another writer can invalidate the snapshot and cause mid-transaction `BUSY_SNAPSHOT`. | `BEGIN IMMEDIATE`, then re-read and validate inside the acquired write transaction. |
+| Shared Python connection across request threads or forked processes | Violates Python's default thread ownership and SQLite's fork safety contract. | One connection factory; open and close in the executing thread/process. |
+| Foreign keys left at their default | The default is normally off and can be compile-time dependent, so relying on it can permit orphan authority rows. | Enable and verify on every connection; run separate foreign-key checks. |
+| `executescript()` inside a migration helper | Python may commit the pending transaction before the script, breaking the promised atomic boundary. | Registered statements executed individually inside one explicit transaction. |
+| Unordered `SELECT` used as source order | SQLite does not promise insertion/rowid order and optimizer versions may change it. | Explicit occurrence ordinal plus `ORDER BY`. |
+| Concurrent WAL on an unqualified SQLite runtime | The official WAL-reset advisory identifies a rare corruption race in affected versions. | Patched-runtime gate and CI/release evidence before #139 activation. |
+
+## 16. Definition of done by issue
+
+### #138 — one non-authoritative Operational Store path
+
+- One deep interface and unit-of-work contract; in-memory and SQLite conformance.
+- WAL bootstrap, migration registry, connection PRAGMA verification, exact ordered
+  duplicate round-trip, compact events, and deterministic 100k/10k scale evidence.
+- Database/sidecar privacy and packaging coverage.
+- Production runtime remains on existing JSON with no dual-write or cutover.
+
+### #139 — concurrent authority safety
+
+- Patched SQLite runtime is a release gate.
+- Two independent connections and two independent processes pass distinct-work,
+  stale-write, bounded-busy, crash, integrity, and recovery tests.
+- Every mutable authority entity uses compare-and-swap revisions.
+- No transaction spans an external call; public redaction behavior is unchanged.
+
+### #140 — Snapshot Effect Journal
+
+- Immutable ordered manifest/items and prepared effect commit before Spotify.
+- Observation commit afterward; uncertain crash window requires reconciliation.
+- Stable identity prevents duplicate creation only when remote completion is proven.
+- Preview produces no effect intent.
+
+### #141 — atomic Approval
+
+- Exact account-scoped manifest and playlist head/revision checks inside
+  `BEGIN IMMEDIATE`.
+- Approval, publication, matching knowledge, Corrections, conflicts, and event
+  commit once or roll back together.
+- Repetition is idempotent; stale inputs fail closed.
+
+### #142 — Qualification Draft lifecycle
+
+- Revisioned choices remain non-authoritative.
+- Discard and successor insert are one transaction; apply uses the Effect Journal.
+- Digests and account-scoped audio associations round-trip without local paths or
+  process handles; deterministic 1,000-draft verification passes.
+
+### #143 — Mirror lifecycle
+
+- Account/source/selection/playlist identity, ordered managed items, manifest,
+  Mirror revision, and effect state remain linked by constrained rows.
+- Replacement, description, relink, and removal recover through separate stable
+  effects.
+- Drift offers only explicit restore/revocation; orphan state never infers deletion.
+
+## Official sources
+
+- DJ Support: [program #125](https://github.com/spontain112/djsupport/issues/125),
+  [schema/migration #127](https://github.com/spontain112/djsupport/issues/127),
+  [implementation map #128](https://github.com/spontain112/djsupport/issues/128),
+  [#138](https://github.com/spontain112/djsupport/issues/138),
+  [#139](https://github.com/spontain112/djsupport/issues/139),
+  [#140](https://github.com/spontain112/djsupport/issues/140),
+  [#141](https://github.com/spontain112/djsupport/issues/141),
+  [#142](https://github.com/spontain112/djsupport/issues/142), and
+  [#143](https://github.com/spontain112/djsupport/issues/143).
+- SQLite: [WAL](https://sqlite.org/wal.html),
+  [transactions](https://sqlite.org/lang_transaction.html),
+  [isolation](https://sqlite.org/isolation.html),
+  [result codes](https://sqlite.org/rescode.html),
+  [PRAGMAs](https://sqlite.org/pragma.html),
+  [foreign keys](https://sqlite.org/foreignkeys.html),
+  [savepoints](https://sqlite.org/lang_savepoint.html),
+  [Online Backup API](https://sqlite.org/backup.html), and
+  [corruption hazards](https://sqlite.org/howtocorrupt.html).
+- Python: [`sqlite3` in Python 3.10](https://docs.python.org/3.10/library/sqlite3.html)
+  and [`sqlite3` in Python 3.14](https://docs.python.org/3.14/library/sqlite3.html).

--- a/docs/research/2026-08-16-sqlite-migration-backup-cutover-contract.md
+++ b/docs/research/2026-08-16-sqlite-migration-backup-cutover-contract.md
@@ -1,0 +1,516 @@
+# SQLite migration, backup, and cutover contract
+
+**Date:** 2026-08-16
+
+**Baseline:** `origin/main` at `6b04a70`
+
+**Status:** Implementation research for issues
+[#144](https://github.com/spontain112/djsupport/issues/144),
+[#145](https://github.com/spontain112/djsupport/issues/145),
+[#146](https://github.com/spontain112/djsupport/issues/146), and
+[#147](https://github.com/spontain112/djsupport/issues/147). No production
+data, live service, database, backup, or credential was accessed.
+
+**Authority:** SQLite documentation and source, Python standard-library
+documentation, and the DJ Support repository and issue contracts. Sourced
+facts and DJ Support design inferences are identified separately.
+
+## Decision
+
+Implement one recoverable pipeline:
+
+1. canonical legacy readers take a stable, read-only snapshot of the three
+   supported JSON authorities;
+2. one transaction imports that snapshot into a private staging database;
+3. semantic verification proves exact equivalence, then SQLite structural and
+   relational checks prove the staged file is internally valid;
+4. SQLite backups use `sqlite3.Connection.backup()` into a fresh staging
+   database, never a live-file copy;
+5. backup and restore artifacts are closed, self-contained SQLite files with
+   no WAL or SHM member;
+6. activation swaps one small authority pointer between validated SQLite
+   generations while every client is quiesced; and
+7. legacy JSON and superseded SQLite generations remain retained, inert, and
+   private for an explicitly documented rollback window.
+
+The authority pointer is a selector, not a second state store. Before the
+pointer exists, the accepted migration version may use JSON. Once it exists,
+the referenced SQLite generation is the only runtime authority; a missing,
+unsupported, or damaged generation stops the application. It must never cause
+a fallback to JSON.
+
+## Non-negotiable boundaries
+
+- **Reject live-file copying.** A WAL-mode database can contain committed data
+  in `-wal` that is not yet in the main file. SQLite says separating the main
+  file from its WAL can lose committed transactions or corrupt the database,
+  and lists the Online Backup API as a safe way to copy a live database
+  ([WAL persistent state](https://www.sqlite.org/wal.html#the_wal_file),
+  [corruption guidance](https://www.sqlite.org/howtocorrupt.html#_backup_or_restore_while_a_transaction_is_active)).
+- **Reject WAL/SHM archival.** The WAL is persistent database state while it is
+  live; SHM is a transient, native-byte-order coordination cache and is rebuilt
+  from WAL. Neither is a portable backup member
+  ([WAL-mode files and recovery](https://www.sqlite.org/walformat.html#files_on_disk)).
+  Produce a new logical snapshot through SQLite instead.
+- **Reject dual-write.** JSON and SQLite must never both accept production
+  writes. There is no two-database atomic commit in this design, and SQLite
+  explicitly notes that WAL transactions spanning attached databases are not
+  atomic as a set
+  ([WAL limitations](https://www.sqlite.org/wal.html#overview)).
+- **Reject silent fallback.** A bad or missing activated database is a recovery
+  condition, not permission to resurrect stale JSON. Fallback would make
+  authority depend on damage timing and could overwrite newer state.
+- **Reject partial-client cutover.** CLI, web, and Agent Clients must drain and
+  close their store connections before activation, then all reopen through
+  Runtime Assembly. A pointer swap without connection quiescence would leave
+  some clients using the old generation.
+- **Reject deletion as retention policy.** Original JSON, superseded database
+  generations, and rollback backups are removed only by a later explicit,
+  separately previewed cleanup. Expiry of the rollback window is not deletion
+  authorization.
+
+## Primary-source facts
+
+### A logical backup is the safe snapshot seam
+
+Python's `Connection.backup(target, pages=..., progress=..., name="main",
+sleep=...)` works while other clients access the source. Positive `pages`
+values copy incrementally; the target is another `Connection`
+([Python 3.10 `sqlite3` backup](https://docs.python.org/3.10/library/sqlite3.html#sqlite3.Connection.backup)).
+The underlying SQLite API holds a write transaction on the destination, takes
+only step-sized read locks on the source, restarts when another connection
+changes the source, and leaves a completed destination as a consistent
+snapshot. Continuous source writes can repeatedly restart an incremental
+backup, so completion needs an application deadline rather than an unbounded
+retry loop
+([SQLite Online Backup API](https://www.sqlite.org/c3ref/backup_finish.html),
+[backup locking](https://www.sqlite.org/backup.html#file_and_database_connection_locking)).
+
+This guarantee is consistency, not an application-defined event boundary. A
+backup under concurrent writes may advance as SQLite restarts it. Therefore a
+DJ Support backup manifest must read its generation/revision facts from the
+completed destination, never assume the copy represents the instant at which
+the command began.
+
+### WAL and connection lifecycle matter
+
+In WAL mode, a read transaction sees one fixed snapshot, readers can coexist
+with a writer, and only one writer can commit at a time
+([WAL concurrency](https://www.sqlite.org/wal.html#concurrency),
+[SQLite transactions](https://www.sqlite.org/lang_transaction.html#read_transactions_versus_write_transactions)).
+Committed frames may remain in `-wal` until checkpointed. A clean final
+read/write connection normally checkpoints and removes WAL/SHM, but abnormal
+or read-only shutdown can leave them behind
+([WAL file lifecycle](https://www.sqlite.org/walformat.html#file_lifecycles)).
+SQLite recommends converting a database to `journal_mode=DELETE` before
+placing the image on read-only media
+([read-only WAL guidance](https://www.sqlite.org/wal.html#read_only_databases)).
+
+As of this research date, SQLite documents a rare WAL-reset corruption bug in
+versions through 3.51.2, fixed in 3.51.3 with backports 3.44.6 and 3.50.7. The
+trigger requires multiple connections with concurrent checkpoint/write timing
+([SQLite WAL-reset notice](https://www.sqlite.org/wal.html#the_wal_reset_bug)).
+Python exposes the linked runtime version as `sqlite3.sqlite_version` and
+`sqlite3.sqlite_version_info`, which is distinct from the Python wrapper
+version
+([Python runtime-version constants](https://docs.python.org/3.10/library/sqlite3.html#sqlite3.sqlite_version)).
+
+### File identity and schema identity are different
+
+SQLite provides a 32-bit `application_id` for identifying an application file
+format and an application-owned 32-bit `user_version`. SQLite does not interpret
+`user_version`. By contrast, `schema_version` is SQLite's internal schema
+cookie; writing it manually can yield stale statements, wrong results, or
+corruption
+([application and user identifiers](https://www.sqlite.org/pragma.html#pragma_application_id),
+[database header](https://www.sqlite.org/fileformat.html#the_database_header),
+[schema-version warning](https://www.sqlite.org/pragma.html#pragma_schema_version)).
+SQLite's source includes the known application-ID assignments
+([`magic.txt`](https://www.sqlite.org/src/file?name=magic.txt&ci=trunk)).
+
+### Integrity and referential integrity are separate checks
+
+Full `PRAGMA integrity_check` returns one row containing `ok` when SQLite finds
+no low-level format, page, index, uniqueness, or constraint-consistency error.
+It does **not** detect foreign-key violations; `PRAGMA foreign_key_check` must
+also return no rows
+([SQLite integrity pragmas](https://www.sqlite.org/pragma.html#pragma_integrity_check)).
+Foreign-key enforcement is disabled by default for compatibility and must be
+enabled separately on every connection
+([SQLite foreign-key enablement](https://www.sqlite.org/foreignkeys.html#fk_enable)).
+
+An opened restore candidate is an external file even if it originally came
+from DJ Support. SQLite recommends `PRAGMA trusted_schema=OFF` immediately on
+each connection so schema expressions cannot invoke unaudited functions or
+virtual tables
+([SQLite trusted-schema guidance](https://www.sqlite.org/security.html#untrusted_sqlite_database_files)).
+
+### Archive and filesystem primitives have narrower guarantees than the product
+
+Python warns that ZIP extraction needs prior inspection; archives may contain
+absolute or parent-relative paths, duplicate names are possible, CRC/header
+checking is only what `testzip()` provides, decompression bombs can exhaust
+resources, and interrupted extraction leaves partial output
+([Python `zipfile`](https://docs.python.org/3/library/zipfile.html#zipfile.ZipFile.extractall),
+[`testzip`](https://docs.python.org/3/library/zipfile.html#zipfile.ZipFile.testzip),
+[decompression pitfalls](https://docs.python.org/3/library/zipfile.html#decompression-pitfalls)).
+SHA-256 is guaranteed by `hashlib`; use a streaming `sha256().update(...)` loop
+because `hashlib.file_digest()` was added only in Python 3.11
+([Python `hashlib`](https://docs.python.org/3/library/hashlib.html)).
+
+`os.replace(src, dst)` overwrites a file across platforms, may fail across
+filesystems, and is atomic if successful. `os.fsync()` flushes a file descriptor
+on Unix and Windows, but Python does not promise that one call makes a
+multi-file protocol power-loss atomic
+([Python `os.replace`](https://docs.python.org/3/library/os.html#os.replace),
+[`os.fsync`](https://docs.python.org/3/library/os.html#os.fsync)).
+Windows and POSIX also differ around open names: Windows commonly rejects
+removal of an in-use file, while POSIX may unlink the name while existing
+handles keep the old object
+([Python removal semantics](https://docs.python.org/3/library/os.html#os.remove)).
+Python 3.10 additionally cannot reopen a still-open `NamedTemporaryFile` by
+name on Windows, so named database staging must close the creator handle before
+SQLite opens it
+([Python 3.10 temporary-file semantics](https://docs.python.org/3.10/library/tempfile.html#tempfile.NamedTemporaryFile)).
+
+## DJ Support implementation contract
+
+The remainder of this document is a project design inference from those facts
+and the issue acceptance criteria. It is normative for the four tickets unless
+implementation evidence forces a recorded revision.
+
+### Store and archive identifiers
+
+The Operational Store contract must define and test these independent values:
+
+| Identifier | Meaning | Validation rule |
+| --- | --- | --- |
+| `APPLICATION_ID` | “This is a DJ Support Operational Store” | Choose one stable signed 32-bit value not currently assigned in SQLite `magic.txt`; every create, open, import, backup, and restore requires an exact match. |
+| `PRAGMA user_version` | Current relational schema version | Positive monotonic integer. Open only versions explicitly registered as current or migratable. Never substitute package version or `schema_version`. |
+| Migration registry | Applied application migrations | One row per immutable migration ID and digest, with a uniqueness constraint. The sequence and digest set must match the release's registry. |
+| Schema fingerprint | Canonical expected SQL objects | Compare normalized expected tables, indexes, triggers, and views; do not rely on `user_version` alone. Do not emit SQL in user reports. |
+| Store generation | Stable identity/name for one database lifetime | Non-personal random ID retained inside store metadata, backup manifest, and authority pointer. It changes for restore/cutover generations, not for ordinary transactions. The selected generation's contents and authority revision continue to advance while it is active. |
+| Authority revision | Monotonic application commit fact | Read from the completed backup destination and use for Preview freshness and audit; never infer it from wall-clock time. |
+
+Every connection must set `foreign_keys=ON`, `trusted_schema=OFF`, the accepted
+busy timeout, and the accepted journaling/synchronous policy before it crosses
+the Operational Store interface. Opening a database with the wrong application
+ID, schema version, migration registry, or schema fingerprint fails closed.
+
+### #144 — read-only JSON migration Preview
+
+The current authorities are the three canonical stores selected by
+`RuntimePaths`: Matching Knowledge, Publication State, and Transfer State
+([runtime paths](../../djsupport/runtime.py),
+[matching schemas](../../djsupport/cache.py),
+[publication and Transfer readers](../../djsupport/transfer.py)). The importer
+must call their canonical strict readers for every version those readers
+document as supported. It must not introduce a fourth, permissive JSON parser.
+Configuration and Spotipy-managed credentials never enter the snapshot or
+database.
+
+Preview protocol:
+
+1. Acquire one migration-maintenance lease that all three JSON writers and new
+   Runtime Assembly graphs honor. Acquire any existing file locks in a fixed
+   documented order underneath that lease.
+2. Open every input read-only, reject symlinks and unexpected file types, read
+   bounded bytes, and retain a SHA-256 plus size in private process memory.
+   Missing optional sections are interpreted only by the canonical versioned
+   reader. Unknown, malformed, ambiguous, or unsupported data stops the run.
+3. Convert each supported legacy version into one typed canonical domain
+   snapshot. Preserve identities, explicit nulls, ordered Source Occurrences,
+   duplicate occurrences, account/source/playlist relationships, Approval and
+   Mirror authority, revisions, evidence digests, checkpoints, and incomplete
+   external-effect facts. Never manufacture a completed effect from absence.
+4. Create a uniquely named database in a private staging directory. Create the
+   schema and import all rows inside one transaction with foreign keys enabled.
+   A failure rolls the transaction back; the database is never a runtime path.
+5. Commit, then verify application ID, user version, migration registry, schema
+   fingerprint, full `integrity_check`, empty `foreign_key_check`, and the exact
+   semantic equivalence contract below.
+6. Re-read source size and digest before releasing the maintenance lease. Any
+   change invalidates the Preview. Remove or quarantine the staging database;
+   never activate it.
+7. Return only a redacted report: supported/unsupported state, aggregate counts
+   by domain category, equality booleans, bounded stable error codes, and a
+   short-lived Preview token bound to source digests, importer version, schema
+   version, and staging-store digest. Do not include paths, credentials, source
+   metadata, playlist/track/account IDs, fingerprints, SQL, row values, or raw
+   exceptions.
+
+Exact verification is semantic rather than a count-only check. Both the typed
+legacy snapshot and SQLite adapter must project the same canonical sequence for
+each category. Each sequence uses explicit type tags, field names, null markers,
+and length-prefixed values; ordered collections include zero-based ordinal and
+duplicates as separate records. Compare counts and SHA-256 digests in constant
+shape, and on mismatch bisect internally to a stable category/error code without
+putting identifiers in the report. At minimum verify:
+
+- Matching Knowledge observations, associations, outcomes, revisions, and
+  Approval conflicts;
+- Publication Manifests and their ordered/duplicate managed occurrences;
+- Approval and Mirror identities, relationships, revisions, orphan/relink
+  state, and evidence;
+- Transfers, Batches, Qualification Drafts, successors, decisions, revisions,
+  and checkpoints;
+- Effect Journal intent, attempt, observed-result, and unknown/incomplete state;
+- absence as well as presence of optional evidence and incomplete effects; and
+- zero configuration rows, credential rows, local paths, filenames, raw source
+  metadata, or process-local audition handles.
+
+### #145 — backup creation
+
+Backup protocol:
+
+1. Resolve the active generation through the authority pointer and validate its
+   identity. Create a new private sibling staging directory/file; do not reuse
+   an old destination.
+2. Open a dedicated source connection and a dedicated destination connection.
+   Call `source.backup(destination, pages=N, progress=..., sleep=...)` with
+   bounded retry/time policy. On cancellation, timeout, `BUSY`, `LOCKED`, I/O,
+   or disk-full failure, close both and publish nothing.
+3. Read store generation, authority revision, application ID, and user version
+   from the **destination**. With no other destination client, normalize the
+   snapshot to `journal_mode=DELETE`, close it cleanly, and require that no
+   destination `-wal`, `-shm`, or rollback journal remains. Never delete a live
+   sidecar to force this condition.
+4. Reopen the closed candidate in read-only mode with trusted schema disabled.
+   Require the exact identifiers, schema fingerprint, migration registry,
+   `integrity_check == "ok"`, and no `foreign_key_check` rows. Close it again.
+5. Stream SHA-256 over the final closed bytes. Construct a strict, versioned
+   manifest containing only: archive-format version, store application ID,
+   store schema/user version, migration-registry digest, store generation,
+   authority revision, database member name, byte length, SHA-256, UTC creation
+   time, and producing DJ Support/Python/SQLite versions. No credential,
+   machine path, user identifier, playlist identifier, or source fact belongs
+   in the manifest.
+6. Write exactly two unique, relative regular-file members to a temporary ZIP:
+   `backup-manifest.json` and `operational-store.sqlite3`. Close it, reopen it,
+   run CRC/header checks, parse the manifest strictly, and recheck the embedded
+   database hash and size. Flush/fsync the archive, then `os.replace` it into
+   the chosen destination on the same filesystem. A failed final replace leaves
+   the previous archive untouched.
+
+The hash detects accidental mismatch between manifest and database; because an
+attacker could replace both, it is not an authenticity signature. Do not claim
+tamper authentication without a separately designed key-management system.
+
+### #145 — restore validation and Preview
+
+Restore must not call `extractall()`. Inspect `ZipInfo` entries first and reject:
+
+- any member set other than the two exact allowlisted names;
+- duplicate names, directories, symlinks/special files, encrypted entries,
+  NULs, absolute paths, drive/UNC prefixes, backslashes, `.` or `..` segments;
+- unsupported compression, CRC/header failure, excess member count, excess
+  compressed or uncompressed size, suspicious compression ratio, or insufficient
+  staging disk budget; and
+- an unknown manifest field/version, duplicate JSON key, noncanonical type,
+  hash/length mismatch, unsupported application/schema/migration identity, or
+  any credential/private identifier field.
+
+Stream the database member into a newly created private staging file with a
+hard byte limit. Close it before SQLite opens it. Then apply the same trusted
+schema, application ID, user version, migration registry, schema fingerprint,
+full integrity, and foreign-key checks used by backup. Reject a database that
+creates or requires a WAL/SHM sidecar. A Preview contains only redacted schema,
+generation, revision, age, size, compatibility, and validation results plus a
+short-lived token bound to the archive digest and the current live authority
+revision and canonical semantic digest. Apply revalidates those live freshness
+facts after acquiring the maintenance lease; the token is not authority by
+itself.
+
+### #145/#146 — atomic activation
+
+Use stable generation identities plus a small authority pointer, rather than
+overwriting the active database path:
+
+```text
+private application data/
+  operational-store.authority.json       # selector only
+  operational-stores/
+    <generation-a>.sqlite3                # active: stable identity, mutable state
+    <generation-b>.sqlite3                # validated inactive candidate
+```
+
+The pointer contains only its format version, a generation basename, and the
+expected store-generation ID—no database-content hash, authority revision,
+path outside its fixed store directory, or user data. Its parser accepts only
+a plain basename and reconstructs the path beneath the fixed private directory.
+Runtime then opens that database and validates the matching store-generation
+ID, application ID, supported user version, migration registry, and schema
+fingerprint. The selected generation's bytes and authority revision are
+expected to change during ordinary transactions, so startup must never compare
+them with an activation-time value in the steady-state pointer.
+
+Activation protocol:
+
+1. Acquire a cross-process maintenance lease at the Runtime Assembly boundary;
+   refuse new graphs, wait for active operations to finish, and close every CLI,
+   web, and Agent Client connection. A bounded failure to quiesce aborts.
+2. For migration, create and verify the complete current JSON backup before
+   importing. For restore, create and verify an online backup of the currently
+   active SQLite generation. Never continue if that rollback artifact fails.
+3. Revalidate the source/active revision and all Preview-bound hashes. Import or
+   extract into a unique generation in the fixed store directory, then run the
+   full semantic, structural, and relational checks. Close all handles and
+   fsync the generation.
+4. Write and fsync a temporary pointer in the same directory as the authority
+   pointer. The only activation point is `os.replace(temp_pointer,
+   authority_pointer)`. Before it, the old pointer (or pre-cutover JSON mode)
+   remains authority; after it, the new complete generation is authority.
+   An unreferenced generation left by a crash is inert staging, not authority.
+5. Reopen Runtime Assembly from the pointer, recheck the database identities
+   and the activation-candidate revision retained by the in-progress apply
+   operation (not by the steady-state pointer), and release the lease. If reopen
+   fails after activation, stop in explicit recovery mode; do not write JSON or
+   silently select the previous generation.
+
+This pointer design avoids Windows replacement of an open database and POSIX
+stale handles to an unlinked database. Quiescence remains mandatory because an
+already-open connection would otherwise keep writing the previous generation
+after the pointer swap.
+
+For process-crash semantics, one atomic pointer replacement gives an observable
+old-or-new authority. For power-loss durability, flush the database and pointer
+and sync directory metadata where the OS supports it, but document that Python
+and commodity filesystems cannot promise perfect storage hardware. Startup must
+therefore validate the pointer format/basename and the selected database's
+generation, application, and schema identities, and fail closed on missing or
+torn state. Inactive staging/retained generations may be byte-hashed; the
+selected active generation may not be treated as byte-immutable. The
+cross-platform test matrix below is a release gate, not a substitute for that
+recovery behavior.
+
+### Rollback window and legacy JSON retention
+
+The 0.7 release documentation must define the rollback window by a concrete
+date or release boundary before #145/#146 ship. During the window:
+
+- retain the byte-identical original JSON set, its verified pre-cutover backup,
+  every authority pointer needed to identify the prior SQLite generation, and
+  a verified backup of each generation being replaced;
+- keep JSON outside Runtime Assembly after activation. “Readable for migration
+  or rollback” is not a production adapter and must not become one;
+- before a SQLite-to-SQLite rollback, backup the current generation, stage and
+  validate the chosen prior generation, show the revision difference, require
+  explicit apply, then use the same pointer-swap protocol;
+- before a 0.7-to-0.6 version rollback, backup current SQLite and show that any
+  post-cutover changes are absent from the retained JSON baseline. Require an
+  explicit data-loss acknowledgement. The rollback tool may prepare legacy
+  files for the old binary, but the 0.7 runtime must not start writing them; and
+- when the window expires, report retained artifact categories and offer a
+  separately confirmed cleanup/archive action. Never silently delete or
+  overwrite the original JSON.
+
+Legacy filenames, database files, WAL/SHM sidecars, generation pointers,
+snapshots, backup ZIPs, extracted restores, staging files/directories, rollback
+copies, integrity diagnostics, query exports, operational events, and reports
+are private application data. They must be covered by repository ignore,
+privacy scans, package-manifest exclusion, wheel/sdist inspection, and synthetic
+tests. None belongs in Git or a distribution.
+
+## Crash-injection contract
+
+Use a subprocess and durable synthetic fixtures. At each numbered point, force
+an exception and a hard process exit in separate tests; after restart, inspect
+through public readers rather than trusting temporary-file presence. Every case
+must yield one complete recognized authority and preserve the original inputs.
+
+| Flow | Injection points | Required post-restart result |
+| --- | --- | --- |
+| JSON Preview | before lease; after each source open/read; after source digest; after schema create; between every domain import phase; immediately before/after staging commit; during exact verification; after report creation; during cleanup | JSON bytes and metadata-content digests unchanged; no authority pointer change; no staging database accepted as authority; malformed/partial stage is removable or quarantined. |
+| SQLite backup | before destination create; during each backup progress callback; after backup completion; before/after destination close; during journal normalization; during integrity/FK checks; during hash; while writing each ZIP member; after ZIP close; after archive verification/fsync; immediately before/after final archive replace | Active generation remains usable; no partial archive at final name; an old archive at that name remains byte-identical or one complete new archive exists. |
+| Restore Preview | before member inspection; during streamed extraction; after size/hash checks; during database open; during every identity/integrity check; after Preview token; during cleanup | Active pointer and generation unchanged; partial extraction is not opened by Runtime Assembly; source archive unchanged. |
+| Migration/restore apply | before lease; while draining clients; after rollback backup; after source revalidation; between import phases; before/after staging commit; during semantic/integrity checks; after generation fsync; while writing/fsyncing temporary pointer; immediately before/after pointer replace; before Runtime Assembly reopen; after reopen before lease release | Before pointer replace: old authority only. After pointer replace: new generation only. An invalid selected generation causes recovery stop, never JSON fallback. Original JSON and verified rollback artifact remain. |
+| Explicit rollback | before current-generation backup; after backup; after prior-generation validation; before/after pointer replace; before old-version JSON preparation | Current or chosen prior authority is complete and deterministic; post-cutover SQLite backup and original JSON remain retained; no automatic loss or deletion. |
+
+The test harness must also crash while a source writer is committing and while a
+reader holds a WAL snapshot. A bounded `BUSY`/`LOCKED`/deadline result is an
+acceptable failed operation; a torn success is not.
+
+## Cross-platform verification matrix
+
+Run all tests with synthetic application data and a staging directory located
+beside the active private store so pointer replacement cannot cross filesystems.
+At minimum run Linux on Python 3.10 and 3.14 plus native macOS and Windows on a
+supported Python. Record `sqlite3.sqlite_version` in CI evidence and reject a
+known-vulnerable WAL build unless the platform vendor documents the relevant
+backport.
+
+| Verification | Linux | macOS | Windows | Pass evidence |
+| --- | --- | --- | --- | --- |
+| Online backup under concurrent WAL writes | Python 3.10 + 3.14 | Native runner | Native runner | Completed backup has accepted identity, exact internal revision, `integrity_check=ok`, no FK rows, and no WAL/SHM member; deadline failure publishes nothing. |
+| Raw-copy negative control | Required | Required | Required | Put a committed marker in WAL, copy only the main file in test isolation, and prove it is not an accepted backup. This test documents why production never uses the path. |
+| Backup cancellation/disk-full/I/O failure | Required | Required | Required | Existing archive and active store unchanged; temp artifacts private and non-authoritative. |
+| Hostile restore archives | Required | Required | Required | Traversal, drive/UNC, backslash, duplicate, symlink/special, encrypted, oversized/bomb, bad CRC, bad hash, extra member, unknown manifest, wrong application/schema, corrupt page, and FK violation all fail before Preview/apply. |
+| Same-directory pointer replacement | Native filesystem | APFS/default runner filesystem | NTFS/default runner filesystem | Repeated readers observe complete old or new pointer JSON, never partial; cross-volume candidate is rejected before apply. |
+| Open-handle cutover guard | POSIX stale-handle scenario | POSIX stale-handle scenario | Sharing/replace-failure scenario | Activation refuses until all registered clients close; after success every new graph reports the new generation and no old graph can write. |
+| Subprocess hard-exit matrix | Required | Required | Required | Every injection point satisfies the old-or-new table above over repeated runs. |
+| 0.7 rollback-window round trip | Required | Required | Required | Pre-cutover JSON hash unchanged; current SQLite backed up; prior generation restored only after Preview; second restore can return to the later generation. |
+| Privacy and packaging | Required | Required | Required | Git and built wheel/sdist contain none of the private artifact patterns or synthetic run output. |
+
+Do not claim power-failure certification from ordinary CI. Process termination,
+I/O fault injection, and native-filesystem tests prove the application state
+machine. Filesystem/hardware durability remains bounded by the platform's
+documented flush and rename behavior.
+
+## Acceptance-criteria mapping
+
+| Issue | Acceptance evidence produced by this contract |
+| --- | --- |
+| #144 | Canonical supported-version readers; one maintenance-stable read-only snapshot; all named matching/publication/Approval/Mirror/Transfer/Batch/Qualification/checkpoint/legacy facts; one-transaction staging import; typed semantic projections covering identity/order/duplicates/relationships/authority/revisions/evidence/incomplete effects; fail-closed source revalidation; redacted report; synthetic crash matrix; explicit credential/config exclusion; ticket-specific release record. |
+| #145 | `Connection.backup` logical snapshot; closed DELETE-mode single-file artifact; strict two-member manifest/hash archive recording store schema and hash; hostile path/member/resource validation; trusted-schema/application/schema/integrity/FK gates; redacted Preview-bound revalidation; validated generation plus atomic pointer apply; retained prior backup and explicit 0.7 rollback policy; documented ignore/privacy/package matrix; native synthetic platform tests; ticket-specific release record. |
+| #146 | Verified complete current-state backup before apply; exact #144 verification in staging; one pointer-replace activation point; Runtime Assembly lease and CLI/web/Agent reopen; pre-switch JSON versus post-switch SQLite determinism; no dual-write/partial-client/silent-fallback path; byte-identical legacy retention; configuration/credentials remain external; crash injection at every phase; live services and publication remain gated; ticket-specific release record. |
+| #147 | Runtime and Transfer interfaces resolve only the SQLite generation selected by the pointer; JSON readers move to explicit migration/rollback tooling only; obsolete JSON writers/locks/temp paths/schema constants can be deleted; interface-level behavior tests replace adapter-specific tests without weaker coverage; ignore/privacy/package checks enumerate every database and transition artifact; canonical architecture/storage docs name SQLite as sole production authority; complete offline and package suites pass; ticket-specific release record. |
+
+All four tickets remain fully synthetic and offline. They do not authorize
+Spotify or Beatport calls, owner-data access, tags, releases, or package
+publication. Each distributable ticket adds its own `.release-notes/*.md`
+record; adding the record does not authorize consuming it into a release.
+
+## Implementation order and review gates
+
+1. Freeze the application ID, user-version registry, schema fingerprint, and
+   canonical semantic projections before writing importer or backup code.
+2. Build #144 without an activation API. Its staging path must be structurally
+   impossible for Runtime Assembly to select.
+3. Build #145 backup and hostile restore Preview. Prove the snapshot is
+   self-contained and the pointer protocol works with synthetic stores before
+   enabling restore apply.
+4. Build #146 around one maintenance lease and one pointer replacement. Review
+   the cached diff specifically for a JSON write, fallback, second activation
+   flag, or client-specific store choice; any one of those blocks merge.
+5. Keep the explicit rollback tool and supported legacy readers, then complete
+   #147 by deleting production JSON writers and adapter-specific tests only
+   after interface-level behavior coverage is equivalent.
+
+Security, privacy, and packaging review must inspect generated artifacts, not
+only source patterns. Release review must verify the native platform matrix and
+the linked runtime SQLite versions. A green integrity check alone is not exact
+migration proof, and a matching SHA-256 alone is not archive authenticity.
+
+## Primary sources
+
+- SQLite: [Online Backup API](https://www.sqlite.org/c3ref/backup_finish.html),
+  [backup guide](https://www.sqlite.org/backup.html),
+  [WAL](https://www.sqlite.org/wal.html),
+  [WAL file format and lifecycle](https://www.sqlite.org/walformat.html),
+  [database corruption hazards](https://www.sqlite.org/howtocorrupt.html),
+  [transactions](https://www.sqlite.org/lang_transaction.html),
+  [pragmas](https://www.sqlite.org/pragma.html),
+  [foreign keys](https://www.sqlite.org/foreignkeys.html),
+  [database file format](https://www.sqlite.org/fileformat.html),
+  [untrusted database guidance](https://www.sqlite.org/security.html), and
+  [`magic.txt`](https://www.sqlite.org/src/file?name=magic.txt&ci=trunk).
+- Python: [3.10 `sqlite3`](https://docs.python.org/3.10/library/sqlite3.html),
+  [`os`](https://docs.python.org/3/library/os.html),
+  [`zipfile`](https://docs.python.org/3/library/zipfile.html),
+  [`hashlib`](https://docs.python.org/3/library/hashlib.html), and
+  [3.10 `tempfile`](https://docs.python.org/3.10/library/tempfile.html).
+- DJ Support: [program #125](https://github.com/spontain112/djsupport/issues/125),
+  [migration Preview #144](https://github.com/spontain112/djsupport/issues/144),
+  [backup/restore #145](https://github.com/spontain112/djsupport/issues/145),
+  [cutover #146](https://github.com/spontain112/djsupport/issues/146), and
+  [JSON-writer retirement #147](https://github.com/spontain112/djsupport/issues/147).


### PR DESCRIPTION
Supports #125 and front-loads implementation evidence for #138–#149 plus #132. It does not close or implement those delivery tickets.

## Research contracts

- map every acceptance criterion to present evidence, missing work, dependency order, TDD seams, and exact gates
- define the SQLite concurrency/durability contract for #138–#143 from official SQLite/Python sources
- define the migration, backup, restore, cutover, rollback, and crash contract for #144–#147

## Highest-leverage findings

- #138 remains blocked only by human #136 and the separately owned ADR-0005 lane needs a stable integrated route before schema writes
- use shared in-memory/SQLite conformance tests through Transfer rather than creating new policy surfaces
- SQLite's documented WAL-reset race makes linked-runtime qualification a hard #139 production gate; the local 3.43.1 runtime is affected
- never span Spotify with a database transaction: commit intent, call, then retain the observation; ambiguous completion is `uncertain`
- back up with `sqlite3.Connection.backup()`, never live-file/WAL copying
- activate a validated generation through one quiesced authority-pointer swap, with no dual-write or JSON fallback
- the authority pointer selects a stable generation identity only; it does not store mutable database bytes/revision

## Scope and validation

Exactly three internal `docs/research/**` files. No product behavior or user guidance changes, so merged #161 policy correctly requires no consumer release record.

- complete offline suite — 761 passed
- privacy + release-record focused tests — 24 passed
- staged diff whitespace check — passed
- local-path/credential marker scan — clean
- repo-relative links and whitespace — validated in the research lanes

## Boundaries

No production authority switch, database, owner data, live Spotify/Beatport call, tag, GitHub Release, or package publication. The dirty separate `djsupport/operational-store-architecture` worktree was inspected read-only for decision compatibility and remains untouched.
