### PR TITLE
Publish security and open-source attribution policies

### DIFF
--- a/.release-notes/open-source-acknowledgements.md
+++ b/.release-notes/open-source-acknowledgements.md
@@ -1,0 +1,7 @@
+---
+bump: patch
+section: Added
+---
+
+Credit the open-source runtime dependencies, optional web stack, development
+tooling, and independent local tools that make DJ Support possible.

--- a/.release-notes/security-policy.md
+++ b/.release-notes/security-policy.md
@@ -1,0 +1,7 @@
+---
+bump: patch
+section: Added
+---
+
+Document supported versions, private vulnerability reporting, sensitive-data
+handling, report scope, and safe coordinated disclosure.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -92,6 +92,10 @@ use the repository's [issue workflow](docs/agents/issue-tracker.md) and
 
 ## Protect local DJ data
 
+Report suspected vulnerabilities according to [`SECURITY.md`](SECURITY.md).
+Never put vulnerability details or sensitive evidence in a public issue or
+pull request.
+
 Keep user data out of Git. This includes credentials and tokens, source-library
 files and paths, playlist state and identifiers, Transfer reports and review
 CSVs, Approved Matches, Corrections, matching-knowledge files, and local
@@ -136,6 +140,14 @@ offline release gate.
 
 Follow the canonical [maintainer release checklist](docs/releasing.md) for the
 separate validation, candidate, final-release, and return-to-development gates.
+
+When adding, removing, or changing a direct runtime, optional, development, or
+build dependency—or a documented external tool—update
+[`THIRD_PARTY.md`](THIRD_PARTY.md) in the same pull request. Link the canonical
+upstream project, state how DJ Support uses it, and verify the SPDX license from
+upstream metadata. Do not copy a third-party license into DJ Support unless its
+distribution terms require that exact notice; package artifacts must retain all
+notices required for content they actually bundle.
 
 When a persistent schema changes, keep its reader compatible with documented
 older versions or provide an explicit migration. Add a synthetic backup/restore

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,5 +1,7 @@
 include CHANGELOG.md
 include CONTRIBUTING.md
+include SECURITY.md
+include THIRD_PARTY.md
 include docs/backup-and-restore.md
 include docs/releasing.md
 include docs/release-notes-0.4.0.md

--- a/README.md
+++ b/README.md
@@ -246,6 +246,11 @@ djsupport beatport --export-file beatport-export.json --dry-run
 djsupport beatport --export-file beatport-export.json
 ```
 
+DJ Support consumes only the exported file and does not distribute
+`beatport-pp-cli`. Its canonical upstream, license, and supported installation
+route remain unverified in [issue #133](https://github.com/spontain112/djsupport/issues/133);
+do not infer a distribution from this interoperability example.
+
 The file is validated before Spotify access. Its public source URL, ordered
 occurrences, repeated Beatport IDs, mixes, durations, ISRC, musical facts,
 release/label facts, dates, and tri-state availability are retained through the
@@ -417,8 +422,12 @@ is `$XDG_DATA_HOME/djsupport` or `~/.local/share/djsupport`.
 - [Release notes](docs/release-notes-0.5.0.md)
 - [Maintainer release checklist](docs/releasing.md)
 - [Changelog](CHANGELOG.md)
+- [Security policy](SECURITY.md)
+- [Open-source acknowledgements](THIRD_PARTY.md)
 - [Contributing](CONTRIBUTING.md)
 
-## License
+## License and acknowledgements
 
-MIT
+DJ Support is available under the [MIT License](LICENSE). It is built with
+open-source projects maintained by people and communities we gratefully credit
+in [Open-source acknowledgements](THIRD_PARTY.md).

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,66 @@
+# Security policy
+
+DJ Support handles Spotify credentials and private local music-library state.
+Please report suspected security vulnerabilities privately and share only the
+minimum evidence needed to reproduce the issue.
+
+## Supported versions
+
+| Version | Security support |
+| --- | --- |
+| Latest final GitHub Release | Supported |
+| Exact pre-release candidates | Best effort while under test |
+| Older releases and the moving `main` branch | Not supported |
+
+Upgrade to the [latest final release](https://github.com/spontain112/djsupport/releases/latest)
+before reporting an issue that may already be fixed.
+
+## Report a vulnerability
+
+Do not disclose vulnerability details in a public issue, discussion, pull
+request, log, or test fixture. In particular, never include credentials,
+tokens, real library or playlist data, local paths, reports, Corrections,
+Approved Matches, matching knowledge, or application-data archives.
+
+If available, use GitHub's
+[private security advisory form](https://github.com/spontain112/djsupport/security/advisories/new).
+If that form is unavailable, open a
+[public issue](https://github.com/spontain112/djsupport/issues/new) containing
+only a request for a private security contact. Do not describe the
+vulnerability in that issue.
+
+In the private report, include:
+
+- the affected release or exact commit;
+- the security impact and affected boundary;
+- minimal reproduction steps using synthetic data; and
+- any relevant environment details with secrets and local paths removed.
+
+This is a volunteer-maintained open-source project. Reports are handled on a
+best-effort basis; no response deadline, fix deadline, or bug bounty is
+promised. The maintainer may validate the report with synthetic data,
+coordinate a fix and advisory, and publish a patched release.
+
+## Scope
+
+Security reports include suspected credential or token exposure, unauthorized
+access to local files or private Transfer state, path traversal, authorization
+bypasses for Spotify mutation or Approval, unsafe handling of imported data or
+backups, unintended exposure by the loopback web adapter, and exploitable
+dependency or supply-chain behavior.
+
+Ordinary matching errors, feature requests, provider outages, and support
+questions belong in public issues unless they create a confidentiality,
+integrity, or authorization failure.
+
+## Safe research and coordinated disclosure
+
+Use your own accounts and synthetic data. Do not access another person's data,
+mutate playlists without authorization, perform denial-of-service testing, or
+violate a provider's terms. Give the maintainer a reasonable opportunity to
+investigate and release a fix before public disclosure.
+
+If the root cause is in an upstream project, report it through that project's
+security process. Also notify DJ Support privately when its integration is
+affected. See [Open-source acknowledgements](THIRD_PARTY.md) for the upstream
+projects used directly by DJ Support.

--- a/THIRD_PARTY.md
+++ b/THIRD_PARTY.md
@@ -1,0 +1,72 @@
+# Open-source acknowledgements
+
+DJ Support is possible because people maintain and share excellent open-source
+software. Thank you to every author, maintainer, reviewer, documentarian, and
+contributor behind the projects below.
+
+This is an acknowledgement and navigation index, not a replacement for the
+projects' license texts. DJ Support does not vendor these projects. Python
+package installers resolve them separately under their own licenses and may
+also install transitive dependencies; inspect the installed distributions for
+the exact version and complete license material in a particular environment.
+
+## Runtime dependencies
+
+| Project | How DJ Support uses it | License |
+| --- | --- | --- |
+| [Spotipy](https://github.com/spotipy-dev/spotipy) | Spotify authentication and Web API access | MIT |
+| [Click](https://github.com/pallets/click) | Command-line interface | BSD-3-Clause |
+| [python-dotenv](https://github.com/theskumar/python-dotenv) | Optional environment-file loading | BSD-3-Clause |
+| [RapidFuzz](https://github.com/rapidfuzz/RapidFuzz) | Source-to-Spotify similarity scoring | MIT |
+| [Requests](https://github.com/psf/requests) | HTTP access for supported Beatport sources | Apache-2.0 |
+| [jsonschema](https://github.com/python-jsonschema/jsonschema) | Strict Beatport export contract validation | MIT |
+
+## Optional local web dependencies
+
+| Project | How DJ Support uses it | License |
+| --- | --- | --- |
+| [FastAPI](https://github.com/fastapi/fastapi) | Local web adapter | MIT |
+| [Uvicorn](https://github.com/Kludex/uvicorn) | Local ASGI server | BSD-3-Clause |
+
+## Development and build tools
+
+| Project | How DJ Support uses it | License |
+| --- | --- | --- |
+| [Python](https://github.com/python/cpython) | Language and standard library | PSF-2.0 |
+| [Git](https://github.com/git/git) | Source history and contribution workflow | GPL-2.0-only |
+| [setuptools](https://github.com/pypa/setuptools) | Package build backend | MIT |
+| [wheel](https://github.com/pypa/wheel) | Wheel build format tooling | MIT |
+| [build](https://github.com/pypa/build) | Isolated source and wheel builds | MIT |
+| [pytest](https://github.com/pytest-dev/pytest) | Offline behavior tests | MIT |
+| [pytest-cov](https://github.com/pytest-dev/pytest-cov) | Test coverage | MIT |
+| [HTTPX](https://github.com/encode/httpx) | Local web-adapter tests | BSD-3-Clause |
+| [PyYAML](https://github.com/yaml/pyyaml) | Release-workflow validation tests | MIT |
+| [Tomli](https://github.com/hukkin/tomli) | TOML parsing on Python 3.10 | MIT |
+
+## Continuous integration tools
+
+| Project | How DJ Support uses it | License |
+| --- | --- | --- |
+| [checkout](https://github.com/actions/checkout) | GitHub Actions source checkout | MIT |
+| [setup-python](https://github.com/actions/setup-python) | GitHub Actions Python toolchains | MIT |
+
+## Independent external tools
+
+These tools are not Python dependencies and are not bundled with DJ Support.
+Users install or run them separately under their own licenses.
+
+| Project | How DJ Support interoperates with it | License |
+| --- | --- | --- |
+| [Chromaprint](https://github.com/acoustid/chromaprint) / `fpcalc` | Optional, local-only audio fingerprint calculation | LGPL-2.1-only |
+| `beatport-pp-cli` | Optional producer of the occurrence-safe Beatport V2 JSON consumed by DJ Support | Unverified; do not infer an upstream or installation route until [issue #133](https://github.com/spontain112/djsupport/issues/133) is resolved |
+
+Spotify, Beatport, and Rekordbox are third-party products and trademarks, not
+open-source dependencies of DJ Support. Interoperability does not imply their
+endorsement of this project.
+
+## Maintenance rule
+
+Any change to direct dependencies, build tools, or documented external-tool
+interoperability must update this file in the same pull request. Release
+validation checks that the direct dependency groups in `pyproject.toml` remain
+represented here and that this acknowledgement ships in the source archive.

--- a/tests/test_release_channels.py
+++ b/tests/test_release_channels.py
@@ -14,6 +14,42 @@ except ModuleNotFoundError:  # pragma: no cover - exercised on Python 3.10
 REPOSITORY_ROOT = Path(__file__).parents[1]
 
 
+def test_direct_tools_are_credited_and_source_archive_includes_acknowledgements():
+    with (REPOSITORY_ROOT / "pyproject.toml").open("rb") as pyproject_file:
+        metadata = tomllib.load(pyproject_file)
+    project = metadata["project"]
+
+    credits = (REPOSITORY_ROOT / "THIRD_PARTY.md").read_text()
+    declared = [
+        *project["dependencies"],
+        *project["optional-dependencies"]["web"],
+        *project["optional-dependencies"]["dev"],
+        *metadata["build-system"]["requires"],
+    ]
+    package_names = {
+        re.split(r"[<>=!~;\[]", requirement, maxsplit=1)[0].strip().lower()
+        for requirement in declared
+    }
+
+    assert not [name for name in package_names if name not in credits.lower()]
+    assert "Chromaprint" in credits and "beatport-pp-cli" in credits
+    assert "issue #133" in credits and "Unverified" in credits
+    assert "include THIRD_PARTY.md" in (REPOSITORY_ROOT / "MANIFEST.in").read_text()
+    assert (REPOSITORY_ROOT / "THIRD_PARTY.md").is_file()
+
+
+def test_security_policy_uses_private_reporting_and_is_in_source_archive():
+    policy = (REPOSITORY_ROOT / "SECURITY.md").read_text()
+    normalized_policy = " ".join(policy.split())
+    manifest = (REPOSITORY_ROOT / "MANIFEST.in").read_text()
+
+    assert "security/advisories/new" in policy
+    assert "Do not describe the vulnerability" in normalized_policy
+    assert "synthetic data" in normalized_policy
+    assert "no response deadline" in normalized_policy
+    assert "include SECURITY.md" in manifest
+
+
 def test_source_checkout_uses_a_supported_release_version():
     with (REPOSITORY_ROOT / "pyproject.toml").open("rb") as pyproject_file:
         project = tomllib.load(pyproject_file)["project"]


### PR DESCRIPTION
## Summary

- publish a public vulnerability-reporting and coordinated-disclosure policy;
- credit every direct runtime, optional web, development, build, and CI tool;
- ship both policy files in the source distribution and contract that behavior;
- state explicitly that DJ Support does not distribute the external Beatport
  CLI and that its upstream/license remain unverified in #133.

The dependency project links and license identifiers were checked against
upstream repository metadata. This replay also updates Uvicorn to its current
canonical repository owner and records Chromaprint as `LGPL-2.1-only` from its
upstream license file.

Closes #169.

## Verification

- `python3 -m pytest tests/test_release_channels.py tests/test_repository_privacy.py` — 55 passed
- `python3 -m pytest` — 792 passed
- `python3 -m compileall -q djsupport tests`
- `python3 scripts/release_records.py check origin/main HEAD`
- `python3 -m build`
- source archive contains `SECURITY.md` and `THIRD_PARTY.md`
- cached scope and whitespace review clean

No live provider calls, user data, runtime changes, tag, release, or package
publication are included.
