### PR TITLE
docs: qualify SQLite runtime delivery

### DIFF
--- a/docs/research/2026-08-16-operational-store-adr-integration-audit.md
+++ b/docs/research/2026-08-16-operational-store-adr-integration-audit.md
@@ -1,0 +1,435 @@
+# Operational Store ADR integration audit
+
+**Date:** 2026-08-16
+
+**Status:** read-only architecture/specification audit; no architecture-lane edit,
+commit, push, authority switch, live-service call, or owner-data access
+
+**Compared state:**
+
+- `origin/main` at `4be422b5565ac5491084771afa04784b2289318b`;
+- the uncommitted `djsupport/operational-store-architecture` worktree at
+  `8959036569d26976ea2754c0c2f1aa0b588383ec`;
+- accepted program issue
+  [#125](https://github.com/spontain112/djsupport/issues/125), delivery issues
+  [#138](https://github.com/spontain112/djsupport/issues/138)–
+  [#147](https://github.com/spontain112/djsupport/issues/147),
+  and diagnostics issue [#132](https://github.com/spontain112/djsupport/issues/132);
+- the three research contracts merged by PR #163: the
+  [issue frontier](2026-08-16-operational-store-issue-frontier.md),
+  [concurrency and durability contract](2026-08-16-sqlite-concurrency-durability-contract.md),
+  and [migration, backup, and cutover contract](2026-08-16-sqlite-migration-backup-cutover-contract.md);
+- current SQLite and Python primary documentation.
+
+The architecture worktree was inspected only. Its exact dirty scope was five
+files: `.gitignore`, `docs/architecture.md`, `docs/storage.md`,
+`tests/test_repository_privacy.py`, and the untracked
+`docs/adr/0005-use-one-local-transactional-operational-store.md`. This audit writes
+only this findings file in a separate worktree.
+
+## Outcome
+
+ADR-0005 remains the right canonical decision and should keep its concise ADR
+shape. It aligns with the accepted program on the fundamental choice: one local
+SQLite Operational Store behind one internal interface, in-memory conformance
+adapter, Transfer as sole policy authority, credentials and configuration kept
+outside the store, Preview-first/backup-first migration, an Effect Journal around
+external calls, private local Operational Events, no application-level encryption
+in the first release, and retained rollback state.
+
+The current five-file draft is **not ready to integrate unchanged**. It contains
+four architecture-level ambiguities, one stale delivery sequence, and privacy
+rules that do not match the canonical filenames now published on `main`. It also
+lacks the release record required by the current range checker. These are bounded
+review corrections; they do not justify taking implementation ownership away from
+the separate architecture session.
+
+The smallest sound route is an owner-led replay of the five-file draft onto
+current `origin/main`, correction of the blocking items below, and one explicit
+scope addition for a release record. ADR-0005 should link to the merged research
+for mechanics rather than duplicate hundreds of lines of connection, schema,
+backup, archive, filesystem, and crash-injection detail.
+
+## Baseline and overlap
+
+The architecture branch has no commits beyond its merge base and is 18 mainline
+commits behind `origin/main`. The only overlapping tracked file changed upstream
+is `docs/architecture.md`: `main` now documents the merged Runtime Assembly seam.
+That upstream change is additive and does not reject ADR-0005, but it makes the
+draft's proposed sequence stale. Runtime Assembly and the web assembly work have
+already landed, while the draft still lists assembly as future work.
+
+PR #163 deliberately left ADR-0005 to this owning lane. Its issue-frontier note
+says schema work must wait for a stable ADR integration route and must not recreate
+the concurrent draft. Therefore this audit does not propose moving the ADR into
+the research branch. It proposes only a review contract the owner can apply.
+
+The accepted issue numbering explicitly calls the decision ADR-0005. The absence
+of ADR-0004 on current `main` is not a reason to renumber this file during
+integration; renumbering would break the accepted issue and merged research
+references without improving the decision.
+
+## Finding 1: the WAL production claim needs a maintained runtime-qualification gate
+
+The draft says the first production implementation uses WAL, but it does not say
+that concurrent production authority must fail closed when the linked SQLite
+runtime is not qualified. That omission is material. The runtime in this audit is
+Python 3.12.1 linked to SQLite 3.43.1. SQLite's official WAL advisory says the rare
+WAL-reset corruption race is likely present through 3.51.2 and requires multiple
+connections, the exact operating mode introduced by #139. SQLite identifies
+3.51.3 and specific backports as fixes and recommends upgrading
+([official WAL-reset advisory](https://sqlite.org/wal.html#the_wal_reset_bug),
+[#139](https://github.com/spontain112/djsupport/issues/139)).
+
+There is also a correction to the merged concurrency research. Its phrases
+"3.51.3 or later" and "3.51.3+" are too broad. SQLite withdrew 3.52.0 because its
+floating-point conversion changes could leave expression indexes stale across
+versions; SQLite then re-released the line as 3.53.0 with index repair/detection
+support. A monotonic `version >= (3, 51, 3)` predicate would incorrectly admit the
+withdrawn 3.52.0 runtime
+([SQLite release news](https://sqlite.org/news.html),
+[3.51.3 release](https://sqlite.org/releaselog/3_51_3.html),
+[3.53.0 release](https://sqlite.org/releaselog/3_53_0.html)).
+
+The stable ADR decision should therefore be concise and non-numeric: concurrent
+WAL authority is enabled only for a linked SQLite build proven by the maintained
+runtime-qualification contract; an unqualified or withdrawn build fails closed.
+The implementation contract must use an explicit allow/deny table (and, for a
+downstream backport, recorded distributor/source-build evidence), not a single
+lower-bound comparison. At minimum it must reject the observed 3.43.1 runtime,
+all unpatched lines identified by the WAL advisory, and withdrawn 3.52.0. Exact
+currently accepted versions and source IDs belong in the corrected concurrency
+research and executable tests, not permanently copied into the ADR.
+
+#138 may still build a non-authoritative adapter on an older runtime because its
+acceptance criteria retain JSON production authority. #139 must not claim safe
+concurrent production behavior until its native macOS/Linux/Windows matrix proves
+the runtime gate on the exact release commit.
+
+## Finding 2: the architecture delivery sequence is stale and contradicts the issue graph
+
+The new `docs/architecture.md` section proposes this sequence: migration/cutover,
+then Effect Journal, then Runtime Assembly, then deletion tests, then diagnostics.
+That sequence no longer matches either repository state or the accepted tickets:
+
+- Runtime Assembly and web construction are already merged on `main`.
+- #138 first adds one non-authoritative Preview path and expressly forbids cutover.
+- #139 qualifies concurrency before #140–#143 move external effects and local
+  authority transactions into the store.
+- #144 and #145 add migration Preview and backup/restore only after those domain
+  slices.
+- #146 performs the only production activation, and #147 then removes JSON writers
+  and fallback wiring.
+- #130 and #132 follow #147; #131's rendering deletion test is already closed.
+
+This is not merely outdated project-management prose: putting cutover before the
+Effect Journal would violate #140 and #146's recovery model. The minimum correction
+is to remove the five-step list from the stable architecture document and link to
+the [merged dependency map](2026-08-16-operational-store-issue-frontier.md#dependency-order-and-parallel-safe-lanes).
+If a short sequence remains, it must use the current #138 → #147 boundaries and
+must describe Runtime Assembly as an existing seam, not future work.
+
+## Finding 3: reject every runtime dual-authority path, not only a "long-term" adapter
+
+The ADR rejects "Runtime dual-write and long-term JSON production adapters." The
+word "long-term" leaves an unintended opening for a temporary JSON fallback or a
+partially migrated client. Accepted #125 and #128 reject a JSON production runtime
+adapter; #146 additionally rejects dual-write, partial-client cutover, and silent
+fallback; #147 keeps legacy readers only in explicit migration/rollback tooling.
+
+The canonical wording should be categorical:
+
+- before #146's activation point, all production clients use JSON authority;
+- after the activation point, all production clients resolve the selected SQLite
+  generation;
+- there is no runtime dual-write, partial-client cutover, or silent JSON fallback;
+  and
+- retained JSON is inert, read-only input to explicit migration/rollback workflows,
+  never a second runtime authority.
+
+The existing additions to `docs/architecture.md` and `docs/storage.md` correctly
+say that JSON remains executable until migration ships. Preserve that temporal
+boundary while removing "long-term" from the rejection.
+
+## Finding 4: atomic authority means a stable selector, not a frozen active database
+
+The draft promises an atomic authority switch but does not define what changes
+atomically. The merged cutover contract corrected this before PR #163 merged: one
+small authority pointer selects a complete database generation by stable identity.
+The pointer is not a second state store and must not contain a database-byte hash
+or authority revision that changes during ordinary writes.
+
+The durable architectural invariant is:
+
+- an inactive candidate is closed, validated, inert, and may be byte-hashed;
+- activation atomically replaces only the selector after all clients quiesce;
+- the selected generation then becomes the mutable sole authority; and
+- an already-open connection to an old generation is forbidden, so Runtime
+  Assembly must drain/reopen CLI, web, and Agent Client graphs around activation.
+
+This design is a project inference from #145/#146 plus SQLite/Python filesystem
+behavior. WAL files are part of the live database state, and Python only promises
+`os.replace()` atomicity for a successful same-filesystem replacement; replacing
+an open database is also platform-sensitive
+([SQLite WAL file lifecycle](https://sqlite.org/wal.html#the_wal_file),
+[Python `os.replace`](https://docs.python.org/3/library/os.html#os.replace),
+[cutover contract](2026-08-16-sqlite-migration-backup-cutover-contract.md#145146--atomic-activation)).
+
+ADR-0005 needs at most one sentence expressing selector-versus-active-state
+semantics plus a link to the cutover contract. File layout, pointer JSON fields,
+fsync ordering, maintenance leases, Preview tokens, and crash points should stay
+in research and executable implementation tests.
+
+## Finding 5: SQLite backup means the Online Backup API, never a live file-family copy
+
+The draft uses "backup-first" and later says safe schema migrations may run after
+an automatic backup, but does not distinguish a verified logical SQLite snapshot
+from copying a live `.sqlite3` file. In WAL mode, a commit may exist only in the
+`-wal` file, and SQLite warns that separating or copying mismatched database/WAL
+state can lose transactions or corrupt the database. SQLite's Online Backup API,
+exposed as Python `Connection.backup()`, is the accepted snapshot seam
+([SQLite backup API](https://sqlite.org/backup.html),
+[Python backup API](https://docs.python.org/3.10/library/sqlite3.html#sqlite3.Connection.backup),
+[#145](https://github.com/spontain112/djsupport/issues/145)).
+
+The concise storage decision should say that an active Operational Store is backed
+up through `Connection.backup()` into a fresh private destination, then closed and
+verified; production never archives or filesystem-copies a live main/WAL/SHM
+family. The detailed deadline, normalization, archive-member, integrity,
+foreign-key, schema, hash, and restore protocol remains in the merged backup and
+cutover research.
+
+The JSON migration's pre-cutover backup and a post-cutover SQLite snapshot are
+different operations. The ADR may call both "backup-first," but `docs/storage.md`
+should make that distinction explicit so no implementation reuses the current JSON
+byte-copy code as a SQLite snapshot mechanism.
+
+## Finding 6: analytics are deletable non-authority; "append-only" is too absolute
+
+The draft correctly makes analytics rebuildable and non-authoritative, but its ADR
+calls Operational Events "append-only" and limits the authority disclaimer to
+"matching or playlist authority." #132 requires users to delete analytics history
+without deleting authority-bearing state and forbids any analytics authority, not
+only matching/playlist authority.
+
+The stable distinction should be:
+
+- Operational Events are append-only under ordinary recording and never consumed
+  as an authority-bearing input;
+- SQL views and diagnostics are rebuildable read-only projections;
+- an explicit analytics-history deletion may remove events/projections without
+  deleting or changing Transfers, Approval, Matching Knowledge, publication state,
+  Effect Journal recovery facts, or other authority-bearing rows; and
+- even a privacy-redacted diagnostics export remains private local user data.
+
+Exact event categories, view SQL, JSON schema, one-million-event scale fixtures,
+and deletion mechanics belong to #132 after #147. ADR-0005 should state only the
+authority/deletion boundary and link to #132.
+
+## Finding 7: the proposed ignore rules miss the filenames selected by merged research
+
+The draft adds useful DJ Support-specific patterns and representative tests, but
+its names predate PR #163. The merged research uses `operational-store.sqlite3`,
+`operational-store.authority.json`, and `operational-stores/<generation>.sqlite3`.
+None is ignored by the five-file draft. A read-only `git check-ignore --no-index`
+probe against that draft produced:
+
+| Representative private artifact | Draft result |
+| --- | --- |
+| `operational-store.sqlite3` | exposed |
+| `operational-store.sqlite3-wal` | exposed |
+| `operational-store.sqlite3-shm` | exposed |
+| `operational-store.sqlite3-journal` | exposed |
+| `operational-store.authority.json` | exposed |
+| `operational-stores/<generation>.sqlite3` | exposed |
+| `djsupport-snapshot-2026-08-16.sqlite3` | exposed |
+| `djsupport-restore-staging/operational-store.sqlite3` | exposed |
+
+The current canonical JSON authorities are also exposed if copied to a repository:
+`matching-knowledge.json`, `publication-manifests.json`, and
+`publication-manifests.transfers.json`. The backup reader's supported legacy set
+also includes exposed `transfers.json`, `legacy-migration.json`, and
+`foundation-migration.json`. Canonical `config.json` remains outside the future
+database but is still a private source-path reference and is likewise exposed at a
+repository root. Existing patterns protect older dot-prefixed names and
+`playlist-state.json`, but that does not satisfy #125's configuration/legacy-state
+boundary or #147's explicit package/repository gate. Canonical names are listed by
+the current storage schema and backup reader
+([storage inventory](../storage.md#current-schema-owners),
+[`SUPPORTED_SCHEMAS`](../../djsupport/backup.py)).
+
+The draft's prose also says synthetic fixtures can still be committed under
+`tests/fixtures/`. That is too permissive for generated SQLite images: #138, #145,
+and #147 require package inspection to reject database, sidecar, snapshot, backup,
+staging, diagnostic, export, legacy-state, and report artifacts. Tests should
+generate databases beneath temporary directories, not retain binary SQLite fixture
+images. Invented source facts may remain reviewable fixtures when their explicit
+format and privacy policy allow them.
+
+Before integration, the owner should choose one exact canonical filename corpus
+shared by `.gitignore` and `tests/test_repository_privacy.py`. It must include the
+active pointer, active/staged/retained generation directory, main/WAL/SHM/rollback
+journal family, logical snapshots, ZIP backups, migration/restore staging and
+extraction, rollback copies, analytics/diagnostics/query exports, all supported
+legacy JSON authorities, and reports. Avoid blanket `*.db`/`*.sqlite*` rules, but
+do not preserve a loophole for committed generated database fixtures.
+
+The present privacy test proves only ignore behavior for its hand-picked names.
+It does not prove source archives or wheels are clean. The architecture PR may
+truthfully land the corrected ignore corpus as a front-loaded guard, while #138,
+#145, and #147 still own package-build rejection at the point executable artifact
+names exist. `docs/storage.md` must not claim package coverage until generated
+sdist/wheel inspection actually enforces it.
+
+## Finding 8: current release policy expands the minimum PR scope to six files
+
+Current `scripts/release_records.py` classifies `docs/architecture.md` and
+`docs/storage.md` as distributable paths; only `docs/research/` is exempt. The
+five-file dirty draft has no `.release-notes/*.md` record, so a normal committed
+range would fail with "Distributable behavior changed without a release record"
+([release checker](../../scripts/release_records.py),
+[#125 program gate](https://github.com/spontain112/djsupport/issues/125)).
+
+The minimum reviewable architecture PR therefore contains the corrected five
+draft files **plus one owner-approved release record**. This is a deliberate
+six-file scope, not an invitation to add schema, runtime, backup, or migration
+implementation. If the owner instead drops both distributable documentation files,
+the result would no longer integrate ADR-0005 as the canonical architecture route,
+so that is not an equivalent solution.
+
+## ADR depth boundary
+
+ADR-0005 should remain short because its job is to preserve decisions that survive
+implementation changes. It should contain:
+
+1. one Operational Store/internal interface and Transfer's sole-policy-authority
+   boundary;
+2. the before/after authority model with categorical no-dual-write/no-fallback;
+3. Effect Journal transaction/effect ordering;
+4. compact, explicitly deletable, non-authoritative events/projections;
+5. Preview-first, verified backup-first activation with stable-generation selector
+   semantics;
+6. Python `sqlite3`/WAL plus fail-closed maintained runtime qualification; and
+7. private-data, credential/configuration, encryption, and rollback boundaries.
+
+It should link to the two merged implementation contracts for transaction mode,
+busy timeout, schema registry, foreign keys, trusted schema, revision SQL,
+integrity checks, Online Backup API mechanics, archive validation, filesystem
+flush/replace steps, pointer schema, crash matrices, scale fixtures, and platform
+qualification. Repeating those details in the ADR would create two canonical
+contracts and make future safety corrections—such as the 3.52.0 withdrawal—easy
+to miss.
+
+## Minimum exact integration route
+
+1. Leave the separate `djsupport/operational-store-architecture` worktree under
+   its current session's ownership. Do not stash, reset, rebase, stage, or commit
+   it from a different session.
+2. The owner records the exact five-file dirty state, then replays it in an
+   owner-controlled clean worktree/branch based on the then-current `origin/main`.
+   A fresh replay is safer than asking another session to manipulate the dirty,
+   18-commit-old worktree.
+3. Preserve current Runtime Assembly documentation from `main`; replace the stale
+   delivery sequence with a link to the merged issue frontier.
+4. Apply Findings 1–7 without adding implementation: maintained WAL qualification,
+   categorical no-fallback language, selector/mutability semantics, Online Backup
+   API boundary, deletable non-authority analytics, and one canonical private-file
+   corpus.
+5. Add exactly one `.release-notes/*.md` record approved for this architecture and
+   privacy-guardrail change. Final scope is six files.
+6. Correct the merged concurrency research's `3.51.3+` predicate in its own
+   research-owned change, explicitly denying withdrawn 3.52.0. ADR integration may
+   proceed with generic fail-closed qualification wording, but #139 remains blocked
+   until the corrected executable predicate and CI evidence land.
+7. Run the focused privacy/documentation/release-policy tests, the complete offline
+   suite, compilation, release range check, and package build/inspection. Review
+   the final cached diff and file list before any commit or push.
+8. Open one architecture PR against current `main`; do not combine it with #138
+   schema or adapter code. Once merged, ADR-0005 has the stable route required by
+   #138. The separate #136 release/publication gate still blocks #138 schema writes.
+
+## Blocking versus non-blocking findings
+
+### Blocking for the ADR integration PR
+
+- Remove or correct the stale `docs/architecture.md` delivery sequence.
+- Replace "long-term JSON production adapters" with categorical no-dual-write,
+  no-partial-cutover, and no-silent-fallback wording.
+- State the maintained fail-closed WAL runtime-qualification invariant and do not
+  encode a naive `>= 3.51.3` rule; withdrawn 3.52.0 must be denied.
+- Preserve the stable-selector/mutable-active-generation distinction or link it
+  unambiguously from the concise ADR/storage decision.
+- State that SQLite backup uses `Connection.backup()` and never raw-copies a live
+  main/WAL/SHM family.
+- Reconcile ordinary append-only events with #132's explicit analytics-history
+  deletion and broaden "never authority" beyond matching/playlist authority.
+- Align `.gitignore`, its test corpus, and storage prose with canonical operational,
+  generation, staging, backup, diagnostics, and legacy JSON names.
+- Add the required release record and integrate from current `origin/main` without
+  disturbing the existing dirty owner worktree.
+
+### Blocking for #139 or later production authority, but not for the ADR-only PR
+
+- Correct the merged concurrency research and executable runtime predicate so it
+  uses maintained release/source evidence and explicitly rejects 3.52.0.
+- Prove accepted SQLite builds on native macOS, Linux, and Windows jobs, including
+  Python 3.10/3.14 Linux edges, on the exact candidate commit.
+- Implement and test the authority pointer, quiescence, logical backup, restore,
+  and crash protocols in their owning #145/#146 slices.
+- Add generated sdist/wheel rejection when executable private-artifact names land;
+  `.gitignore` alone is not package proof.
+
+### Non-blocking and already aligned
+
+- Keep the filename and references as ADR-0005.
+- Keep one SQLite Operational Store plus in-memory conformance adapter.
+- Keep Transfer as sole policy authority and clients as adapters.
+- Keep configuration and Spotipy-managed credentials outside the database and
+  backup/migration payloads.
+- Keep Effect Journal intent before and observation after the bounded Spotify call,
+  with no database transaction across it.
+- Keep JSON production authority until #146 and original JSON retained through the
+  explicit rollback window.
+- Keep private local-only operation, OS account/disk protection for the first
+  release, fail-closed integrity behavior, and no telemetry.
+- ADR integration may precede #136 because it changes decisions/guardrails only;
+  #136 still blocks schema implementation and any production transition.
+
+## Exact owning-session review checklist
+
+- [ ] Confirm the source worktree still has exactly the original five dirty files
+  and no concurrent edits before preserving/replaying it.
+- [ ] Base the integration branch on the then-current `origin/main`; retain the
+  merged Runtime Assembly text in `docs/architecture.md`.
+- [ ] Keep ADR-0005 concise and link both merged implementation research contracts.
+- [ ] Delete the stale five-step delivery list or replace it with the exact
+  #138 → #147 dependency route.
+- [ ] Say explicitly: JSON before activation, SQLite after activation, never
+  dual-write, partial-client cutover, or silent fallback.
+- [ ] Say explicitly: the pointer selects only stable generation identity; an
+  inactive candidate is inert and a selected active generation remains mutable.
+- [ ] Say explicitly: active SQLite backups use `Connection.backup()` into a fresh
+  verified destination, never a filesystem copy of live database/WAL/SHM files.
+- [ ] Require maintained fail-closed runtime qualification; test that 3.43.1 and
+  withdrawn 3.52.0 are denied and do not use one monotonic version comparison.
+- [ ] Clarify that ordinary Operational Events are non-authoritative and that an
+  explicit analytics-history deletion cannot alter authority-bearing state.
+- [ ] Run `git check-ignore --no-index` over the complete canonical private-artifact
+  corpus, including pointer, generation directory, sidecars, snapshots, backups,
+  migration/restore staging, diagnostics/exports, current legacy JSON, and reports.
+- [ ] Ensure no generated SQLite database fixture is tracked or packaged; generate
+  synthetic databases only in temporary test storage.
+- [ ] Add one valid `.release-notes/*.md` record; final intended PR scope is exactly
+  the five corrected draft files plus that record.
+- [ ] Run
+  `python3 -m pytest tests/test_repository_privacy.py tests/test_documentation.py tests/test_release_records.py`.
+- [ ] Run `python3 -m pytest` and `python3 -m compileall -q djsupport tests`.
+- [ ] After committing, run `python3 scripts/release_records.py check origin/main HEAD`.
+- [ ] Build sdist/wheel and inspect their member names; do not claim package privacy
+  from `.gitignore` tests alone.
+- [ ] Review `git diff --cached --name-only` and `git diff --cached` before commit;
+  do not use `git add -A`.
+- [ ] Do not add Operational Store schema/runtime code, cut over authority, access
+  owner data, call live services, or publish tags/releases/packages in this PR.
+- [ ] Merge ADR-0005 before #138 schema writes, while preserving #136 as the separate
+  release/publication and return-to-development gate.

--- a/docs/research/2026-08-16-sqlite-concurrency-durability-contract.md
+++ b/docs/research/2026-08-16-sqlite-concurrency-durability-contract.md
@@ -125,7 +125,12 @@ SQLite's current WAL documentation says the WAL-reset race is likely present fro
 3.44.6 and 3.50.7. It requires at least two connections in different threads or
 processes and a tightly timed write/checkpoint race, but can corrupt the database;
 SQLite recommends upgrading.
-([official WAL-reset advisory](https://sqlite.org/wal.html#the_wal_reset_bug))
+SQLite separately withdrew 3.52.0 because some expression indexes could fail to
+interoperate with earlier releases; 3.53.0 reintroduced that release line with
+corrections.
+([official WAL-reset advisory](https://sqlite.org/wal.html#the_wal_reset_bug),
+[SQLite 3.52.0 withdrawal](https://sqlite.org/releaselog/3_52_0.html),
+[SQLite release news](https://sqlite.org/news.html))
 
 Python exposes the runtime SQLite library separately from the Python module
 version through `sqlite3.sqlite_version` and `sqlite3.sqlite_version_info`.
@@ -133,26 +138,34 @@ version through `sqlite3.sqlite_version` and `sqlite3.sqlite_version_info`.
 
 ### Implementation implication (inference)
 
-Before #139 enables concurrent authority, the store should fail closed unless its
-runtime is one of:
+Before #139 enables concurrent authority, the store should fail closed unless the
+exact selected-binding artifact and its SQLite version/source identity match a
+reviewed entry in DJ Support's maintained qualification manifest. Initially
+eligible upstream releases include exact 3.44.6 and 3.50.7 backports, exact
+3.51.3, and reviewed non-withdrawn 3.53 releases. Eligibility is not admission by
+version string: the artifact still needs exact source/build evidence.
 
-- SQLite 3.51.3 or later;
-- the 3.50 line at 3.50.7 or later;
-- the 3.44 line at 3.44.6 or later; or
-- a downstream build whose maintainer explicitly documents the same fix, recorded
-  in DJ Support's release qualification.
+SQLite 3.52.0 is denied even though it contains the WAL-reset fix, and an unlisted
+future release remains unknown until reviewed. A simple numeric lower-bound
+comparison is unsafe because upstream identifies the intervening 3.45–3.49 lines
+and 3.51.0–3.51.2 as affected and because a monotonic comparison would admit the
+withdrawn 3.52.0 release. A downstream backport requires exact vendor package,
+source/patch, and runtime-fingerprint evidence rather than a user assertion.
 
-A simple `version >= 3.44.6` comparison is unsafe because upstream identifies the
-intervening 3.45–3.49 lines and 3.51.0–3.51.2 as affected. The capability error
-must report the runtime version without printing a database path. #138 may run its
-single-process, non-authoritative conformance work on older versions, but the
-multi-client capability must remain disabled.
+The capability error must report only public runtime identity and a stable reason
+code, without printing a database path. #138 may run its single-process,
+non-authoritative conformance work on older versions, but the multi-client
+capability must remain disabled. The exact policy and CI evidence are maintained
+in the [runtime delivery](2026-08-16-sqlite-runtime-qualification-and-delivery.md)
+and [CI qualification](2026-08-16-sqlite-runtime-ci-qualification.md) contracts.
 
 ### Required tests
 
-- Unit-test the allow/deny matrix around 3.44.5/3.44.6, 3.45.x, 3.50.6/3.50.7,
-  and 3.51.2/3.51.3.
-- Record `sys.version` and `sqlite3.sqlite_version` as non-private CI metadata on
+- Unit-test the exact evidence policy around 3.44.5/3.44.6, 3.45.x,
+  3.50.6/3.50.7, 3.51.2/3.51.3, withdrawn 3.52.0, a reviewed 3.53 build, and an
+  unlisted future build.
+- Record the Python and selected-binding versions plus the runtime SQLite version,
+  source ID, compile options, and artifact identity as non-private CI metadata on
   macOS, Linux, and Windows, including the Python 3.10 and 3.14 Linux edges.
 - Make the concurrent-persistence suite fail, not skip, if the release runtime is
   not proven patched. A downstream-backport exception requires explicit build

--- a/docs/research/2026-08-16-sqlite-runtime-ci-qualification.md
+++ b/docs/research/2026-08-16-sqlite-runtime-ci-qualification.md
@@ -1,0 +1,621 @@
+# SQLite runtime and CI qualification for concurrent WAL authority
+
+**Date:** 2026-08-16
+
+**Code baseline:** `main` at `4be422b5565ac5491084771afa04784b2289318b`
+
+**Status:** Read-only qualification research for
+[#125](https://github.com/spontain112/djsupport/issues/125),
+[#139](https://github.com/spontain112/djsupport/issues/139), and
+[#149](https://github.com/spontain112/djsupport/issues/149). No production
+authority switch, owner-data access, live service call, release, commit, or push
+was performed.
+
+**Authority:** Repository requirements and primary sources from SQLite, Python,
+CPython, GitHub Actions, and operating-system vendors. “DJ Support should” and
+“the workflow must” statements below are implementation inferences from those
+sources.
+
+## Executive decision
+
+Issue #139 cannot safely enable concurrent WAL authority on the stock GitHub
+Actions Python runtimes observed on 2026-08-16. SQLite says the WAL-reset race is
+likely present from 3.7.0 through 3.51.2, is fixed in 3.51.3 and later, and has
+backports for 3.44.6 and 3.50.7. The race requires multiple connections plus an
+overlap between checkpointing and a commit that resets the WAL; SQLite could not
+reproduce it organically and used special internal test logic. Its recommendation
+is to upgrade, not to certify an application-level workaround.
+([SQLite WAL-reset advisory](https://sqlite.org/wal.html#the_wal_reset_bug))
+
+The current repository CI runs only `ubuntu-latest` with floating Python `3.10`
+and `3.14` selectors ([workflow](../../.github/workflows/ci.yml)). The current
+GitHub Ubuntu 24.04 image advertises SQLite 3.45.1, while Canonical's current Noble
+package is 3.45.1-1ubuntu2.7 and its changelog does not carry the WAL-reset fix.
+The current official CPython 3.14.7 Windows and macOS build recipes bundle SQLite
+3.50.4. Those versions are within the advisory's affected range.
+([Ubuntu 24.04 runner manifest](https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2404-Readme.md),
+[Ubuntu Noble package](https://packages.ubuntu.com/noble/libsqlite3-0),
+[Canonical package changelog](https://changelogs.ubuntu.com/changelogs/pool/main/s/sqlite3/sqlite3_3.45.1-1ubuntu2.7/changelog),
+[CPython 3.14.7 Windows build](https://github.com/python/cpython/blob/v3.14.7/PCbuild/readme.txt),
+[CPython 3.14.7 macOS build](https://github.com/python/cpython/blob/v3.14.7/Mac/BuildScript/build-installer.py))
+
+Therefore the safe implementation order is:
+
+1. Implement a runtime capability probe and an exact, reviewed evidence policy.
+2. Keep concurrent WAL production authority unavailable when the runtime is
+   affected, withdrawn, unknown, or only numerically “new enough.”
+3. Add native cross-platform persistence tests, but do not mistake a passing
+   stress test for proof that SQLite contains the upstream fix.
+4. Qualify the exact selected-binding artifact and its SQLite runtime in every
+   required release cell before #139 or #149 can pass.
+
+This document audits the currently accepted standard-library `sqlite3` route.
+The companion
+[runtime delivery research](2026-08-16-sqlite-runtime-qualification-and-delivery.md)
+finds that a qualified bundled binding is the strongest cross-platform delivery
+route and recommends APSW 3.53.4.0 behind an explicit decision gate. If that
+amendment is accepted, every production qualification rule below applies to the
+selected APSW artifact and its embedded SQLite runtime; standard-library
+`sqlite3` observations remain compatibility evidence only. The product must
+probe the binding that actually opens the Operational Store, never a different
+SQLite wrapper loaded in the same process.
+
+There must be no user setting, environment variable, or undocumented switch that
+overrides the gate. A vendor backport can be admitted without a user toggle only
+through a reviewed evidence entry tied to exact runtime fingerprints and primary
+vendor patch evidence.
+
+## 1. What the repository currently proves
+
+| Requirement | Current evidence | Qualification consequence |
+| --- | --- | --- |
+| Python support | `pyproject.toml` declares Python 3.10+, and CI runs the full suite on floating `3.10` and `3.14`. | Keep both Linux edges, but pin exact patch releases for release qualification. |
+| Operating systems | CI has only `ubuntu-latest`; no native macOS or Windows persistence job exists. | #139's macOS/Linux/Windows requirement is not met. |
+| SQLite behavior | No production SQLite adapter or runtime gate exists yet. | Existing green CI cannot qualify concurrent WAL authority. |
+| Offline/least privilege | CI has read-only contents permission, pinned checkout/setup-python actions, no service credentials, and the complete offline suite. | New jobs must preserve those constraints. |
+| Evidence retention | Repository policy test explicitly forbids `upload-artifact`. | Initially emit a redacted JSON record to the log and job summary. Adding uploaded artifacts requires a separate reviewed workflow-policy change. |
+| Release candidate | Package validation builds once on Ubuntu/Python 3.14, but does not run a cross-platform persistence suite against that exact wheel. | #149 must install the same wheel digest in all qualification cells. |
+
+These conclusions follow from the current
+[CI workflow](../../.github/workflows/ci.yml),
+[release-channel policy test](../../tests/test_release_channels.py),
+[runtime test surface](../../tests/test_runtime.py), and the merged
+[concurrency/durability contract](2026-08-16-sqlite-concurrency-durability-contract.md).
+
+## 2. Why the selected binding's runtime is the evidence boundary
+
+For the currently accepted standard-library route, Python documents
+`sqlite3.sqlite_version` and `sqlite3.sqlite_version_info` as the version of the
+SQLite library loaded by that wrapper. It is distinct from the Python wrapper's
+own version. SQLite exposes `sqlite_source_id()` as the check-in timestamp and
+source-tree hash of the running library. These are the facts the application will
+execute, so the probe must obtain them through the exact binding that opens the
+Operational Store. If another binding is selected, its wrapper identity and
+native artifact replace `_sqlite3` in the evidence tuple; probing the standard
+library would not qualify that store.
+([Python 3.10 runtime API](https://docs.python.org/3.10/library/sqlite3.html#sqlite3.sqlite_version),
+[SQLite runtime/source ID API](https://sqlite.org/c3ref/libversion.html),
+[SQLite `sqlite_source_id()`](https://sqlite.org/lang_corefunc.html#sqlite_source_id))
+
+An operating-system package version is supporting provenance, not a substitute
+for this probe:
+
+- GitHub's Ubuntu Python builder installs the distribution SQLite development
+  library and builds CPython against it. The resulting interpreter normally loads
+  the runner's shared SQLite library, so the exact runner image and installed
+  library build can change independently of the requested Python minor version.
+  ([Actions Ubuntu builder](https://github.com/actions/python-versions/blob/main/builders/ubuntu-python-builder.psm1))
+- For modern macOS and Windows, `actions/python-versions` wraps the official
+  python.org installers. CPython's platform build sources identify the bundled
+  SQLite, and that library need not equal the operating system's `sqlite3`
+  command or package.
+  ([Actions macOS builder](https://github.com/actions/python-versions/blob/main/builders/macos-python-builder.psm1),
+  [Actions Windows builder](https://github.com/actions/python-versions/blob/main/builders/win-python-builder.psm1))
+- A representative interpreter probe returned SQLite `3.43.1` and source ID
+  `2023-09-11 12:01:27 2d3a40c05c49e1a49264912b1a05bc2143ac0e7c3df588276ce80a4cbc9bd1b0`.
+  On that macOS interpreter the extension had no dynamic SQLite dependency. The
+  OS package version would therefore have been the wrong evidence; the result is
+  correctly classified as `unqualified_affected`.
+
+`actions/setup-python` first resolves its tool cache and otherwise downloads an
+`actions/python-versions` release. A minor selector such as `3.14` is a moving
+SemVer request, not a release-candidate identity. Runner images also change under
+stable labels, and GitHub says `-latest` labels can migrate to newer operating
+systems. Every qualification run must record the resolved patch version and exact
+runner image; release gates must request an exact Python patch release and a
+versioned OS label.
+([setup-python version resolution](https://github.com/actions/setup-python#supported-version-syntax),
+[actions/python-versions manifest](https://raw.githubusercontent.com/actions/python-versions/main/versions-manifest.json),
+[GitHub-hosted runner images](https://github.com/actions/runner-images),
+[GitHub-hosted runner documentation](https://docs.github.com/en/actions/concepts/runners/github-hosted-runners))
+
+### Current stock-runtime finding
+
+This table is a dated observation, not a permanent allowlist. Every workflow run
+must probe again.
+
+| Required surface | Distribution chain | Evidence available on 2026-08-16 | Result for concurrent WAL |
+| --- | --- | --- | --- |
+| Ubuntu 24.04, Python 3.10 | Actions-built CPython; dynamically linked distribution SQLite | Runner/package evidence points to SQLite 3.45.1; Canonical changelog has no WAL-reset backport. | `unqualified_affected` |
+| Ubuntu 24.04, Python 3.14 | Same Ubuntu linkage, different interpreter | Same linked-library risk; an exact cell probe remains mandatory. | `unqualified_affected` unless the probe matches a reviewed downstream attestation |
+| Native macOS 15, Python 3.14.7 | `actions/python-versions` wraps the python.org installer; CPython build recipe bundles SQLite 3.50.4 | SQLite is bundled with the interpreter, not inferred from macOS. | `unqualified_affected` |
+| Windows 2025, Python 3.14.7 x64 | `actions/python-versions` wraps the python.org installer; CPython build recipe bundles SQLite 3.50.4 | SQLite is bundled with the interpreter, not inferred from Windows. | `unqualified_affected` |
+
+CPython `main` has moved to a later SQLite release, but unreleased branch state
+does not qualify any released Python artifact. Likewise, building a patched
+interpreter only inside CI proves that curated artifact, not the Python that a
+normal end user already has installed.
+
+## 3. Runtime qualification policy
+
+### 3.1 Classification, not a numeric minimum
+
+A predicate such as `sqlite_version >= 3.51.3` is unsafe for three reasons:
+
+1. It rejects upstream's supported 3.44.6 and 3.50.7 backports.
+2. It can accept a vendor version string whose source does not contain the fix.
+3. It accepts SQLite 3.52.0, which SQLite withdrew because of expression-index
+   interoperability. A withdrawn build is not a production-qualified runtime
+   merely because it contains the WAL patch.
+   ([SQLite news](https://sqlite.org/news.html))
+
+The runtime policy should return one of five explicit states:
+
+| State | Meaning | Product behavior |
+| --- | --- | --- |
+| `qualified_upstream` | Exact version and source ID match a reviewed, non-withdrawn upstream release containing the fix. | Concurrent WAL may proceed, subject to the rest of #139's tests. |
+| `qualified_downstream_attestation` | Exact runtime/build fingerprints match a reviewed vendor backport entry. | Concurrent WAL may proceed with the evidence ID recorded. |
+| `unqualified_affected` | Runtime is in a known affected release/build family. | Fail before creating, opening for write, or converting the production store to WAL. |
+| `unqualified_withdrawn` | Exact release is withdrawn or explicitly denied, including 3.52.0. | Fail closed even if the WAL fix is present. |
+| `unqualified_unknown` | Missing, malformed, future, locally modified, or unmatched evidence. | Fail closed and name the missing evidence, never offer an override. |
+
+The initial reviewed upstream evidence can include these exact public source IDs:
+
+| Release | SQLite source ID | Basis |
+| --- | --- | --- |
+| 3.51.3 | `2026-03-13 10:38:09 737ae4a34738ffa0c3ff7f9bb18df914dd1cad163f28fd6b6e114a344fe6d618` | Release explicitly fixes the WAL-reset bug. |
+| 3.53.0 | `2026-04-09 11:41:38 4525003a53a7fc63ca75c59b22c79608659ca12f0131f52c18637f829977f20b` | First non-withdrawn 3.53 release; release notes explicitly include the fix. |
+| 3.53.4 | `2026-07-24 19:02:57 bf7c7f30031888f4e796e429ab3978879485813aaca6f641c7b33e4e09459bcc` | Current official release fingerprint at this research date. |
+
+([SQLite 3.51.3 release](https://sqlite.org/releaselog/3_51_3.html),
+[SQLite 3.53.0 release](https://sqlite.org/releaselog/3_53_0.html),
+[SQLite 3.53.4 release](https://sqlite.org/releaselog/3_53_4.html))
+
+That table is deliberately exact and conservative. It is not a rule that all
+other versions fail forever: each later upstream release is added after its
+official release/source ID and withdrawal status are reviewed. The advisory-linked
+3.44.6 and 3.50.7 backports may likewise be admitted only with the exact source ID
+returned by the candidate runtime. The advisory's backport labels alone must not
+silently authorize a distributor-modified binary.
+
+### 3.2 Downstream backport evidence schema
+
+A downstream build can keep an older numeric version, and a vendor patch may not
+make the source ID alone sufficient. Admission therefore requires one
+maintainer-reviewed, repository-owned public evidence entry with all applicable
+selectors:
+
+```json
+{
+  "schema_version": 1,
+  "evidence_id": "sqlite-wal-reset/<vendor>/<product>/<build>",
+  "status": "active",
+  "distributor": "public vendor name",
+  "product": "public runtime/package name",
+  "channel": "stable",
+  "os": {"name": "...", "release": "...", "architecture": "..."},
+  "python": {
+    "implementation": "CPython",
+    "version": "exact patch version",
+    "build": "public build identity"
+  },
+  "sqlite": {
+    "version": "runtime-reported version",
+    "source_id": "runtime-reported full source ID",
+    "compile_options_sha256": "sha256 of sorted compile options"
+  },
+  "binary": {
+    "binding_extension_sha256": "sha256, no filesystem path",
+    "linked_sqlite_sha256": "sha256 when dynamically linked",
+    "vendor_package": "exact package and build version when applicable"
+  },
+  "fix": {
+    "upstream_checkin": "official SQLite fix/backport check-in URL",
+    "vendor_advisory": "official vendor advisory/changelog URL",
+    "vendor_patch_digest": "sha256 of the reviewed public patch"
+  },
+  "qualification": {
+    "repository_commit": "full DJ Support SHA",
+    "workflow_run": "public Actions run URL",
+    "qualified_at_utc": "RFC 3339 timestamp",
+    "reviewed_by": "public maintainer identity"
+  },
+  "supersedes": null,
+  "revoked_at_utc": null
+}
+```
+
+Rules for applying an attestation:
+
+- Match every populated selector exactly. No prefix, version range, wildcard,
+  “same package family,” or user assertion is accepted.
+- On dynamically linked systems, match the loaded SQLite library build as well as
+  the selected Python binding extension. Hashing only the wrapper is insufficient
+  when the shared library can be upgraded independently.
+- Require a primary vendor advisory, changelog, or public source patch that maps
+  the vendor change to SQLite's fix. A passing black-box race test is not patch
+  provenance.
+- Treat missing or conflicting fields as `unqualified_unknown`.
+- Revocation is fail-closed and ships through the normal reviewed code/release
+  path. It does not require or permit an end-user toggle.
+
+This lets a real downstream backport work without forcing all users onto one
+SQLite number, while preserving an auditable reason for every accepted binary.
+
+## 4. Capability probe contract
+
+The same probe should run in product startup, unit tests, every persistence CI
+cell, and release qualification. It must execute before the production adapter
+creates a database, enables WAL, runs a migration, or accepts a write.
+
+### Required inputs
+
+Collect from the running interpreter and selected Operational Store binding:
+
+- Probe schema and policy version.
+- Python implementation, exact `sys.version_info`, public build/compiler identity,
+  and architecture. Do not record `sys.executable` or module paths.
+- OS name, release, architecture, requested runner label, and exact runner image
+  version.
+- Binding package/distribution name and exact wrapper version.
+- The binding's reported SQLite version plus `SELECT sqlite_source_id()` from a
+  fresh in-memory connection created by that same binding.
+- Sorted `PRAGMA compile_options`; hash the full sorted set and retain the
+  non-sensitive options required by the connection contract.
+- SHA-256 of the selected native binding extension bytes, but not its path.
+- When dynamically linked, SHA-256 and exact public package/build identity of the
+  loaded SQLite library, again without a filesystem path.
+- Exact policy result, evidence ID if matched, and a stable public reason code.
+
+For the standard-library compatibility route, also collect
+`sqlite3.sqlite_version`, `sqlite3.sqlite_version_info`, and
+`sqlite3.threadsafety`. For a bundled binding, collect its documented equivalent
+identity APIs and the exact installed wheel/distribution identity. Never combine
+the wrapper identity from one binding with the SQLite runtime from another.
+
+Python 3.10 hard-codes its DB-API `threadsafety` value, while newer Python derives
+it from SQLite's threading mode. The probe should therefore retain the
+`THREADSAFE` compile option as cross-version evidence rather than treating
+`sqlite3.threadsafety` alone as equivalent across 3.10 and 3.14.
+([Python 3.10 `threadsafety`](https://docs.python.org/3.10/library/sqlite3.html#sqlite3.threadsafety),
+[Python 3.14 `threadsafety`](https://docs.python.org/3.14/library/sqlite3.html#sqlite3.threadsafety))
+
+### Required outputs and behavior
+
+The probe returns a typed result, never a bare Boolean. A successful result names
+the exact evidence entry. A failure contains only safe remediation such as
+“install a supported DJ Support/Python build whose linked SQLite runtime is
+qualified”; it must not print local database paths, Python installation paths, or
+environment dumps.
+
+The production gate then obeys these invariants:
+
+```text
+probe -> qualified_*        -> adapter may open/enable WAL -> normal #139 checks
+probe -> unqualified_*      -> raise before store mutation -> no override/fallback
+probe cannot collect proof  -> unqualified_unknown         -> no override/fallback
+```
+
+Policy unit tests should feed invented probe records for each classification,
+including exact matches, one-field mismatches, modified source IDs, missing linked
+library hashes, future releases, official backports, revoked attestations, and the
+explicit 3.52.0 deny. No test needs a real user database or local path.
+
+## 5. No-autocheckpoint plus quiesced checkpoints is not qualification
+
+It is theoretically possible to narrow the advisory's race by disabling automatic
+checkpoints on every connection and running manual checkpoints only while all
+writers are globally quiesced. That is not a supported substitute for a patched
+runtime:
+
+- SQLite says the race needs a second checkpoint to start while another
+  connection commits and resets the WAL. It still recommends upgrading.
+  ([advisory details](https://sqlite.org/wal.html#the_wal_reset_bug))
+- `wal_autocheckpoint` configures a connection; every code path and process must
+  obey the same policy. SQLite also checkpoints when the last connection closes.
+  ([automatic checkpoints](https://sqlite.org/wal.html#automatic_checkpoint),
+  [WAL lifecycle](https://sqlite.org/wal.html#avoiding_excessively_large_wal_files))
+- Preventing close-time checkpointing requires the C-level
+  `SQLITE_DBCONFIG_NO_CKPT_ON_CLOSE` control. Python exposes database-config
+  controls only from 3.12, so Python 3.10 cannot implement one common stdlib-only
+  control surface for the supported range.
+  ([Python 3.14 `setconfig`](https://docs.python.org/3.14/library/sqlite3.html#sqlite3.Connection.setconfig),
+  [SQLite database configuration](https://sqlite.org/c3ref/c_dbconfig_defensive.html))
+- A test that fails to reproduce a rare race cannot prove that all present and
+  future connection-close/checkpoint paths are globally quiesced. SQLite itself
+  needed special test instrumentation.
+
+CI could only support that mitigation claim with a single enforceable connection
+factory, control over every process, proof that every connection has
+autocheckpoint disabled, a complete close-checkpoint control on every supported
+Python, a global checkpoint coordinator whose exclusion is mechanically tested,
+and deterministic upstream-equivalent fault instrumentation. Those preconditions
+are not available through the Python 3.10 standard library, and upstream does not
+bless the workaround. Reject it as a qualification route; at most use explicit
+checkpoint scheduling as defense in depth on an already qualified runtime.
+
+## 6. CI topology and fail-versus-skip policy
+
+Use two visibly different job classes.
+
+### 6.1 Stock-runtime compatibility observation
+
+Keep the ordinary full-suite Linux matrix on Python 3.10 and 3.14. Add the probe
+and test that known affected/unknown stock runtimes are rejected before WAL
+mutation. Such a cell can pass by proving fail-closed behavior, but its job name
+and JSON result must say `compatibility-observation`; it is never evidence that
+#139 may activate.
+
+### 6.2 Required qualified-persistence matrix
+
+Once an exact safe runtime artifact exists for every row, require this matrix on
+#139 and on the exact #149 release-candidate commit:
+
+| Cell | Runner | Python selector | Required proof |
+| --- | --- | --- | --- |
+| Linux lower edge | `ubuntu-24.04` x64 | exact supported 3.10 patch | Qualified linked SQLite plus complete persistence suite |
+| Linux upper edge | `ubuntu-24.04` x64 | exact supported 3.14 patch | Qualified linked SQLite plus complete persistence suite |
+| Native macOS | `macos-15` arm64 | exact supported 3.14 patch | Qualified selected-binding SQLite plus complete persistence suite |
+| Native Windows | `windows-2025` x64 | exact supported 3.14 patch | Qualified selected-binding SQLite plus complete persistence suite |
+
+This meets #139's explicit Linux version edges and native three-OS surface without
+claiming support for an architecture that was never tested. If DJ Support promises
+Intel macOS too, add a separate native Intel cell; do not let emulation stand in
+for it. Versioned labels reduce, but do not eliminate, runner drift, so the exact
+image remains part of the evidence.
+
+All rows use the same repository SHA and, for #149, install the same wheel SHA-256.
+Actions stay pinned to full commit SHAs; permissions remain `contents: read`; no
+Spotify/Beatport credentials or calls are introduced.
+
+### Fail-versus-skip rules
+
+- Policy/classification unit tests run everywhere and **fail** on a missing field,
+  unexpected classification, or denylist regression. They never skip.
+- A required persistence cell **fails** if the probe is not `qualified_*`. It may
+  not use `pytest.skip`, `continue-on-error`, dynamic matrix exclusion, or an
+  expected-failure marker.
+- A stock observation cell may pass only after asserting the exact fail-closed
+  state. It cannot satisfy the required qualification job or be counted as a
+  release-platform pass.
+- A runner outage or unavailable exact interpreter leaves the required check
+  incomplete/failed. It is not converted to a skip.
+- Experimental architectures may run in a clearly non-required job, but their
+  result is never substituted for a required row.
+- Any scope change needed to make a row available stops #149 for a reviewed
+  decision; it does not weaken the gate.
+
+This distinction allows useful CI on today's unsafe stock interpreters while
+making it impossible for an expected rejection to masquerade as production
+qualification.
+
+## 7. Concurrency and crash tests
+
+Runtime provenance and application conformance are independent evidence. The
+probe proves which SQLite is running; tests prove DJ Support uses it correctly.
+
+### Required on every pull request in each qualified cell
+
+- Open fresh connections in independent child processes using platform-native
+  process creation. Never share a connection across a fork, thread, or process.
+- Verify the connection factory's WAL, `synchronous=FULL`, foreign-key, busy-timeout,
+  and transaction settings on every connection.
+- Coordinate two writers with events/pipes, not timing sleeps, and prove distinct
+  entity writes both persist through close/reopen.
+- Race two revision-qualified writes to the same entity and prove exactly one wins
+  while the stale revision fails closed.
+- Hold the writer lock deliberately and prove bounded busy handling returns the
+  domain result within the documented limit.
+- Keep a reader snapshot open while a writer commits and a checkpoint is
+  requested; prove snapshot stability, later visibility, and integrity after
+  reopen.
+- Put a synthetic external-call callback between two database units of work and
+  assert no transaction remains open while that callback runs.
+- Run `PRAGMA quick_check`, `PRAGMA integrity_check`, and
+  `PRAGMA foreign_key_check` after concurrency and after every crash/reopen case.
+- Crash a child before `BEGIN`, after writes but before `COMMIT`, and immediately
+  after `COMMIT` returns. On reopen, require the exact prior or next domain state,
+  never a mixture. Python documents `os._exit()` as immediate process exit and
+  `multiprocessing` provides cross-platform process contexts.
+  ([Python `os._exit`](https://docs.python.org/3.10/library/os.html#os._exit),
+  [Python multiprocessing contexts](https://docs.python.org/3.14/library/multiprocessing.html#contexts-and-start-methods))
+
+### Extended scheduled/manual qualification
+
+- Repeat the independent-process writer/checkpointer scenario enough times to
+  expose application locking mistakes, with bounded total duration.
+- Exercise long-reader/checkpoint pressure, every supported migration boundary,
+  and each deterministic application fault seam.
+- Run the entire matrix manually for #149 against an exact commit and wheel
+  digest. A schedule is useful drift detection, but only the exact candidate run
+  is release evidence.
+
+### What these tests cannot prove
+
+A successful stress run does not prove absence of the WAL-reset bug. SQLite says
+the race was not organically reproducible and its deterministic trigger used
+special internal logic. `sqlite3_test_control()` is test-only, may be omitted at
+compile time, and can change without notice, so hosted Python binaries cannot be
+assumed to expose an upstream-equivalent trigger.
+([SQLite testing interface](https://sqlite.org/c3ref/test_control.html),
+[SQLite testing](https://sqlite.org/testing.html))
+
+Likewise, Python's progress handler runs after a configured number of virtual
+machine instructions; the documentation does not promise a callback at a specific
+point inside the C `COMMIT` path. It cannot be labeled “crash during commit” until
+a test first demonstrates the intended injection point. If #139 requires an exact
+kill inside C commit rather than the three observable transaction boundaries, the
+ticket needs a reviewed test-only VFS/fault harness. The acceptance criterion must
+not be silently skipped.
+([Python progress handler](https://docs.python.org/3.10/library/sqlite3.html#sqlite3.Connection.set_progress_handler))
+
+Hosted-runner process kills prove application-visible process-crash atomicity on
+that runner filesystem. They do not prove physical power-loss behavior, storage
+firmware honesty, or every filesystem's `fsync` implementation.
+
+## 8. Auditable CI evidence
+
+Each cell should emit one path-free `sqlite-runtime-qualification.json` payload to
+the log and `$GITHUB_STEP_SUMMARY`. It contains only synthetic/public build data:
+
+- schema and policy versions;
+- repository full SHA, workflow name, run ID/attempt, job, UTC time;
+- requested runner label, OS/release/architecture, exact runner image version, and
+  included-software manifest URL;
+- full action commit SHAs;
+- requested and resolved Python versions, implementation/build identity, and the
+  exact `actions/python-versions` release/asset when used;
+- all capability-probe fields and the resulting state/evidence ID;
+- test selection, pass/fail/error counts, durations, and final result;
+- exact wheel SHA-256 for #149 candidate runs.
+
+Do not include environment dumps, usernames, hostnames, home/temp paths, database
+names, database/WAL/SHM bytes, snapshots, reports, playlist identifiers, or any
+owner-derived fixture. Tests use invented state only.
+
+The present repository test rejects `upload-artifact`; therefore an implementation
+that merely adds `actions/upload-artifact` would violate the existing least-
+privilege contract. The first safe route is durable public job logs/summaries plus
+the exact run URLs recorded in #149. If downloadable JSON retention is later
+required, change the workflow policy in a separate reviewed scope: pin the upload
+action by full SHA, allow only the one generated JSON file, set bounded retention,
+inspect its contents, and keep all database/crash files excluded.
+
+## 9. Evidence limits and unstable inputs
+
+| Evidence | What it proves | What it does not prove |
+| --- | --- | --- |
+| Binding-reported SQLite version | Numeric version reported by the selected Operational Store binding | Patch presence, withdrawal status, or vendor backport identity |
+| `sqlite_source_id()` | Upstream check-in identity for an unmodified build; edited amalgamations may change only part of the ID | That a distro backport changed its version/source ID, or that an arbitrary binary is trusted |
+| OS package/advisory | Vendor-supported package build and documented patch provenance | The Python process loaded that package on macOS/Windows or in a custom interpreter |
+| Binding-extension hash | Exact selected Python extension artifact | Exact shared `libsqlite3` on dynamically linked systems |
+| Linked-library hash | Exact binary loaded for one dynamic build | Semantic safety without reviewed patch provenance |
+| CPython build source | What the official tagged build recipe intended to bundle | The exact bytes loaded by a particular runner; probe them |
+| Runner manifest | Snapshot of advertised image contents | Future contents of the same label |
+| Exact Python selector | Requested/resolved interpreter patch line | SQLite safety; the bundled/system library still needs probing |
+| Concurrency/crash tests | DJ Support behavior under tested schedules and process failures | Absence of a rare upstream race or real hardware power-loss semantics |
+| `sqlite3_test_control` | Upstream internal fault injection when present in a controlled SQLite build | A stable production API or capability of hosted Python binaries |
+
+The absence of a public Canonical WAL-reset advisory/backport for the current
+Noble package is an evidence gap, not proof that no private or future patch exists.
+The correct state remains `unqualified_unknown` or `unqualified_affected` until
+official evidence and the actual runtime fingerprint agree.
+
+## 10. Ticket acceptance criteria
+
+### #139 — qualify before production authority
+
+- [ ] A single runtime-probe implementation interrogates the binding that opens
+  the Operational Store, produces all required safe metadata on Python 3.10 and
+  3.14, and classifies exact upstream, downstream, affected, withdrawn, revoked,
+  malformed, and unknown cases.
+- [ ] The policy uses exact reviewed version/source/build evidence, explicitly
+  rejects SQLite 3.52.0, and does not implement a bare numeric-minimum gate.
+- [ ] Production SQLite/WAL creation, migration, and write authority fail before
+  mutation on every `unqualified_*` result, with no CLI/config/environment toggle.
+- [ ] A downstream backport is accepted only through the reviewed schema above and
+  exact selector/fingerprint matching.
+- [ ] Required CI has native Ubuntu 24.04/Python 3.10, Ubuntu 24.04/Python 3.14,
+  macOS 15, and Windows 2025 cells, using exact Python patch versions and probing
+  the selected binding/runtime artifact in each.
+- [ ] Every required cell is `qualified_*`; a stock-runtime expected rejection is
+  separately named and cannot satisfy this check.
+- [ ] The independent-process concurrency, stale-revision, bounded-busy,
+  checkpoint-pressure, no-external-call-in-transaction, crash/reopen, integrity,
+  and foreign-key tests pass with invented state on all four cells.
+- [ ] Any claim of a crash *inside* C commit is backed by a demonstrated injection
+  point or reviewed test-only VFS/fault harness; otherwise the claim is narrowed
+  to observable transaction boundaries.
+- [ ] CI remains read-only/offline and emits a path-free evidence record. No
+  database, WAL/SHM, snapshot, or owner-derived evidence is uploaded.
+- [ ] The no-autocheckpoint/quiesced-checkpoint design is not accepted as a
+  substitute for a patched runtime.
+
+### #149 — release-candidate evidence
+
+- [ ] The exact release-candidate commit and one wheel SHA-256 are identical across
+  every qualification cell.
+- [ ] A manually dispatched run on that exact commit completes the whole required
+  matrix with no skip, xfail, `continue-on-error`, or removed row.
+- [ ] Every cell's JSON/log evidence includes its exact runner image, resolved
+  Python, SQLite version/source ID/binary fingerprints, policy result/evidence ID,
+  test result, and wheel digest.
+- [ ] The #149 record links the exact run and explains any admitted downstream
+  attestation. No release/tag/publication occurs as part of qualification.
+- [ ] A runner/runtime drift, failed cell, missing attestation, withdrawn build, or
+  unavailable exact interpreter stops the candidate instead of weakening scope.
+
+## 11. Concrete commands and workflow assertions
+
+The eventual implementation should make these commands green from a clean
+checkout, using the repository's final marker/file names:
+
+```bash
+python -m pytest tests/test_sqlite_runtime_qualification.py
+python -m pytest tests/test_operational_store.py tests/test_operational_store_concurrency.py
+python -m pytest tests/test_operational_store_crash.py
+python -m pytest
+python -m compileall -q djsupport tests
+```
+
+Each matrix cell should also run a path-free probe before persistence tests. The
+exact module name is an implementation choice, but the assertion shape is not:
+
+```bash
+python -m djsupport.sqlite_runtime_probe --format json --require-qualified
+python -m pytest -m "sqlite_persistence and not live_service"
+```
+
+Repository behavior tests should parse the workflow and assert:
+
+- versioned native runner labels are exactly `ubuntu-24.04`, `macos-15`, and
+  `windows-2025`, not `*-latest`;
+- required Linux rows cover exact Python 3.10.x and 3.14.x, while macOS/Windows
+  use the reviewed exact patch selector;
+- checkout/setup actions remain full-SHA pinned and checkout credentials do not
+  persist;
+- workflow/job permissions remain `contents: read` and no service secrets exist;
+- every required cell runs the probe with `--require-qualified`, the same complete
+  persistence test command, and evidence emission;
+- no `continue-on-error`, skip-based success, dynamic row removal, live Spotify or
+  Beatport call, tag, release, package publication, or user-data upload exists;
+- `upload-artifact` remains forbidden unless a separate policy change introduces
+  one pinned, allowlisted, JSON-only evidence upload;
+- the release workflow passes the same wheel SHA-256 to every cell and records the
+  exact candidate SHA/run URL.
+
+Until all #139 criteria are green on exact qualified runtimes, the correct CI
+outcome is: ordinary compatibility tests may pass, the fail-closed runtime test
+must pass, and the production concurrent-WAL qualification gate remains blocked.
+
+## Primary sources
+
+- SQLite: [WAL and WAL-reset advisory](https://sqlite.org/wal.html),
+  [3.51.3 release](https://sqlite.org/releaselog/3_51_3.html),
+  [3.53.0 release](https://sqlite.org/releaselog/3_53_0.html),
+  [3.53.4 release](https://sqlite.org/releaselog/3_53_4.html),
+  [news/withdrawals](https://sqlite.org/news.html),
+  [runtime identity](https://sqlite.org/c3ref/libversion.html),
+  [testing interface](https://sqlite.org/c3ref/test_control.html), and
+  [testing overview](https://sqlite.org/testing.html).
+- Python/CPython: [Python 3.10 `sqlite3`](https://docs.python.org/3.10/library/sqlite3.html),
+  [Python 3.14 `sqlite3`](https://docs.python.org/3.14/library/sqlite3.html),
+  [CPython 3.14.7 Windows build](https://github.com/python/cpython/blob/v3.14.7/PCbuild/readme.txt), and
+  [CPython 3.14.7 macOS build](https://github.com/python/cpython/blob/v3.14.7/Mac/BuildScript/build-installer.py).
+- GitHub Actions: [setup-python](https://github.com/actions/setup-python),
+  [python-versions](https://github.com/actions/python-versions),
+  [runner images](https://github.com/actions/runner-images), and
+  [GitHub-hosted runner documentation](https://docs.github.com/en/actions/concepts/runners/github-hosted-runners).
+- Ubuntu/Canonical: [Noble `libsqlite3-0`](https://packages.ubuntu.com/noble/libsqlite3-0),
+  [package changelog](https://changelogs.ubuntu.com/changelogs/pool/main/s/sqlite3/sqlite3_3.45.1-1ubuntu2.7/changelog), and
+  [Ubuntu security notices](https://ubuntu.com/security/notices).

--- a/docs/research/2026-08-16-sqlite-runtime-qualification-and-delivery.md
+++ b/docs/research/2026-08-16-sqlite-runtime-qualification-and-delivery.md
@@ -1,0 +1,463 @@
+# SQLite runtime qualification and delivery
+
+**Date:** 2026-08-16
+
+**Status:** Findings for an implementation decision
+
+**Scope:** DJ Support's local Operational Store on Python 3.10-3.14, macOS, Linux, and Windows
+
+**Evidence rule:** Primary sources only; public product and synthetic engineering evidence only
+
+## Executive finding
+
+DJ Support cannot guarantee a WAL-reset-safe Operational Store by requiring a Python version, testing only `sqlite3.sqlite_version`, relying on an operating-system update, or scheduling checkpoints itself. The supported Python installers and CI routes do not identify one SQLite runtime, and the official SQLite remedy for the WAL-reset corruption bug is to upgrade the SQLite library.
+
+The production-grade route is:
+
+1. Put a fail-closed SQLite runtime qualifier in front of every Operational Store open.
+2. Ship one audited SQLite runtime as an application dependency across the supported matrix instead of inheriting whatever SQLite happens to be behind the standard-library module.
+3. Record the selected binding artifact, SQLite version, SQLite source ID, build provenance, supported wheel tags, and withdrawn-release denylist in a reviewed qualification manifest.
+4. Keep JSON authoritative until that runtime is installed and qualified; never silently change the database to rollback-journal mode.
+5. Run the issue #139 concurrency and crash suite against the actual release artifacts on every claimed Python/OS combination.
+
+The strongest current candidate is **APSW 3.53.4.0**, whose official wheels bundle SQLite 3.53.4 and cover Python 3.10-3.14 on the three target operating systems. It should sit behind DJ Support's internal Operational Store port so its non-DB-API interface does not escape into Transfer or adapters. Selecting it requires an explicit amendment to the accepted wording in issue #125 and the literal standard-library wording in issue #138; it must not arrive as an incidental dependency swap.
+
+If that amendment is not accepted, the honest alternative is to keep the Python standard-library binding, qualify each concrete interpreter build, and fail closed on the common installers that remain affected or lack verified vendor-backport evidence. That alternative cannot currently promise the Operational Store on every advertised Python 3.10-3.14/macOS/Linux/Windows combination.
+
+## Repository decision context
+
+This analysis preserves the accepted direction while making its newly discovered runtime prerequisite explicit:
+
+- [Issue #125](https://github.com/spontain112/djsupport/issues/125) accepted one local SQLite Operational Store, Python `sqlite3`, WAL, short transactions, bounded waits, and optimistic revisions.
+- [Issue #138](https://github.com/spontain112/djsupport/issues/138) is a non-authoritative Preview and keeps production Runtime Assembly on JSON.
+- [Issue #139](https://github.com/spontain112/djsupport/issues/139) introduces the independent-connection, concurrent-authority workloads that meet the upstream bug's trigger conditions and therefore needs the hard runtime gate.
+- The merged [issue-frontier research](2026-08-16-operational-store-issue-frontier.md), [concurrency and durability contract](2026-08-16-sqlite-concurrency-durability-contract.md), and [migration, backup, and cutover contract](2026-08-16-sqlite-migration-backup-cutover-contract.md) establish the surrounding dependency order and fail-closed posture.
+
+## The upstream safety boundary
+
+SQLite's official [WAL-reset advisory](https://sqlite.org/wal.html#the_wal_reset_bug) says:
+
+- the bug is likely present from SQLite 3.7.0 through 3.51.2;
+- the fixed upstream release is 3.51.3, with official backports at 3.44.6 and 3.50.7;
+- it requires WAL, at least two connections in separate threads or processes, and an overlapping write and checkpoint;
+- the corrupting sequence is a completed checkpoint, a second checkpoint starting, another connection committing and resetting the WAL, and a later checkpoint skipping committed content; and
+- despite the low observed probability, the consequence is corruption and application developers should upgrade.
+
+The release number is not a monotonic allow rule. SQLite [withdrew 3.52.0](https://sqlite.org/releaselog/3_52_0.html), and the project's [news explanation](https://sqlite.org/news.html) says it could fail to interoperate with earlier releases for some expression indexes. SQLite 3.53.0 reintroduced the work with corrections. Therefore:
+
+- `SQLite >= 3.51.3` is **not** an acceptable predicate because it admits withdrawn 3.52.0.
+- 3.52.0 must be denied even though it contains the WAL-reset fix.
+- An explicit withdrawn-release denylist is part of qualification, and an unknown future release does not become production-qualified merely because its number is larger.
+
+The version merged by PR #163 used “3.51.3 or later” as a shorthand. This
+research stream corrects that contract to require a positively qualified build
+and explicitly deny withdrawn 3.52.0 rather than comparing one version floor.
+
+### Initial upstream release policy
+
+| Runtime claim | Initial result | Required evidence |
+| --- | --- | --- |
+| SQLite 3.44.6 | Eligible backport | Exact runtime identity plus the official 3.44.6 backport lineage linked by the advisory |
+| SQLite 3.50.7 | Eligible backport | Exact runtime identity plus the official 3.50.7 backport lineage linked by the advisory |
+| SQLite 3.51.3 | Eligible | Exact source ID from the [3.51.3 release](https://sqlite.org/releaselog/3_51_3.html) |
+| SQLite 3.52.0 | Denied | Officially withdrawn |
+| SQLite 3.53.0-3.53.4 | Eligible after artifact qualification | Exact source ID, artifact provenance, wheel matrix, and no withdrawn status; [3.53.4](https://sqlite.org/releaselog/3_53_4.html) is the current researched release |
+| An older vendor version with a backport | Unknown by default | Exact vendor package/build plus a vendor source/advisory proving the WAL-reset patch |
+| Any unlisted build | Denied by default | A reviewed manifest update |
+
+“Eligible” is deliberately not “accepted from the version string.” It means a release can be added to DJ Support's qualification manifest after its concrete artifact is checked.
+
+## Identity is more than a version string
+
+At runtime, record at least:
+
+- Python implementation and version;
+- Python SQLite wrapper and wrapper version;
+- `SELECT sqlite_version()`;
+- `SELECT sqlite_source_id()`;
+- `PRAGMA compile_options`;
+- binding package name and installed distribution version;
+- operating system, architecture, and wheel or vendor-package identity; and
+- the qualification-manifest entry that admitted the build.
+
+Qualification has two evidence layers. The release/install job records the original wheel filename, digest, and provenance. The running process checks what it can actually observe: binding distribution/version, SQLite version/source ID, compile options, OS, and architecture. An ordinary Python installation does not necessarily preserve the original wheel archive, so runtime code must not pretend it has re-verified that archive's attestation. A managed installer may retain an installation report; otherwise the exact dependency and source identity correlate the runtime to the artifact set admitted by release CI.
+
+SQLite documents [SQLITE_SOURCE_ID](https://sqlite.org/c3ref/c_source_id.html) as the source check-in identity and exposes the corresponding [runtime library APIs](https://sqlite.org/c3ref/libversion.html). The official SQLite 3.51.3 source ID is:
+
+`2026-03-13 10:38:09 737ae4a34738ffa0c3ff7f9bb18df914dd1cad163f28fd6b6e114a344fe6d618`
+
+The researched current SQLite 3.53.4 source ID is:
+
+`2026-07-24 19:02:57 bf7c7f30031888f4e796e429ab3978879485813aaca6f641c7b33e4e09459bcc`
+
+Source ID improves evidence but is not a cryptographic attestation that an arbitrary downstream binary contains a particular backport. A vendor may retain an older upstream version, apply patches, and produce a different source ID; a locally rebuilt or edited source can also differ. A downstream build is accepted only when a reviewed entry maps the exact version, source ID, vendor package revision, platform, and architecture to:
+
+1. an official vendor advisory or source-package change;
+2. the exact patch/check-in that fixes the WAL-reset bug;
+3. the artifact repository and integrity/provenance evidence; and
+4. a passing DJ Support release-artifact test.
+
+Unknown identity fails closed. Diagnostics may print these public build facts, but never the database path or user state.
+
+## Why the standard library is not one runtime
+
+Python's `sqlite3` module is an interface to the SQLite library used to build that interpreter. The [Python documentation](https://docs.python.org/3/library/sqlite3.html#sqlite3.sqlite_version) exposes the runtime SQLite version separately from the module version, while the [Unix build requirements](https://docs.python.org/3/using/configure.html#build-requirements) describe SQLite as a build dependency. Consequently, “Python 3.14” does not identify the SQLite build.
+
+### Official installer evidence
+
+The last or current binary-installing releases in each supported Python series embed the following SQLite versions in their tagged CPython build recipes:
+
+| Python series | Official binary release inspected | Bundled SQLite in tagged macOS/Windows recipes | WAL-reset status by upstream advisory |
+| --- | --- | --- | --- |
+| 3.10 | [3.10.11](https://www.python.org/downloads/release/python-31011/) | 3.40.1 | Affected |
+| 3.11 | [3.11.9](https://www.python.org/downloads/release/python-3119/) | 3.45.1 | Affected |
+| 3.12 | [3.12.10](https://www.python.org/downloads/release/python-31210/) | 3.49.1 | Affected |
+| 3.13 | [3.13.15](https://www.python.org/downloads/release/python-31315/) | 3.50.4 | Affected |
+| 3.14 | [3.14.7](https://www.python.org/downloads/release/python-3147/) | 3.50.4 | Affected |
+
+The evidence is in CPython's tagged Windows `PCbuild/python.props` and macOS `Mac/BuildScript/build-installer.py`:
+
+- [CPython 3.10.11 Windows recipe](https://github.com/python/cpython/blob/v3.10.11/PCbuild/python.props) and [macOS recipe](https://github.com/python/cpython/blob/v3.10.11/Mac/BuildScript/build-installer.py)
+- [CPython 3.11.9 Windows recipe](https://github.com/python/cpython/blob/v3.11.9/PCbuild/python.props) and [macOS recipe](https://github.com/python/cpython/blob/v3.11.9/Mac/BuildScript/build-installer.py)
+- [CPython 3.12.10 Windows recipe](https://github.com/python/cpython/blob/v3.12.10/PCbuild/python.props) and [macOS recipe](https://github.com/python/cpython/blob/v3.12.10/Mac/BuildScript/build-installer.py)
+- [CPython 3.13.15 Windows recipe](https://github.com/python/cpython/blob/v3.13.15/PCbuild/readme.txt) and [macOS recipe](https://github.com/python/cpython/blob/v3.13.15/Mac/BuildScript/build-installer.py)
+- [CPython 3.14.7 Windows recipe](https://github.com/python/cpython/blob/v3.14.7/PCbuild/readme.txt) and [macOS recipe](https://github.com/python/cpython/blob/v3.14.7/Mac/BuildScript/build-installer.py)
+
+The tagged macOS installer recipes compile and archive `libsqlite3.a`. The tagged Windows build downloads SQLite source and builds its own SQLite DLL before building `_sqlite3`. Those artifacts do not dynamically inherit a later SQLite fix merely because macOS or Windows updates its system library.
+
+A de-identified probe of a current DJ Support development interpreter corroborates the official build model: a python.org-style Python 3.12 interpreter reports SQLite 3.43.1 and source ID `2023-09-11 12:01:27 2d3a40c05c49e1a49264912b1a05bc2143ac0e7c3df588276ce80a4cbc9bd1b0`, and its extension does not dynamically link a system SQLite library. This observation is supporting evidence only; the decision rests on the official CPython recipes.
+
+### CI is also build-specific
+
+The official [actions/setup-python advanced usage](https://github.com/actions/setup-python/blob/main/docs/advanced-usage.md) explains that hosted-toolcache entries or the `actions/python-versions` builds supply Python. The official [Ubuntu builder](https://github.com/actions/python-versions/blob/main/builders/ubuntu-python-builder.psm1) installs the distribution's `libsqlite3-dev`, while the macOS builder can use python.org installers and Windows uses official executables. A GitHub Actions matrix over Python labels therefore does not qualify SQLite unless the job interrogates the runtime it actually imported.
+
+The present DJ Support CI matrix covers Ubuntu with Python 3.10 and 3.14. Production qualification needs all supported minor versions on macOS, Linux, and Windows, using the release installation path rather than a convenient development interpreter.
+
+## Downstream vendor backports
+
+Version suffixes prove that vendors patch old upstream releases, not that a particular security fix is present. For example, Ubuntu's official [USN-8480-1](https://ubuntu.com/security/notices/USN-8480-1) lists patched SQLite packages with Ubuntu revision suffixes while retaining old upstream version numbers. Ubuntu publishes the [source-package changelog](https://launchpad.net/ubuntu/+source/sqlite3/+changelog), and Debian publishes its [SQLite source-package security tracker](https://security-tracker.debian.org/tracker/source-package/sqlite3).
+
+No official Ubuntu or Debian source found in this pass specifically proves that the installed older packages carry the 2026 WAL-reset patch. They remain unqualified until such an advisory/changelog and exact binary identity are available. A generic “security updated” status or an old version with a distro suffix is insufficient.
+
+Even a verified operating-system backport only helps interpreters dynamically linked to that package. It cannot repair the separately bundled SQLite used by the official macOS and Windows Python builds described above. The capability probe must interrogate the imported binding, never the platform's `sqlite3` command-line tool.
+
+## Delivery options and hard tradeoffs
+
+### Option A: standard-library capability gate
+
+**Shape:** Keep `sqlite3`; admit only a manifest-qualified concrete interpreter build.
+
+**Benefits**
+
+- No new runtime dependency or binding API.
+- Preserves issue #125 and #138 wording.
+- Linux distribution Python can become eligible when a vendor publishes verifiable backport evidence.
+
+**Costs**
+
+- Common supported python.org macOS/Windows installers are affected according to their tagged build inputs.
+- Support becomes an interpreter-build matrix, not a Python-version matrix.
+- A user can upgrade DJ Support without changing the vulnerable SQLite embedded in Python.
+- An OS update cannot repair a statically or separately bundled interpreter.
+- Source-built Python and environment managers add more build identities.
+
+**Verdict:** Suitable as a fail-closed compatibility path, not as the default production delivery mechanism for a cross-platform guarantee.
+
+### Option B: APSW with bundled SQLite
+
+**Shape:** Depend on an exact qualified APSW release and keep it behind the Operational Store port.
+
+APSW's official [comparison with pysqlite](https://rogerbinns.github.io/apsw/pysqlite.html) says its PyPI builds include SQLite statically and independently of the system SQLite. The current [APSW 3.53.4.0 project release](https://pypi.org/project/apsw/3.53.4.0/) requires Python 3.10 or newer and publishes CPython wheels for the relevant Windows, macOS, manylinux, and musllinux combinations, including Python 3.14. Its release artifacts publish PyPI provenance attestations. APSW's [copyright page](https://rogerbinns.github.io/apsw/copyright.html) describes permissive terms and required notices.
+
+**Benefits**
+
+- One SQLite source line across user machines rather than inheritance from each interpreter.
+- Current wheels contain SQLite 3.53.4, whose official release source ID is known and whose line contains the WAL-reset fix.
+- Current artifacts cover the requested Python 3.10-3.14 and desktop OS matrix.
+- DJ Support's own wheel may remain pure Python because the native code is delivered by a dependency.
+- Published provenance can be recorded during qualification.
+
+**Costs**
+
+- APSW intentionally is not Python DB-API `sqlite3`; the adapter implementation and tests must account for its transaction behavior and exception surface.
+- This changes an accepted architecture detail and needs an explicit ADR/issue amendment.
+- APSW and standard-library `sqlite3` may load two SQLite libraries in one process. APSW's documentation warns against opening the same database through both. DJ Support must make the chosen Operational Store engine exclusive.
+- Native wheel availability remains a release concern; unsupported platform tags can trigger a source build unless install policy prevents or qualifies it.
+- A third-party native dependency adds maintainer, release, provenance, and vulnerability-monitoring risk.
+
+**Verdict:** Best current production route, provided the decision is explicit, the artifact is pinned/qualified, and all Operational Store opens go through one adapter.
+
+### Option C: pysqlite3 or pysqlite3-binary
+
+**Shape:** Use the separately packaged CPython `sqlite3` module, potentially as a closer DB-API replacement.
+
+The official [pysqlite3 project page](https://pypi.org/project/pysqlite3/) describes a separately packaged standard-library module and a statically linked build option. However, the researched pysqlite3 0.6.0 release predates the March 2026 fix. The official [pysqlite3-binary project page](https://pypi.org/project/pysqlite3-binary/) currently shows an older release and a much narrower Linux wheel set.
+
+**Benefits**
+
+- API is closer to the accepted standard-library implementation.
+- A correctly rebuilt release could bundle a qualified SQLite.
+
+**Costs**
+
+- Current release date and package label do not prove a fixed SQLite; the actual runtime and source ID still need inspection.
+- The current binary distribution does not cover the required macOS/Linux/Windows matrix.
+- Provenance and release freshness are weaker than the current APSW candidate.
+
+**Verdict:** Not currently qualified. Re-evaluate only when a post-advisory release publishes complete wheels and concrete runtime/provenance evidence.
+
+### Option D: DJ Support-owned native extension
+
+**Shape:** Vendor an official SQLite amalgamation plus a Python binding or maintain a controlled pysqlite fork.
+
+The PyPA [binary-extension packaging guide](https://packaging.python.org/en/latest/guides/packaging-binary-extensions/) explains that binary distributions multiply across Python versions, operating systems, and architectures; the stable ABI can reduce the Python dimension only when the extension can use it. PyPA's [packaging flow](https://packaging.python.org/en/latest/flow/) also explains that installers fall back to a source distribution when no compatible wheel exists. PyPA recommends tools such as `cibuildwheel` in its [tool recommendations](https://packaging.python.org/en/latest/guides/tool-recommendations/).
+
+**Benefits**
+
+- Maximum control over SQLite version, compile options, patch intake, and release timing.
+- The outward adapter could preserve the standard-library-style subset.
+
+**Costs**
+
+- DJ Support becomes responsible for native build hardening, all wheel tags, repair/delocation, signing/provenance, source builds, crash debugging, and urgent SQLite rebuilds.
+- The matrix is at least five CPython minors times three operating systems times each claimed architecture unless an ABI strategy genuinely reduces it.
+- Missing wheels cause compiler/toolchain UX during installation.
+- Vendoring CPython-derived binding code adds PSF license obligations in addition to the SQLite and binding notices.
+
+**Verdict:** A fallback only if no maintained binding can meet the contract. It is disproportionate to the product at this stage.
+
+## Why checkpoint scheduling is not a production workaround
+
+The upstream race requires a second checkpoint to overlap the commit that resets the WAL. In a fully controlled closed system, disabling auto-checkpoint and allowing checkpoints only while an exclusive Runtime Assembly maintenance lease is held could theoretically remove that overlap **if every connection and every checkpoint obeyed the same lease**.
+
+That is not a supportable guarantee here:
+
+- SQLite's [automatic-checkpoint documentation](https://sqlite.org/wal.html#automatic_checkpoint) says a checkpoint occurs by default at the page threshold **or when the last connection closes**.
+- The standard-library binding does not provide an application policy seam for every close-time checkpoint path.
+- Independent CLI, web, and future agent processes can open or close connections outside one process-local coordinator; a stale or bypassed lease restores the overlap.
+- SQLite warns that disabling automatic checkpoints can let the WAL grow excessively, consuming disk and degrading reads.
+- Crash, forced termination, or another SQLite client can bypass the intended maintenance ceremony.
+- The SQLite advisory recommends upgrading; it does not publish checkpoint scheduling as a supported remediation.
+
+Therefore checkpoint serialization may narrow the timing window but does not qualify an affected runtime. The runtime gate must still reject it. An acceptance test should specifically prove that `wal_autocheckpoint=0` and a maintenance-lease flag cannot override a failed runtime qualification.
+
+## Why rollback journal is not a silent fallback
+
+The WAL-reset bug is WAL-specific, so rollback journal avoids this particular race. But issue #125 explicitly accepted WAL to support short concurrent reads and writes. SQLite's [WAL documentation](https://sqlite.org/wal.html) identifies the concurrency difference: in WAL, readers and a writer can proceed together, while rollback journaling follows the traditional lock/journal model.
+
+Changing to `journal_mode=DELETE` would silently replace an accepted concurrency contract and produce different behavior under #139's multi-process workloads. It is an architectural alternative, not a runtime mitigation.
+
+On an unqualified runtime DJ Support should:
+
+- leave JSON as authority before cutover;
+- refuse to open a concurrent WAL Operational Store;
+- show an actionable, path-free upgrade message; and
+- never silently return a usable store in rollback mode.
+
+Issue #138's explicitly non-authoritative Preview can still exercise an in-memory implementation and pure schema/migration logic. A temporary, single-connection standard-library SQLite test adapter may be used only if it is unmistakably non-production and cannot be selected by Runtime Assembly. It must not be represented as qualification for #139.
+
+## Installation and upgrade contract
+
+### Installation
+
+For the recommended APSW route:
+
+1. Pin the audited binding release in package metadata for the release train.
+2. Publish the exact supported Python/OS/architecture tags.
+3. In CI and release qualification, install from the built DJ Support wheel into clean environments and require binary artifacts for the native binding.
+4. Verify the downloaded artifact's index provenance and recorded digest.
+5. Import the binding and compare version, source ID, compile options, binding version, and artifact identity with the reviewed manifest.
+6. Fail before creating or migrating user state if no qualified artifact resolves.
+
+Normal Python dependency metadata cannot force every installer never to build an sdist. A source installation is therefore an advanced, separately qualified route: it must produce the same approved source identity and pass the same tests. It is not silently covered by the wheel claim. PyPA's [secure installation guidance](https://pip.pypa.io/en/stable/topics/secure-installs/) describes hash-checking mode for repeatable artifact selection.
+
+The user-facing failure should say which public runtime facts are unsupported and how to install a supported build. It must not expose application-data paths, database contents, or credentials.
+
+### Upgrade
+
+- Upgrading DJ Support alone must not be reported as repairing an interpreter-embedded SQLite.
+- A binding update is a reviewed qualification change with a manifest diff, upstream release review, wheel/provenance review, and full matrix run.
+- Perform the runtime check before schema migration, backup, or authority cutover.
+- Preserve the last qualified binding until the replacement passes. Do not loosen the manifest just to admit a newer version.
+- A cleanly closed synthetic WAL database created with the prior qualified release must reopen, pass integrity/foreign-key checks, and preserve its state digest after the upgrade.
+- A database left with synthetic WAL state after process termination must recover correctly under the replacement before a release is admitted.
+
+## Supply chain, security, and licensing
+
+### Minimum controls
+
+- Pin a specific binding release for each DJ Support release train.
+- Record hashes and PyPI provenance for every admitted wheel; do not rely on a project name and version alone.
+- Generate an SBOM or equivalent dependency inventory that names both the Python binding and embedded SQLite.
+- Monitor the official [SQLite news](https://sqlite.org/news.html), release notes, and selected binding release feed.
+- Treat a withdrawn upstream release as an immediate denylist/update event even when it fixes the target advisory.
+- Exercise the runtime identity assertion in shipped code and in release CI.
+- Keep the native dependency behind one deep adapter and forbid other modules from opening the Operational Store.
+- Add the selected binding and its notices to open-source credits.
+
+SQLite states that its source is in the [public domain](https://sqlite.org/copyright.html). APSW publishes its own [permissive copyright terms](https://rogerbinns.github.io/apsw/copyright.html), including notice and non-misrepresentation conditions. A DJ Support-owned fork of CPython binding code must also preserve the [PSF license](https://github.com/python/cpython/blob/main/LICENSE). Exact notice files should be taken from the actual selected artifacts at implementation time.
+
+### Candidate-specific risk
+
+APSW currently gives the best artifact coverage and freshness, but using it transfers trust to its build/release process. Its PyPI provenance is valuable evidence, not a substitute for DJ Support's runtime assertion or release tests. The binding update cadence, maintainer concentration, native compiler inputs, and wheel tags belong in the review checklist. DJ Support should never open the same Operational Store through both APSW and `sqlite3`.
+
+## Recommended issue and implementation split
+
+### R1 — Correct and adopt the qualification decision
+
+**Can land now, before #138 and #139.**
+
+- Correct the merged “3.51.3 or later” shorthand to deny withdrawn 3.52.0 and require a qualified build.
+- Amend ADR/issue #125 and #138 if APSW is selected: “qualified SQLite Python binding, no ORM” replaces the literal standard-library requirement.
+- Record the decision, fallback policy, open-source notices, and one-binding-only rule.
+- Keep JSON authoritative.
+
+### R2 — Runtime identity and fail-closed qualifier
+
+**Can land before #138; blocks any Runtime Assembly selection of SQLite.**
+
+- Add the reviewed qualification-manifest format.
+- Implement a pure classifier over binding identity, SQLite version, source ID, artifact/vendor provenance, platform, architecture, and withdrawn denylist.
+- Add path-free diagnostics and the negative rules for checkpoint scheduling and rollback fallback.
+- Make unknown builds unavailable rather than “warn and continue.”
+
+This issue can be developed test-first without opening a real user database.
+
+### R3 — Select and deliver the native runtime
+
+**Should land before the SQLite adapter portion of #138 to avoid churn; must land before #139.**
+
+- Select APSW 3.53.4.0 or reject it through the explicit ADR gate.
+- Add the dependency, adapter boundary, credits/notices, release qualification manifest, and clean-wheel matrix.
+- Prove binary installation and runtime identity on Python 3.10-3.14, macOS/Linux/Windows, for every architecture DJ Support claims.
+- Keep DJ Support's own domain and Transfer modules independent of the binding API.
+
+### #138 — Non-authoritative Preview
+
+The in-memory port, schema model, migration registry, serialization, privacy boundaries, and deterministic tests can proceed before R3. Runtime Assembly must remain on JSON. If the SQLite adapter proceeds before binding selection, constrain it to the shared Operational Store port and do not let standard-library-specific transaction behavior become the interface.
+
+### #139 — Concurrent authority
+
+#139 remains blocked until R1-R3 are merged and the selected release artifacts pass the full matrix. Its concurrency, stale-revision, WAL, process-crash, recovery, and cutover tests are the proof that the installed runtime meets the accepted contract.
+
+## Exact acceptance tests
+
+### Qualification classifier
+
+1. Reject an upstream 3.44.5 fixture.
+2. Accept only the manifest fixture for official backport 3.44.6 with its reviewed source lineage and artifact identity.
+3. Reject representative 3.45.1 and 3.49.1 fixtures.
+4. Reject an upstream 3.50.6 fixture.
+5. Accept only the manifest fixture for official backport 3.50.7 with its reviewed source lineage and artifact identity.
+6. Reject official 3.51.2.
+7. Accept official 3.51.3 only with source ID `2026-03-13 10:38:09 737ae4a34738ffa0c3ff7f9bb18df914dd1cad163f28fd6b6e114a344fe6d618`.
+8. Reject 3.52.0 unconditionally as withdrawn, even though its numeric version is greater than 3.51.3.
+9. Accept the selected 3.53.4 artifact only with source ID `2026-07-24 19:02:57 bf7c7f30031888f4e796e429ab3978879485813aaca6f641c7b33e4e09459bcc`, selected binding version, artifact digest/provenance, platform, and architecture.
+10. Reject the same approved version paired with an unknown source ID.
+11. Reject the same source ID paired with an unapproved binding artifact or vendor package revision.
+12. Reject a synthetic old-version “vendor backport” until its manifest entry includes an official vendor source/advisory and exact patch lineage; accept only the exact approved tuple.
+13. Reject any unlisted newer release until a reviewed manifest update admits it.
+14. Confirm `wal_autocheckpoint=0`, a maintenance-lease flag, or any checkpoint policy cannot change a rejected result.
+15. Confirm an unqualified runtime cannot be converted silently to rollback journal and returned as an Operational Store.
+
+### Runtime probe and privacy
+
+16. Probe the imported binding, not the system CLI, for SQLite version, source ID, compile options, wrapper, and distribution identity.
+17. Emit only public runtime facts and a stable reason code; assert diagnostics contain no home directory, database path, playlist name, credentials, or row values.
+18. Run the probe before file creation, schema migration, backup, or cutover.
+19. Confirm every production Operational Store open passes through the gate; direct binding imports outside the adapter fail the architecture check.
+20. Confirm the same database cannot be opened through both APSW and standard-library `sqlite3` in DJ Support.
+
+### Packaging and installation
+
+21. Build the DJ Support wheel, install it in a clean environment, and resolve the selected native binding as a binary wheel for each CPython 3.10, 3.11, 3.12, 3.13, and 3.14 job on Linux, macOS, and Windows.
+22. Cover each architecture publicly claimed by DJ Support; do not infer an architecture from another wheel tag.
+23. Fail a binary-only installation on an intentionally unsupported tag before first run, with an actionable message and no state mutation.
+24. Verify the installed wheel digest and published provenance against the qualification manifest.
+25. Import the installed binding and assert its runtime source ID and compile options, rather than trusting wheel filenames or dependency metadata.
+26. Inspect the built DJ Support wheel and source archive for credentials, user-derived data, absolute local paths, and unexpected native binaries.
+27. Assert package metadata names the selected dependency and that distributed credits/notices cover the binding and SQLite.
+
+### Upgrade and recovery
+
+28. Create a synthetic WAL store with the previous qualified release, close cleanly, upgrade in place, reopen, and assert `integrity_check`, `foreign_key_check`, schema version, and a canonical state digest.
+29. Terminate a writer after a committed synthetic transaction leaves WAL state, upgrade the binding, recover, and assert the committed state and integrity checks.
+30. Attempt an upgrade under an unqualified runtime and prove it stops before migration or authority changes.
+31. Upgrade from a qualified build to a numerically newer but unlisted/withdrawn fixture and prove the gate rejects it.
+32. Prove backup/restore and rollback preserve the qualified-runtime requirement and never reopen through a different binding implicitly.
+
+### #139 release matrix
+
+33. Run independent-process readers and writers against WAL on the installed release artifact, not just a source checkout.
+34. Exercise bounded busy waits, optimistic revision conflicts, checkpoint pressure, last-connection close, process termination, restart, and recovery.
+35. Assert committed-state digests, `integrity_check`, and `foreign_key_check` after every stress/crash scenario.
+36. Run those tests for every Python/OS combination claimed by the installer; a skipped native-runtime test fails release qualification.
+37. Keep JSON authoritative until the same artifact matrix passes cutover, rollback, and post-cutover restart tests.
+
+## What can land before #138/#139
+
+The safe pre-runtime slice is substantial:
+
+- this research and the 3.52.0 correction;
+- the ADR/issue wording decision;
+- the qualification manifest schema and pure classifier;
+- the public, path-free runtime probe;
+- unit fixtures for safe, affected, withdrawn, unknown, and vendor-backport identities;
+- CI inventory that reports the imported runtime on every matrix job;
+- binding selection and artifact/provenance evaluation;
+- in-memory Operational Store models, migration planning, serialization, and privacy tests; and
+- packaging/credits scaffolding that does not yet select SQLite in Runtime Assembly.
+
+What must **not** land as a production claim before R1-R3:
+
+- SQLite as Runtime Assembly authority;
+- #139's concurrent WAL authority;
+- a version-floor-only capability gate;
+- a checkpoint-lease “mitigation” on an affected runtime;
+- a silent rollback-journal fallback; or
+- documentation promising all Python 3.10-3.14/macOS/Linux/Windows installs work without a qualified native artifact.
+
+The dependency order is therefore:
+
+`R1 decision/correction -> R2 qualifier -> R3 delivered runtime -> #138 adapter/preview completion -> #139 concurrent authority and cutover`.
+
+## Sources
+
+### SQLite
+
+- [Write-Ahead Logging, including the 2026 WAL-reset advisory](https://sqlite.org/wal.html)
+- [SQLite 3.51.3 release](https://sqlite.org/releaselog/3_51_3.html)
+- [SQLite 3.52.0 withdrawn release](https://sqlite.org/releaselog/3_52_0.html)
+- [SQLite 3.53.4 release](https://sqlite.org/releaselog/3_53_4.html)
+- [SQLite news](https://sqlite.org/news.html)
+- [Compile-time source identity](https://sqlite.org/c3ref/c_source_id.html)
+- [Runtime library identity APIs](https://sqlite.org/c3ref/libversion.html)
+- [SQLite copyright](https://sqlite.org/copyright.html)
+
+### Python and CI
+
+- [Python sqlite3 runtime version documentation](https://docs.python.org/3/library/sqlite3.html#sqlite3.sqlite_version)
+- [CPython Unix build requirements](https://docs.python.org/3/using/configure.html#build-requirements)
+- [CPython tagged Windows and macOS build recipes](https://github.com/python/cpython)
+- [Python 3.10.11](https://www.python.org/downloads/release/python-31011/), [3.11.9](https://www.python.org/downloads/release/python-3119/), [3.12.10](https://www.python.org/downloads/release/python-31210/), [3.13.15](https://www.python.org/downloads/release/python-31315/), and [3.14.7](https://www.python.org/downloads/release/python-3147/) releases
+- [actions/setup-python advanced usage](https://github.com/actions/setup-python/blob/main/docs/advanced-usage.md)
+- [actions/python-versions Ubuntu builder](https://github.com/actions/python-versions/blob/main/builders/ubuntu-python-builder.psm1)
+- [CPython license](https://github.com/python/cpython/blob/main/LICENSE)
+
+### Packaging and candidate bindings
+
+- [PyPA binary-extension packaging guide](https://packaging.python.org/en/latest/guides/packaging-binary-extensions/)
+- [PyPA packaging flow](https://packaging.python.org/en/latest/flow/)
+- [PyPA tool recommendations](https://packaging.python.org/en/latest/guides/tool-recommendations/)
+- [pip secure installs](https://pip.pypa.io/en/stable/topics/secure-installs/)
+- [APSW versus pysqlite](https://rogerbinns.github.io/apsw/pysqlite.html)
+- [APSW 3.53.4.0 artifacts and provenance](https://pypi.org/project/apsw/3.53.4.0/)
+- [APSW copyright](https://rogerbinns.github.io/apsw/copyright.html)
+- [pysqlite3](https://pypi.org/project/pysqlite3/)
+- [pysqlite3-binary](https://pypi.org/project/pysqlite3-binary/)
+
+### Operating-system vendors
+
+- [Ubuntu USN-8480-1](https://ubuntu.com/security/notices/USN-8480-1)
+- [Ubuntu sqlite3 source-package changelog](https://launchpad.net/ubuntu/+source/sqlite3/+changelog)
+- [Debian SQLite security tracker](https://security-tracker.debian.org/tracker/source-package/sqlite3)


### PR DESCRIPTION
## Summary

- correct the merged WAL qualification shortcut so withdrawn SQLite 3.52.0 and unknown future builds fail closed
- document the exact runtime identity, CI, crash, provenance, packaging, and privacy evidence required before concurrent WAL authority
- evaluate cross-platform delivery options and recommend APSW 3.53.4.0 behind an explicit architecture decision gate
- audit the separate ADR-0005 draft against the merged Operational Store contracts without modifying its worktree

## Verification

- 761 full-suite tests passed
- 45 focused privacy, documentation, release-policy, and release-channel tests passed
- compilation passed
- release range check reports no distributable changes
- whitespace, relative-link, and local-path checks passed

## Boundaries

Research and contract correction only. No dependency, production adapter, authority switch, live service, owner-data access, tag, release, or package publication is included.

Supports #125, #138, #139, and #149.