### PR TITLE
ci: add pinned CodeQL scanning

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,49 @@
+name: CodeQL
+
+'on':
+  pull_request:
+    branches:
+      - main
+  push:
+    branches:
+      - main
+  schedule:
+    - cron: "17 3 * * 1"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  analyze:
+    name: CodeQL ${{ matrix.language }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      actions: read
+      contents: read
+      packages: read
+      security-events: write
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - language: python
+            build-mode: none
+          - language: actions
+            build-mode: none
+    steps:
+      - name: Check out source
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v4.37.7
+        with:
+          languages: ${{ matrix.language }}
+          build-mode: ${{ matrix.build-mode }}
+      - name: Analyze
+        uses: github/codeql-action/analyze@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v4.37.7

--- a/.release-notes/codeql-scanning.md
+++ b/.release-notes/codeql-scanning.md
@@ -1,0 +1,7 @@
+---
+bump: patch
+section: Added
+---
+
+Scan Python and GitHub Actions changes with pinned, least-privilege CodeQL
+analysis on pull requests, main, and a weekly schedule.

--- a/THIRD_PARTY.md
+++ b/THIRD_PARTY.md
@@ -49,6 +49,7 @@ the exact version and complete license material in a particular environment.
 | --- | --- | --- |
 | [checkout](https://github.com/actions/checkout) | GitHub Actions source checkout | MIT |
 | [setup-python](https://github.com/actions/setup-python) | GitHub Actions Python toolchains | MIT |
+| [CodeQL](https://github.com/github/codeql-action) | Static security analysis for Python and GitHub Actions workflows | MIT |
 
 ## Independent external tools
 

--- a/tests/test_release_channels.py
+++ b/tests/test_release_channels.py
@@ -33,6 +33,7 @@ def test_direct_tools_are_credited_and_source_archive_includes_acknowledgements(
 
     assert not [name for name in package_names if name not in credits.lower()]
     assert "Chromaprint" in credits and "beatport-pp-cli" in credits
+    assert "[CodeQL](https://github.com/github/codeql-action)" in credits
     assert "issue #133" in credits and "Unverified" in credits
     assert "include THIRD_PARTY.md" in (REPOSITORY_ROOT / "MANIFEST.in").read_text()
     assert (REPOSITORY_ROOT / "THIRD_PARTY.md").is_file()
@@ -181,6 +182,113 @@ def test_ci_is_a_least_privilege_offline_release_gate():
     for marker in forbidden:
         if marker in lowered_workflow:
             errors.append(f"forbidden workflow capability: {marker}")
+
+    assert not errors, "\n".join(errors)
+
+
+def test_codeql_scans_python_and_workflows_with_least_privilege():
+    workflow_path = REPOSITORY_ROOT / ".github" / "workflows" / "codeql.yml"
+    workflow_text = workflow_path.read_text()
+    workflow = yaml.safe_load(workflow_text)
+    errors = []
+
+    triggers = workflow.get("on", {})
+    if set(triggers) != {"push", "pull_request", "schedule"}:
+        errors.append("CodeQL must run only for main changes and its schedule")
+    if triggers.get("push", {}).get("branches") != ["main"]:
+        errors.append("CodeQL push scans must be limited to main")
+    if triggers.get("pull_request", {}).get("branches") != ["main"]:
+        errors.append("CodeQL pull-request scans must target main")
+    schedules = triggers.get("schedule", [])
+    if len(schedules) != 1 or set(schedules[0]) != {"cron"}:
+        errors.append("CodeQL must define exactly one weekly schedule")
+
+    if workflow.get("permissions") != {"contents": "read"}:
+        errors.append("CodeQL workflow permissions must default to contents: read")
+    concurrency = workflow.get("concurrency", {})
+    if concurrency.get("cancel-in-progress") is not True:
+        errors.append("superseded CodeQL runs must be cancelled")
+    if "github.ref" not in concurrency.get("group", ""):
+        errors.append("CodeQL concurrency must be scoped to the ref")
+
+    jobs = workflow.get("jobs", {})
+    if set(jobs) != {"analyze"}:
+        errors.append("CodeQL must expose one analysis job")
+    analyze = jobs.get("analyze", {})
+    if analyze.get("permissions") != {
+        "actions": "read",
+        "contents": "read",
+        "packages": "read",
+        "security-events": "write",
+    }:
+        errors.append("CodeQL analysis permissions must be the reviewed minimum")
+    if analyze.get("timeout-minutes") != 30:
+        errors.append("CodeQL analysis must have a bounded timeout")
+
+    expected_matrix = [
+        {"language": "python", "build-mode": "none"},
+        {"language": "actions", "build-mode": "none"},
+    ]
+    strategy = analyze.get("strategy", {})
+    if strategy.get("fail-fast") is not False:
+        errors.append("one failed language must not hide the other analysis")
+    if strategy.get("matrix", {}).get("include") != expected_matrix:
+        errors.append("CodeQL must explicitly analyze Python and Actions")
+
+    steps = analyze.get("steps", [])
+    uses = [step.get("uses", "") for step in steps]
+    action_pin = re.compile(
+        r"^(?:actions/checkout|github/codeql-action/(?:init|analyze))@[0-9a-f]{40}$"
+    )
+    if len(uses) != 3 or any(action_pin.fullmatch(action) is None for action in uses):
+        errors.append("CodeQL actions must be canonical and pinned to full SHAs")
+    codeql_pins = {
+        action.rsplit("@", maxsplit=1)[1]
+        for action in uses
+        if action.startswith("github/codeql-action/")
+    }
+    if len(codeql_pins) != 1:
+        errors.append("CodeQL initialization and analysis must use one reviewed pin")
+    checkout = next(
+        (step for step in steps if step.get("uses", "").startswith("actions/checkout@")),
+        {},
+    )
+    if checkout.get("with", {}).get("persist-credentials") is not False:
+        errors.append("CodeQL checkout credentials must not persist")
+    initialize = next(
+        (
+            step
+            for step in steps
+            if step.get("uses", "").startswith("github/codeql-action/init@")
+        ),
+        {},
+    )
+    if initialize.get("with") != {
+        "languages": "${{ matrix.language }}",
+        "build-mode": "${{ matrix.build-mode }}",
+    }:
+        errors.append("CodeQL must initialize only the explicit matrix language")
+
+    forbidden = (
+        "pull_request_target",
+        "workflow_dispatch",
+        "secrets.",
+        "continue-on-error",
+        "permissions: write",
+        "spotify",
+        "beatport",
+        "git tag",
+        "gh release",
+        "twine",
+        "pypi",
+        "upload-sarif",
+    )
+    normalized = workflow_text.casefold()
+    for marker in forbidden:
+        if marker in normalized:
+            errors.append(f"forbidden CodeQL capability: {marker}")
+    if any("run" in step for step in steps):
+        errors.append("CodeQL setup must not execute arbitrary repository commands")
 
     assert not errors, "\n".join(errors)
 

--- a/tests/test_release_channels.py
+++ b/tests/test_release_channels.py
@@ -199,9 +199,8 @@ def test_codeql_scans_python_and_workflows_with_least_privilege():
         errors.append("CodeQL push scans must be limited to main")
     if triggers.get("pull_request", {}).get("branches") != ["main"]:
         errors.append("CodeQL pull-request scans must target main")
-    schedules = triggers.get("schedule", [])
-    if len(schedules) != 1 or set(schedules[0]) != {"cron"}:
-        errors.append("CodeQL must define exactly one weekly schedule")
+    if triggers.get("schedule") != [{"cron": "17 3 * * 1"}]:
+        errors.append("CodeQL must define the reviewed weekly UTC schedule")
 
     if workflow.get("permissions") != {"contents": "read"}:
         errors.append("CodeQL workflow permissions must default to contents: read")
@@ -237,10 +236,18 @@ def test_codeql_scans_python_and_workflows_with_least_privilege():
 
     steps = analyze.get("steps", [])
     uses = [step.get("uses", "") for step in steps]
+    action_roles = [action.rsplit("@", maxsplit=1)[0] for action in uses]
+    expected_action_roles = [
+        "actions/checkout",
+        "github/codeql-action/init",
+        "github/codeql-action/analyze",
+    ]
     action_pin = re.compile(
         r"^(?:actions/checkout|github/codeql-action/(?:init|analyze))@[0-9a-f]{40}$"
     )
-    if len(uses) != 3 or any(action_pin.fullmatch(action) is None for action in uses):
+    if action_roles != expected_action_roles:
+        errors.append("CodeQL must check out, initialize, and analyze in that order")
+    if any(action_pin.fullmatch(action) is None for action in uses):
         errors.append("CodeQL actions must be canonical and pinned to full SHAs")
     codeql_pins = {
         action.rsplit("@", maxsplit=1)[1]
@@ -272,7 +279,6 @@ def test_codeql_scans_python_and_workflows_with_least_privilege():
     forbidden = (
         "pull_request_target",
         "workflow_dispatch",
-        "secrets.",
         "continue-on-error",
         "permissions: write",
         "spotify",
@@ -287,6 +293,8 @@ def test_codeql_scans_python_and_workflows_with_least_privilege():
     for marker in forbidden:
         if marker in normalized:
             errors.append(f"forbidden CodeQL capability: {marker}")
+    if re.search(r"\bsecrets\s*(?:\.|\[)", normalized):
+        errors.append("forbidden CodeQL capability: repository secrets")
     if any("run" in step for step in steps):
         errors.append("CodeQL setup must not execute arbitrary repository commands")
 


### PR DESCRIPTION
Closes #172.

## Scope

- add pinned CodeQL analysis for Python and GitHub Actions
- run on pull requests to `main`, pushes to `main`, and one weekly UTC schedule
- keep workflow defaults read-only and grant only the analysis job's reviewed permissions
- credit CodeQL and add the required release-note record
- enforce the contract with the existing offline release-channel test seam

## Verification

- `python3 -m pytest -q tests/test_release_channels.py` — 9 passed
- `python3 -m pytest -q` — 793 passed
- `python3 -m compileall -q djsupport tests`
- `git diff --check origin/main...HEAD`

## Review

- Standards: no hard violations; explicit workflow-specific contracts retained for audit readability
- Spec: weekly cadence, exact checkout/init/analyze roles, and both dot/bracket secret-access forms are enforced

No live provider access, credentials, package publication, tag, release, or user-derived data is in scope.
