### PR TITLE
fix: classify public root release artifacts

### DIFF
--- a/scripts/release_records.py
+++ b/scripts/release_records.py
@@ -17,6 +17,20 @@ NEXT_VERSION = RECORDS / "next-version"
 ALLOWED_BUMPS = {"patch": 0, "minor": 1, "major": 2}
 ALLOWED_SECTIONS = ("Added", "Changed", "Deprecated", "Removed", "Fixed", "Security")
 VERSION_PATTERN = re.compile(r'(?m)^version = "([^"]+)"$')
+PUBLIC_ROOT_ARTIFACTS = frozenset(
+    {
+        ".env.example",
+        "CHANGELOG.md",
+        "CONTEXT.md",
+        "CONTRIBUTING.md",
+        "LICENSE",
+        "MANIFEST.in",
+        "README.md",
+        "SECURITY.md",
+        "THIRD_PARTY.md",
+        "pyproject.toml",
+    }
+)
 
 
 @dataclass(frozen=True)
@@ -65,10 +79,14 @@ def load_records() -> list[ReleaseRecord]:
 
 
 def _is_distributable(path: str) -> bool:
-    return path.startswith("djsupport/") or path in {"README.md", "pyproject.toml"} or (
-        path.startswith("docs/")
-        and path != "docs/releasing.md"
-        and not path.startswith("docs/research/")
+    return (
+        path.startswith("djsupport/")
+        or path in PUBLIC_ROOT_ARTIFACTS
+        or (
+            path.startswith("docs/")
+            and path != "docs/releasing.md"
+            and not path.startswith("docs/research/")
+        )
     )
 
 

--- a/tests/test_release_records.py
+++ b/tests/test_release_records.py
@@ -14,6 +14,26 @@ sys.modules[SPEC.name] = release_records
 SPEC.loader.exec_module(release_records)
 
 
+def test_public_root_artifacts_are_distributable():
+    public_root_artifacts = (
+        ".env.example",
+        "CHANGELOG.md",
+        "CONTEXT.md",
+        "CONTRIBUTING.md",
+        "LICENSE",
+        "MANIFEST.in",
+        "README.md",
+        "SECURITY.md",
+        "THIRD_PARTY.md",
+        "pyproject.toml",
+    )
+
+    assert all(
+        release_records._is_distributable(path)
+        for path in public_root_artifacts
+    )
+
+
 def test_distributable_paths_exclude_internal_research_only():
     distributable = (
         "djsupport/transfer.py",
@@ -32,6 +52,18 @@ def test_distributable_paths_exclude_internal_research_only():
 
     assert all(release_records._is_distributable(path) for path in distributable)
     assert not any(release_records._is_distributable(path) for path in internal)
+
+
+def test_agent_only_repository_instructions_are_not_distributable():
+    agent_only = (
+        "AGENTS.md",
+        "CLAUDE.md",
+        ".claude/settings.local.json",
+    )
+
+    assert not any(
+        release_records._is_distributable(path) for path in agent_only
+    )
 
 
 def test_release_record_parser_requires_bump_section_and_summary(tmp_path):


### PR DESCRIPTION
Closes #174.

## Scope

- define one immutable `PUBLIC_ROOT_ARTIFACTS` policy with the ten issue-approved paths
- preserve the existing package and public-documentation branches
- keep research, maintainer release guidance, tests, workflows, and agent-only instructions exempt
- add independent positive and negative contract tests

## TDD evidence

- red: `test_public_root_artifacts_are_distributable` failed against the baseline
- green: `python3 -m pytest -q tests/test_release_records.py` — 8 passed
- full offline suite — 795 passed
- `python3 -m compileall -q djsupport tests scripts`
- `git diff --check origin/main...HEAD`
- `python3 scripts/release_records.py check origin/main HEAD` — `No distributable changes.`

## Review

- Standards: zero documented violations and zero smell findings
- Spec: zero findings; every #174 path, preservation rule, exclusion, and boundary is covered

No release record is added because the diff changes only internal tooling and tests. No manifest, package, version, workflow, tag, release, publication, live provider, or user-data behavior is in scope.
