### PR TITLE
docs: adopt APSW binding decision (#165)

### DIFF
--- a/.release-notes/apsw-operational-store-binding.md
+++ b/.release-notes/apsw-operational-store-binding.md
@@ -1,0 +1,8 @@
+---
+bump: patch
+section: Changed
+---
+
+Clarify the documented 0.7 storage plan: APSW 3.53.4.0 will be the sole
+production SQLite binding, and unsupported runtime, artifact, or platform
+combinations will fail closed instead of silently falling back.

--- a/docs/adr/0005-use-one-local-transactional-operational-store.md
+++ b/docs/adr/0005-use-one-local-transactional-operational-store.md
@@ -16,8 +16,7 @@ are rejected. Retained JSON is inert, read-only input to explicit migration or
 rollback workflows.
 
 Migration is backup-first and Preview-first. Active SQLite backups use the
-binding's SQLite Online Backup API (`Connection.backup()` for the
-standard-library implementation) into a fresh closed and verified destination;
+binding's SQLite Online Backup API into a fresh closed and verified destination;
 a live database/WAL/SHM family is never copied or archived as a backup. Database
 transactions never span Spotify calls: the Effect Journal retains intent before
 the bounded effect and its observed result afterward so resume can reconcile
@@ -30,15 +29,25 @@ state. Concurrent WAL authority fails closed unless the exact selected Python
 binding artifact and SQLite runtime pass the maintained qualification policy;
 withdrawn, affected, revoked, and unknown builds are unavailable.
 
-Python's standard `sqlite3` remains the current candidate and no ORM is used.
-[Issue #165](https://github.com/spontain112/djsupport/issues/165) is a required
-decision gate: production adapter work waits until it either confirms that
-binding or records the qualified replacement. Application-level encryption is
-deferred in favor of operating-system account and disk protections. The 0.7
-release line retains verified rollback through a documented window and never
-silently deletes legacy state.
+APSW 3.53.4.0 is the sole production SQLite Python binding, remains private to
+the Operational Store adapter, and is used without an ORM. Python's standard
+`sqlite3` never opens the production Operational Store. The accepted decision
+is recorded in
+[issue #165](https://github.com/spontain112/djsupport/issues/165); #166 owns the
+versioned fail-closed runtime qualification and revocation policy, while #167
+owns pinned artifact delivery, native platform evidence, dependency provenance,
+open-source credits and notices, and update or withdrawal monitoring. Only
+Python 3.10–3.14 installations on macOS, Linux, and Windows whose exact
+OS/architecture/artifact combinations are proved by #167 are supported. There
+is no dual-binding, rollback-journal, checkpoint-scheduling bypass,
+user-configurable override, warning-only path, or JSON fallback.
+Application-level encryption is deferred in favor of operating-system account
+and disk protections. The 0.7 release line retains verified rollback through a
+documented window and never silently deletes legacy state.
 
 The maintained implementation contracts are the
+[APSW integration research](../research/2026-08-16-apsw-operational-store-integration-contract.md),
+the
 [concurrency and durability research](../research/2026-08-16-sqlite-concurrency-durability-contract.md)
 and the
 [migration, backup, and cutover research](../research/2026-08-16-sqlite-migration-backup-cutover-contract.md).


### PR DESCRIPTION
## What changed

- record APSW 3.53.4.0 as the sole production SQLite Python binding behind the private Operational Store adapter
- define the Python 3.10–3.14 and macOS/Linux/Windows target as limited to exact OS, architecture, runtime, and artifact combinations proved by #166 and #167
- preserve the no-ORM boundary and explicitly reject standard-library `sqlite3`, dual binding, rollback-journal fallback, checkpoint bypass, user overrides, warning-only behavior, and JSON fallback
- add the required consumer-facing release-note record

## Why

JC accepted the recommendation in #165. This makes the canonical ADR match that owner decision before runtime qualification work begins.

## Boundaries

This change does not add APSW, create or migrate a database, open an Operational Store, switch production authority, access owner data, call a live provider, create a tag or GitHub Release, or publish a package.

## Checks

- `python3 -m pytest tests/test_release_records.py tests/test_repository_privacy.py -q` — 55 passed
- `python3 -m pytest -q` — full 795-test suite passed
- `python3 scripts/release_records.py check origin/main HEAD` — distributable change includes a release record
- Standards review — no findings
- Spec review — no findings
