### PR TITLE
docs: adopt the Operational Store architecture

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,30 @@ build/
 !tests/fixtures/*.xml
 *playlist-state*.json
 
+# Planned Operational Store, retained legacy authorities, and private derivatives
+operational-store.sqlite3
+operational-store.sqlite3-*
+operational-store.authority.json
+operational-stores/
+djsupport-snapshot-*.sqlite3
+djsupport-snapshot-*.sqlite3-*
+djsupport-backup-*.zip
+backup-manifest.json
+djsupport-migration-*
+djsupport-restore-*
+djsupport-rollback-*
+djsupport-operational-events*
+djsupport-analytics*
+djsupport-diagnostics*
+djsupport-query-export*
+matching-knowledge.json
+publication-manifests.json
+publication-manifests.transfers.json
+transfers.json
+legacy-migration.json
+foundation-migration.json
+config.json
+
 # Local matching evidence and exports (force-add only after explicit consent
 # and privacy review for contribution)
 matching-regression*.json

--- a/.release-notes/operational-store-architecture.md
+++ b/.release-notes/operational-store-architecture.md
@@ -1,0 +1,6 @@
+---
+bump: minor
+section: Changed
+---
+
+Document the accepted single Operational Store direction and extend repository privacy guardrails to the planned SQLite family, backups, staging, diagnostics, exports, and retained legacy state.

--- a/docs/adr/0005-use-one-local-transactional-operational-store.md
+++ b/docs/adr/0005-use-one-local-transactional-operational-store.md
@@ -1,0 +1,44 @@
+# Use one local transactional Operational Store
+
+DJ Support will replace its three authoritative JSON stores with one local
+SQLite Operational Store behind one deep internal interface, with SQLite and
+in-memory adapters. This concentrates transactions, optimistic revisions,
+schema migration, integrity checks, recovery, the Effect Journal, and derived
+local diagnostics while Transfer remains the sole policy authority;
+configuration and Spotipy-managed credentials remain outside the store.
+
+Before verified activation, JSON is the sole production authority. Activation
+atomically replaces one small selector after all clients quiesce; the selector
+names a stable generation identity, while the selected generation remains
+mutable operational state. After activation, SQLite is the sole production
+authority. Runtime dual-write, partial-client cutover, and silent JSON fallback
+are rejected. Retained JSON is inert, read-only input to explicit migration or
+rollback workflows.
+
+Migration is backup-first and Preview-first. Active SQLite backups use the
+binding's SQLite Online Backup API (`Connection.backup()` for the
+standard-library implementation) into a fresh closed and verified destination;
+a live database/WAL/SHM family is never copied or archived as a backup. Database
+transactions never span Spotify calls: the Effect Journal retains intent before
+the bounded effect and its observed result afterward so resume can reconcile
+rather than infer or repeat authority.
+
+Operational Events are compact, private, and append-only during ordinary
+recording. They and their rebuildable projections are never authority-bearing
+inputs, and explicit analytics-history deletion cannot alter authority-bearing
+state. Concurrent WAL authority fails closed unless the exact selected Python
+binding artifact and SQLite runtime pass the maintained qualification policy;
+withdrawn, affected, revoked, and unknown builds are unavailable.
+
+Python's standard `sqlite3` remains the current candidate and no ORM is used.
+[Issue #165](https://github.com/spontain112/djsupport/issues/165) is a required
+decision gate: production adapter work waits until it either confirms that
+binding or records the qualified replacement. Application-level encryption is
+deferred in favor of operating-system account and disk protections. The 0.7
+release line retains verified rollback through a documented window and never
+silently deletes legacy state.
+
+The maintained implementation contracts are the
+[concurrency and durability research](../research/2026-08-16-sqlite-concurrency-durability-contract.md)
+and the
+[migration, backup, and cutover research](../research/2026-08-16-sqlite-migration-backup-cutover-contract.md).

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -207,6 +207,34 @@ High-level tests and callers cross these interfaces rather than reaching into
 the implementation. See [`CONTRIBUTING.md`](../CONTRIBUTING.md) for the file map
 and engineering conventions.
 
+## Accepted production hardening direction
+
+[ADR-0005](adr/0005-use-one-local-transactional-operational-store.md) accepts
+one local transactional Operational Store for the 0.7 development line. It
+will replace the three current production persistence adapters with one deep
+internal interface implemented by SQLite in production and an in-memory
+adapter in behavior tests. Transfer remains the sole public policy authority;
+the Operational Store concentrates transactions, integrity, recovery, and
+derived diagnostics without creating a second policy interface.
+
+[Runtime Assembly](../djsupport/runtime.py) already concentrates production
+adapter selection for CLI, web, and Agent Clients. Delivery follows the
+[#138–#147 dependency map](research/2026-08-16-operational-store-issue-frontier.md#dependency-order-and-parallel-safe-lanes):
+JSON remains the sole production authority before the verified activation
+point, and every client resolves the selected SQLite generation afterward.
+There is no runtime dual-write, partial-client cutover, or silent JSON
+fallback. Retained JSON is inert input to explicit migration or rollback only.
+
+SQLite transactions do not include Spotify. Transfer retains explicit effect
+ordering and Spotify Account publishing guards, while the Effect Journal makes
+incomplete external work durable and reconcilable. The implementation details
+for connection behavior, runtime qualification, migration, backup, restore,
+and atomic activation live in the linked
+[concurrency](research/2026-08-16-sqlite-concurrency-durability-contract.md)
+and
+[cutover](research/2026-08-16-sqlite-migration-backup-cutover-contract.md)
+contracts rather than in this stable architecture overview.
+
 ## Audio capabilities are separate
 
 **Local Audio Identity** calculates an opt-in Chromaprint observation for audio

--- a/docs/storage.md
+++ b/docs/storage.md
@@ -152,6 +152,82 @@ or Transfer document. It does not make separate files one transaction. Transfer
 therefore orders Spotify effects, manifests, matching knowledge, and checkpoints
 explicitly and represents incomplete ordering as recoverable durable state.
 
+## Accepted 0.7 storage direction
+
+[ADR-0005](adr/0005-use-one-local-transactional-operational-store.md) accepts a
+single local SQLite Operational Store as the next production write model. The
+current files and schema table above remain the sole production authority until
+the verified activation in #146. After activation, every production client uses
+the SQLite generation selected by the authority pointer; there is no runtime
+dual-write, partial-client cutover, or silent JSON fallback. Retained JSON stays
+byte-identical and inert for the documented rollback window and is read only by
+explicit migration or rollback tooling.
+
+The Operational Store contains Matching Knowledge, Publication Manifests,
+Approval, Mirrors, Transfers, Batches, Qualification Drafts, checkpoints, the
+Effect Journal, and compact Operational Events. `config.json`, Spotify
+environment values, and Spotipy token storage remain outside the database.
+
+The migration contract is backup → Preview → import → exact verification →
+atomic authority switch. Verification compares canonical typed facts, not only
+counts: identities, relationships, explicit nulls, Source Occurrence order and
+duplicates, authority state, revisions, evidence, and incomplete effects. One
+small same-filesystem pointer selects a complete generation by stable identity.
+An inactive candidate is closed, validated, and inert; once selected, that
+generation remains the mutable sole authority. Runtime Assembly drains and
+reopens CLI, web, and Agent Client graphs around activation so an old generation
+cannot remain open.
+
+An active SQLite store is backed up through the selected binding's SQLite Online
+Backup API (`Connection.backup()` for the standard-library implementation) into
+a fresh private destination. The destination is normalized to a closed,
+self-contained rollback-journal image and passes identity, schema, integrity,
+foreign-key, and hash checks before publication. Production never copies or
+archives a live main/WAL/SHM file family. JSON-era byte backups and post-cutover
+SQLite logical snapshots are separate operations.
+
+SQLite uses WAL, short transactions, bounded lock waits, optimistic revisions,
+and fail-closed integrity behavior. Concurrent WAL authority is available only
+when the exact Python binding artifact and SQLite runtime are admitted by the
+maintained
+[runtime qualification contract](research/2026-08-16-sqlite-runtime-qualification-and-delivery.md);
+affected, withdrawn, revoked, and unknown builds fail before store mutation.
+No database transaction remains open across a Spotify request. Transfer first
+retains bounded effect intent, then performs the effect, then retains the
+observed result; resume reconciles incomplete Effect Journal entries and never
+infers Approval or repeats an uncertain authority write.
+
+Operational Events are append-only during ordinary recording and are never
+consumed as authority-bearing input. SQL views and diagnostics are rebuildable
+read-only projections. An explicit analytics-history deletion may remove events
+and projections without changing Transfers, Approval, Matching Knowledge,
+publication state, Effect Journal recovery facts, or any other authority-bearing
+row. Even privacy-redacted diagnostics remain private local user data.
+
+## Repository exclusion contract
+
+All Operational Store artifacts are private user data even when copied outside
+the application-data directory. `.gitignore` and repository privacy tests cover
+the authority pointer, active/staged/retained generation directory, database and
+WAL/SHM/rollback-journal family, logical snapshots, backup ZIPs, migration and
+restore staging/extraction, rollback copies, analytics, diagnostics, query
+exports, all supported legacy JSON authorities, configuration, and reports.
+
+Rules use DJ Support-specific filename patterns instead of blanket `*.db` or
+`*.sqlite*` exclusions. Tests create synthetic databases only in temporary
+storage; generated SQLite fixture images are never committed. Invented textual
+source fixtures remain reviewable when their format permits them. A generated
+export is not safe for Git merely because it is aggregate, JSON, CSV, or
+privacy-redacted. Package-manifest and built-archive rejection remain explicit
+delivery gates in #138, #145, and #147; ignore rules alone do not prove package
+privacy.
+
+Detailed connection, migration, backup, restore, crash, and platform contracts
+live in the
+[concurrency research](research/2026-08-16-sqlite-concurrency-durability-contract.md)
+and
+[migration/cutover research](research/2026-08-16-sqlite-migration-backup-cutover-contract.md).
+
 ## Migration ownership
 
 - Schema readers accept only documented older versions and fail closed when

--- a/tests/test_repository_privacy.py
+++ b/tests/test_repository_privacy.py
@@ -27,6 +27,34 @@ class TestRepositoryPrivacy:
             ".djsupport_config.json",
             "playlist-state.json",
             "festival-playlist-state.json",
+            "operational-store.sqlite3",
+            "operational-store.sqlite3-wal",
+            "operational-store.sqlite3-shm",
+            "operational-store.sqlite3-journal",
+            "operational-store.authority.json",
+            "operational-stores/01JTEST.sqlite3",
+            "operational-stores/01JTEST.sqlite3-wal",
+            "djsupport-snapshot-2026-08-16.sqlite3",
+            "djsupport-snapshot-2026-08-16.sqlite3-wal",
+            "djsupport-backup-2026-08-16.zip",
+            "backup-manifest.json",
+            "djsupport-migration-staging/candidate.sqlite3",
+            "djsupport-restore-staging/operational-store.sqlite3",
+            "djsupport-restore-extracted/backup-manifest.json",
+            "djsupport-rollback-before-apply.sqlite3",
+            "djsupport-operational-events.json",
+            "djsupport-analytics.json",
+            "djsupport-analytics.csv",
+            "djsupport-analytics.tsv",
+            "djsupport-diagnostics.json",
+            "djsupport-query-export.csv",
+            "matching-knowledge.json",
+            "publication-manifests.json",
+            "publication-manifests.transfers.json",
+            "transfers.json",
+            "legacy-migration.json",
+            "foundation-migration.json",
+            "config.json",
         ],
     )
     def test_user_derived_artifacts_are_ignored(self, path):
@@ -47,6 +75,29 @@ class TestRepositoryPrivacy:
         assert not (
             REPOSITORY_ROOT / "tests/fixtures/match_test_data.csv"
         ).exists()
+
+    def test_generated_sqlite_images_are_not_tracked(self):
+        result = subprocess.run(
+            ["git", "ls-files"],
+            cwd=REPOSITORY_ROOT,
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+        sqlite_artifact_suffixes = (
+            ".sqlite3",
+            ".sqlite3-wal",
+            ".sqlite3-shm",
+            ".sqlite3-journal",
+        )
+
+        tracked_artifacts = [
+            path
+            for path in result.stdout.splitlines()
+            if path.endswith(sqlite_artifact_suffixes)
+        ]
+
+        assert not tracked_artifacts, tracked_artifacts
 
     def test_obsolete_artifact_locations_are_ignored(self):
         for path in (


### PR DESCRIPTION
## Summary

- integrate ADR-0005 as one deep internal Operational Store interface while Transfer remains the sole policy authority
- preserve the exact before/after authority model: JSON before activation, SQLite after, with no dual-write, partial-client cutover, or silent fallback
- record stable-selector versus mutable-generation, Online Backup API, Effect Journal, deletable non-authority analytics, and fail-closed runtime qualification invariants
- extend repository privacy guardrails to canonical database/pointer/generation names, sidecars, backups, staging, diagnostics, exports, configuration, and all supported legacy JSON authorities
- retain current Runtime Assembly documentation and link mechanics to the merged research contracts

## Verification

- 790 full-suite tests passed
- 68 focused privacy, documentation, and release-record tests passed
- compilation passed
- source and wheel distributions built and their members/local-path content were inspected
- release range check confirms the included minor release record
- whitespace and relative-link checks passed

## Scope and ownership

Exactly six files. No schema, runtime adapter, dependency, authority switch, live service, owner-data access, tag, release, or package publication is included. The older dirty djsupport/operational-store-architecture worktree remains unchanged at 8959036569d26976ea2754c0c2f1aa0b588383ec.

Supports #125 and establishes the architecture route required before #138. The binding choice remains gated by #165.