### PR TITLE
feat: qualify SQLite runtimes fail closed (#166)

### DIFF
--- a/.release-notes/sqlite-runtime-qualification.md
+++ b/.release-notes/sqlite-runtime-qualification.md
@@ -1,0 +1,8 @@
+---
+bump: patch
+section: Added
+---
+
+Add the fail-closed runtime qualification foundation for the planned 0.7
+Operational Store, with path-free diagnostics and no admitted native artifact
+until its exact runtime and provenance evidence is reviewed.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,6 +28,7 @@ every flag.
 djsupport/
   transfer.py    Durable Transfer policy, planning, checkpoints, and publication
   runtime.py     Private production assembly for Transfer client adapters
+  operational_store/ Fail-closed selected-binding qualification before store access
   agent.py       Versioned, harness-neutral Transfer contract rendering
   readiness.py   Shared presence-only readiness for CLI and web adapters
   cli.py         Thin Click command-line adapter

--- a/djsupport/contracts/sqlite-runtime-qualification.v1.json
+++ b/djsupport/contracts/sqlite-runtime-qualification.v1.json
@@ -1,0 +1,22 @@
+{
+  "schema_version": 1,
+  "policy_id": "djsupport/sqlite-runtime-qualification/1",
+  "selected_binding": {
+    "distribution": "apsw",
+    "version": "3.53.4.0"
+  },
+  "withdrawn_sqlite_versions": [
+    "3.52.0"
+  ],
+  "affected_sqlite_ranges": [
+    {
+      "minimum": "3.7.0",
+      "maximum": "3.51.2",
+      "exceptions": [
+        "3.44.6",
+        "3.50.7"
+      ]
+    }
+  ],
+  "entries": []
+}

--- a/djsupport/contracts/sqlite-runtime-qualification.v1.schema.json
+++ b/djsupport/contracts/sqlite-runtime-qualification.v1.schema.json
@@ -1,0 +1,368 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/spontain112/djsupport/sqlite-runtime-qualification.v1.schema.json",
+  "title": "DJ Support SQLite runtime qualification manifest",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "policy_id",
+    "selected_binding",
+    "withdrawn_sqlite_versions",
+    "affected_sqlite_ranges",
+    "entries"
+  ],
+  "properties": {
+    "schema_version": {"const": 1},
+    "policy_id": {
+      "type": "string",
+      "pattern": "^[A-Za-z0-9._/-]+$"
+    },
+    "selected_binding": {
+      "$ref": "#/$defs/selected_binding"
+    },
+    "withdrawn_sqlite_versions": {
+      "type": "array",
+      "uniqueItems": true,
+      "items": {"$ref": "#/$defs/sqlite_version"}
+    },
+    "affected_sqlite_ranges": {
+      "type": "array",
+      "items": {"$ref": "#/$defs/affected_range"}
+    },
+    "entries": {
+      "type": "array",
+      "items": {"$ref": "#/$defs/entry"}
+    }
+  },
+  "$defs": {
+    "sha256": {
+      "type": "string",
+      "pattern": "^[0-9a-f]{64}$"
+    },
+    "safe_identity": {
+      "type": "string",
+      "maxLength": 256,
+      "pattern": "^[A-Za-z0-9][A-Za-z0-9._+-]*(/[A-Za-z0-9][A-Za-z0-9._+-]*)*$"
+    },
+    "https_url": {
+      "type": "string",
+      "maxLength": 2048,
+      "pattern": "^https://[^\\s]+$"
+    },
+    "binding_version": {
+      "type": "string",
+      "pattern": "^[0-9]+(?:\\.[0-9]+){3}$"
+    },
+    "utc_timestamp": {
+      "type": "string",
+      "format": "date-time",
+      "pattern": "Z$"
+    },
+    "sqlite_version": {
+      "type": "string",
+      "pattern": "^[0-9]+\\.[0-9]+\\.[0-9]+$"
+    },
+    "selected_binding": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["distribution", "version"],
+      "properties": {
+        "distribution": {"type": "string", "minLength": 1},
+        "version": {"$ref": "#/$defs/binding_version"}
+      }
+    },
+    "affected_range": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["minimum", "maximum", "exceptions"],
+      "properties": {
+        "minimum": {"$ref": "#/$defs/sqlite_version"},
+        "maximum": {"$ref": "#/$defs/sqlite_version"},
+        "exceptions": {
+          "type": "array",
+          "uniqueItems": true,
+          "items": {"$ref": "#/$defs/sqlite_version"}
+        }
+      }
+    },
+    "entry": {
+      "type": "object",
+      "additionalProperties": false,
+      "allOf": [
+        {
+          "if": {
+            "properties": {"status": {"const": "revoked"}},
+            "required": ["status"]
+          },
+          "then": {
+            "properties": {
+              "revoked_at_utc": {"$ref": "#/$defs/utc_timestamp"},
+              "status_evidence_id": {
+                "$ref": "#/$defs/safe_identity"
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {"status": {"const": "active"}},
+            "required": ["status"]
+          },
+          "then": {
+            "properties": {
+              "revoked_at_utc": {"type": "null"},
+              "status_evidence_id": {"type": "null"}
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {"status": {"const": "superseded"}},
+            "required": ["status"]
+          },
+          "then": {
+            "properties": {
+              "status_evidence_id": {
+                "$ref": "#/$defs/safe_identity"
+              }
+            }
+          }
+        }
+      ],
+      "required": [
+        "evidence_id",
+        "classification",
+        "status",
+        "selectors",
+        "artifact",
+        "activated_at_utc",
+        "revoked_at_utc",
+        "supersedes_evidence_id",
+        "status_evidence_id"
+      ],
+      "properties": {
+        "evidence_id": {"$ref": "#/$defs/safe_identity"},
+        "classification": {
+          "enum": [
+            "qualified_upstream",
+            "qualified_downstream_attestation"
+          ]
+        },
+        "status": {"enum": ["active", "revoked", "superseded"]},
+        "selectors": {"$ref": "#/$defs/selectors"},
+        "artifact": {"$ref": "#/$defs/artifact"},
+        "activated_at_utc": {"$ref": "#/$defs/utc_timestamp"},
+        "revoked_at_utc": {
+          "anyOf": [
+            {"$ref": "#/$defs/utc_timestamp"},
+            {"type": "null"}
+          ]
+        },
+        "supersedes_evidence_id": {
+          "anyOf": [
+            {"$ref": "#/$defs/safe_identity"},
+            {"type": "null"}
+          ]
+        },
+        "status_evidence_id": {
+          "anyOf": [
+            {"$ref": "#/$defs/safe_identity"},
+            {"type": "null"}
+          ]
+        }
+      }
+    },
+    "selectors": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["binding", "sqlite", "python", "platform"],
+      "properties": {
+        "binding": {"$ref": "#/$defs/binding"},
+        "sqlite": {"$ref": "#/$defs/sqlite"},
+        "python": {"$ref": "#/$defs/python"},
+        "platform": {"$ref": "#/$defs/platform"}
+      }
+    },
+    "binding": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "distribution",
+        "distribution_version",
+        "wrapper_version",
+        "extension_sha256"
+      ],
+      "properties": {
+        "distribution": {
+          "type": "string",
+          "pattern": "^[A-Za-z0-9][A-Za-z0-9._+-]*$"
+        },
+        "distribution_version": {"$ref": "#/$defs/binding_version"},
+        "wrapper_version": {"$ref": "#/$defs/binding_version"},
+        "extension_sha256": {"$ref": "#/$defs/sha256"}
+      }
+    },
+    "sqlite": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "version",
+        "version_number",
+        "source_id",
+        "compile_options_sha256",
+        "using_amalgamation"
+      ],
+      "properties": {
+        "version": {"$ref": "#/$defs/sqlite_version"},
+        "version_number": {"type": "integer", "minimum": 1},
+        "source_id": {
+          "type": "string",
+          "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2} [0-9]{2}:[0-9]{2}:[0-9]{2} [0-9a-f]{64}$"
+        },
+        "compile_options_sha256": {"$ref": "#/$defs/sha256"},
+        "using_amalgamation": {"type": "boolean"}
+      }
+    },
+    "python": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["implementation", "version", "abi", "gil_mode"],
+      "properties": {
+        "implementation": {"const": "CPython"},
+        "version": {
+          "type": "string",
+          "pattern": "^3\\.(?:10|11|12|13|14)\\.[0-9]+$"
+        },
+        "abi": {
+          "type": "string",
+          "pattern": "^(?:cpython-3(?:10|11|12|13|14)|cp3(?:10|11|12|13|14))t?(?:[-_][A-Za-z0-9_.+-]+)?$"
+        },
+        "gil_mode": {"enum": ["gil", "free-threaded"]}
+      }
+    },
+    "platform": {
+      "type": "object",
+      "additionalProperties": false,
+      "allOf": [
+        {
+          "if": {
+            "properties": {"os": {"const": "Windows"}},
+            "required": ["os"]
+          },
+          "then": {
+            "properties": {
+              "product_type": {
+                "enum": ["domain_controller", "server", "workstation"]
+              }
+            }
+          },
+          "else": {
+            "properties": {
+              "product_type": {"const": "not_applicable"}
+            }
+          }
+        }
+      ],
+      "required": [
+        "os",
+        "version",
+        "kernel_release",
+        "product_type",
+        "architecture"
+      ],
+      "properties": {
+        "os": {"enum": ["Ubuntu", "macOS", "Windows"]},
+        "version": {
+          "type": "string",
+          "pattern": "^[0-9]+(?:\\.[0-9]+){1,3}$"
+        },
+        "kernel_release": {
+          "type": "string",
+          "pattern": "^[A-Za-z0-9][A-Za-z0-9._+-]*$"
+        },
+        "product_type": {
+          "enum": [
+            "domain_controller",
+            "not_applicable",
+            "server",
+            "workstation"
+          ]
+        },
+        "architecture": {
+          "enum": ["AMD64", "aarch64", "amd64", "arm64", "x86_64"]
+        }
+      }
+    },
+    "artifact": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "vendor",
+        "filename",
+        "download_url",
+        "size_bytes",
+        "sha256",
+        "platform_tag",
+        "publisher",
+        "build"
+      ],
+      "properties": {
+        "vendor": {"type": "string", "minLength": 1},
+        "filename": {
+          "type": "string",
+          "maxLength": 512,
+          "pattern": "^[A-Za-z0-9][A-Za-z0-9._+-]*$"
+        },
+        "download_url": {"$ref": "#/$defs/https_url"},
+        "size_bytes": {"type": "integer", "minimum": 1},
+        "sha256": {"$ref": "#/$defs/sha256"},
+        "platform_tag": {
+          "type": "string",
+          "maxLength": 256,
+          "pattern": "^[A-Za-z0-9][A-Za-z0-9._+-]*$"
+        },
+        "publisher": {"$ref": "#/$defs/publisher"},
+        "build": {"$ref": "#/$defs/build"}
+      }
+    },
+    "publisher": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["identity", "provenance_url"],
+      "properties": {
+        "identity": {"$ref": "#/$defs/safe_identity"},
+        "provenance_url": {"$ref": "#/$defs/https_url"}
+      }
+    },
+    "build": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "source_repository_url",
+        "source_commit",
+        "workflow_url",
+        "runner_image"
+      ],
+      "properties": {
+        "source_repository_url": {"$ref": "#/$defs/https_url"},
+        "source_commit": {
+          "type": "string",
+          "pattern": "^(?:[0-9a-f]{40}|[0-9a-f]{64})$"
+        },
+        "workflow_url": {"$ref": "#/$defs/https_url"},
+        "runner_image": {"$ref": "#/$defs/runner_image"}
+      }
+    },
+    "runner_image": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["label", "version", "manifest_url"],
+      "properties": {
+        "label": {"$ref": "#/$defs/safe_identity"},
+        "version": {"$ref": "#/$defs/safe_identity"},
+        "manifest_url": {"$ref": "#/$defs/https_url"}
+      }
+    }
+  }
+}

--- a/djsupport/operational_store/__init__.py
+++ b/djsupport/operational_store/__init__.py
@@ -1,0 +1,23 @@
+"""Private Operational Store runtime qualification interface."""
+
+from djsupport.operational_store.apsw import probe_apsw_runtime
+from djsupport.operational_store.qualification import (
+    QualifiedRuntime,
+    QualificationManifestError,
+    QualificationResult,
+    QualificationState,
+    RuntimeFacts,
+    SQLiteRuntimeUnavailable,
+    SQLiteRuntimeQualification,
+)
+
+__all__ = [
+    "QualificationManifestError",
+    "QualificationResult",
+    "QualificationState",
+    "QualifiedRuntime",
+    "RuntimeFacts",
+    "SQLiteRuntimeUnavailable",
+    "SQLiteRuntimeQualification",
+    "probe_apsw_runtime",
+]

--- a/djsupport/operational_store/apsw.py
+++ b/djsupport/operational_store/apsw.py
@@ -1,0 +1,147 @@
+"""Collect path-free facts from the sole production SQLite binding."""
+
+from __future__ import annotations
+
+from hashlib import sha256
+from importlib import import_module
+from importlib.metadata import version as distribution_version
+from pathlib import Path
+import platform
+import sys
+import sysconfig
+from types import ModuleType
+
+from djsupport.operational_store.qualification import RuntimeFacts
+
+
+class RuntimeProbeError(RuntimeError):
+    """The selected binding could not produce trustworthy public facts."""
+
+    def __init__(self, reason_code: str) -> None:
+        self.reason_code = reason_code
+        super().__init__(f"sqlite_runtime_probe_failed:{reason_code}")
+
+
+def probe_apsw_runtime() -> RuntimeFacts:
+    """Interrogate the APSW runtime that would open the Operational Store."""
+    try:
+        binding = import_module("apsw")
+    except ImportError:
+        raise RuntimeProbeError("binding_unavailable") from None
+    try:
+        extension_path = _binding_extension_path(binding)
+        compile_options = tuple(
+            sorted(str(item) for item in binding.compile_options)
+        )
+        os_name, os_version, os_product_type = (
+            _operating_system_identity()
+        )
+        return RuntimeFacts(
+            binding_distribution="apsw",
+            binding_distribution_version=distribution_version("apsw"),
+            binding_wrapper_version=str(binding.apsw_version()),
+            binding_extension_sha256=_file_sha256(extension_path),
+            sqlite_version=str(binding.sqlite_lib_version()),
+            sqlite_version_number=int(binding.SQLITE_VERSION_NUMBER),
+            sqlite_source_id=str(binding.sqlite3_sourceid()),
+            sqlite_compile_options_sha256=_compile_options_sha256(
+                compile_options,
+            ),
+            using_amalgamation=binding.using_amalgamation is True,
+            python_implementation=_python_implementation(),
+            python_version=(
+                f"{sys.version_info.major}."
+                f"{sys.version_info.minor}."
+                f"{sys.version_info.micro}"
+            ),
+            python_abi=str(sysconfig.get_config_var("SOABI") or "unknown"),
+            python_gil_mode=_python_gil_mode(),
+            os_name=os_name,
+            os_version=os_version,
+            os_kernel_release=platform.release(),
+            os_product_type=os_product_type,
+            architecture=platform.machine(),
+        )
+    except RuntimeProbeError:
+        raise
+    except (AttributeError, ImportError, OSError, TypeError, ValueError):
+        raise RuntimeProbeError("runtime_facts_unavailable") from None
+
+
+def _binding_extension_path(binding: ModuleType) -> Path:
+    value = getattr(binding, "__file__", None)
+    if not isinstance(value, str) or not value:
+        raise RuntimeProbeError("binding_extension_unavailable")
+    return Path(value)
+
+
+def _file_sha256(path: Path) -> str:
+    digest = sha256()
+    with path.open("rb") as source:
+        for chunk in iter(lambda: source.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _compile_options_sha256(options: tuple[str, ...]) -> str:
+    digest = sha256()
+    for option in options:
+        digest.update(option.encode("utf-8"))
+        digest.update(b"\n")
+    return digest.hexdigest()
+
+
+def _python_implementation() -> str:
+    if sys.implementation.name == "cpython":
+        return "CPython"
+    return sys.implementation.name
+
+
+def _python_gil_mode() -> str:
+    is_enabled = getattr(sys, "_is_gil_enabled", None)
+    if callable(is_enabled) and not is_enabled():
+        return "free-threaded"
+    return "gil"
+
+
+def _operating_system_identity() -> tuple[str, str, str]:
+    name = platform.system()
+    if name == "Darwin":
+        return (
+            "macOS",
+            _required_platform_value(platform.mac_ver()[0]),
+            "not_applicable",
+        )
+    if name == "Linux":
+        release = platform.freedesktop_os_release()
+        distribution = _required_platform_value(release.get("ID"))
+        version = _required_platform_value(release.get("VERSION_ID"))
+        if distribution == "ubuntu":
+            return "Ubuntu", version, "not_applicable"
+        return distribution, version, "not_applicable"
+    if name == "Windows":
+        _release, version, _service_pack, _type = platform.win32_ver()
+        return (
+            "Windows",
+            _required_platform_value(version),
+            _windows_product_type(),
+        )
+    raise RuntimeProbeError("platform_identity_unavailable")
+
+
+def _required_platform_value(value: object) -> str:
+    if not isinstance(value, str) or not value:
+        raise RuntimeProbeError("platform_identity_unavailable")
+    return value
+
+
+def _windows_product_type() -> str:
+    product_type = getattr(sys.getwindowsversion(), "product_type", None)
+    try:
+        return {
+            1: "workstation",
+            2: "domain_controller",
+            3: "server",
+        }[product_type]
+    except KeyError:
+        raise RuntimeProbeError("platform_identity_unavailable") from None

--- a/djsupport/operational_store/qualification.py
+++ b/djsupport/operational_store/qualification.py
@@ -1,0 +1,512 @@
+"""Classify exact SQLite binding and runtime evidence before store access."""
+
+from __future__ import annotations
+
+from copy import deepcopy
+from dataclasses import dataclass
+from enum import Enum
+from importlib import resources
+import json
+import re
+from typing import Callable, Mapping, TypeVar
+
+from jsonschema import Draft202012Validator, FormatChecker
+
+
+_MANIFEST_SCHEMA = "sqlite-runtime-qualification.v1.schema.json"
+_PACKAGED_MANIFEST = "sqlite-runtime-qualification.v1.json"
+_T = TypeVar("_T")
+_NEAR_MISS_RULES = (
+    ("binding_artifact_unapproved", "binding", "extension_sha256"),
+    ("sqlite_source_unapproved", "sqlite", "source_id"),
+    ("compile_options_unapproved", "sqlite", "compile_options_sha256"),
+    ("wrapper_version_unapproved", "binding", "wrapper_version"),
+    ("platform_unapproved", "platform", None),
+    ("python_runtime_unapproved", "python", None),
+    ("sqlite_build_unapproved", "sqlite", "using_amalgamation"),
+    ("sqlite_version_number_unapproved", "sqlite", "version_number"),
+)
+
+
+class QualificationManifestError(ValueError):
+    """The repository-owned runtime policy document is not trustworthy."""
+
+
+class SQLiteRuntimeUnavailable(RuntimeError):
+    """The production store must stop before resolving any private path."""
+
+    def __init__(self, result: QualificationResult) -> None:
+        self.result = result
+        super().__init__(f"sqlite_runtime_unavailable:{result.reason_code}")
+
+
+class QualificationState(str, Enum):
+    """The complete fail-closed SQLite runtime policy result."""
+
+    QUALIFIED_UPSTREAM = "qualified_upstream"
+    QUALIFIED_DOWNSTREAM_ATTESTATION = "qualified_downstream_attestation"
+    UNQUALIFIED_AFFECTED = "unqualified_affected"
+    UNQUALIFIED_WITHDRAWN = "unqualified_withdrawn"
+    UNQUALIFIED_UNKNOWN = "unqualified_unknown"
+
+
+@dataclass(frozen=True)
+class RuntimeFacts:
+    """Path-free public facts from the binding that would open the store."""
+
+    binding_distribution: str
+    binding_distribution_version: str
+    binding_wrapper_version: str
+    binding_extension_sha256: str
+    sqlite_version: str
+    sqlite_version_number: int
+    sqlite_source_id: str
+    sqlite_compile_options_sha256: str
+    using_amalgamation: bool
+    python_implementation: str
+    python_version: str
+    python_abi: str
+    python_gil_mode: str
+    os_name: str
+    os_version: str
+    os_kernel_release: str
+    os_product_type: str
+    architecture: str
+
+    def _selectors(self) -> dict[str, object]:
+        return {
+            "binding": {
+                "distribution": self.binding_distribution,
+                "distribution_version": self.binding_distribution_version,
+                "wrapper_version": self.binding_wrapper_version,
+                "extension_sha256": self.binding_extension_sha256,
+            },
+            "sqlite": {
+                "version": self.sqlite_version,
+                "version_number": self.sqlite_version_number,
+                "source_id": self.sqlite_source_id,
+                "compile_options_sha256": self.sqlite_compile_options_sha256,
+                "using_amalgamation": self.using_amalgamation,
+            },
+            "python": {
+                "implementation": self.python_implementation,
+                "version": self.python_version,
+                "abi": self.python_abi,
+                "gil_mode": self.python_gil_mode,
+            },
+            "platform": {
+                "os": self.os_name,
+                "version": self.os_version,
+                "kernel_release": self.os_kernel_release,
+                "product_type": self.os_product_type,
+                "architecture": self.architecture,
+            },
+        }
+
+
+@dataclass(frozen=True)
+class QualificationResult:
+    """Typed classification plus the reviewed evidence identity, if any."""
+
+    state: QualificationState
+    reason_code: str
+    evidence_id: str | None = None
+
+    @property
+    def qualified(self) -> bool:
+        return self.state in {
+            QualificationState.QUALIFIED_UPSTREAM,
+            QualificationState.QUALIFIED_DOWNSTREAM_ATTESTATION,
+        }
+
+    @property
+    def diagnostic(self) -> dict[str, str | None]:
+        """Return only stable, path-free facts safe for diagnostics."""
+        return {
+            "state": self.state.value,
+            "reason_code": self.reason_code,
+            "evidence_id": self.evidence_id,
+        }
+
+
+@dataclass(frozen=True)
+class QualifiedRuntime:
+    """Proof that one reviewed evidence entry admitted this process."""
+
+    state: QualificationState
+    evidence_id: str
+
+
+class SQLiteRuntimeQualification:
+    """Apply one immutable repository-owned qualification manifest."""
+
+    def __init__(self, manifest: Mapping[str, object]) -> None:
+        manifest_document = deepcopy(dict(manifest))
+        _validate_manifest(manifest_document)
+        self._manifest = manifest_document
+
+    @classmethod
+    def packaged(cls) -> SQLiteRuntimeQualification:
+        """Load the immutable policy shipped with this DJ Support build."""
+        manifest_text = (
+            resources.files("djsupport")
+            .joinpath("contracts", _PACKAGED_MANIFEST)
+            .read_text(encoding="utf-8")
+        )
+        manifest = json.loads(manifest_text)
+        if not isinstance(manifest, dict):
+            raise QualificationManifestError(
+                "sqlite_runtime_manifest_invalid:type:root"
+            )
+        return cls(manifest)
+
+    def classify(self, facts: RuntimeFacts) -> QualificationResult:
+        withdrawn = self._manifest.get("withdrawn_sqlite_versions", [])
+        if isinstance(withdrawn, list) and facts.sqlite_version in withdrawn:
+            return QualificationResult(
+                QualificationState.UNQUALIFIED_WITHDRAWN,
+                "sqlite_release_withdrawn",
+            )
+        if not _runtime_facts_are_well_formed(facts):
+            return QualificationResult(
+                QualificationState.UNQUALIFIED_UNKNOWN,
+                "runtime_facts_malformed",
+            )
+        if _is_affected_release(
+            facts.sqlite_version,
+            self._manifest.get("affected_sqlite_ranges", []),
+        ):
+            return QualificationResult(
+                QualificationState.UNQUALIFIED_AFFECTED,
+                "sqlite_release_affected",
+            )
+        selected_binding = self._manifest.get("selected_binding")
+        if not isinstance(selected_binding, dict) or (
+            selected_binding.get("distribution")
+            != facts.binding_distribution
+            or selected_binding.get("version")
+            != facts.binding_distribution_version
+        ):
+            return QualificationResult(
+                QualificationState.UNQUALIFIED_UNKNOWN,
+                "binding_unapproved",
+            )
+        selectors = facts._selectors()
+        entries = self._manifest.get("entries", [])
+        near_miss_reason = None
+        if isinstance(entries, list):
+            for entry in entries:
+                if not isinstance(entry, dict):
+                    continue
+                entry_selectors = entry.get("selectors")
+                if entry_selectors == selectors:
+                    status = entry.get("status")
+                    if status in {"revoked", "superseded"}:
+                        return QualificationResult(
+                            QualificationState.UNQUALIFIED_UNKNOWN,
+                            f"evidence_{status}",
+                            str(entry["evidence_id"]),
+                        )
+                    if status != "active":
+                        continue
+                    state = QualificationState(str(entry["classification"]))
+                    reason_code = (
+                        "downstream_attestation_exact_match"
+                        if state
+                        is QualificationState.QUALIFIED_DOWNSTREAM_ATTESTATION
+                        else "upstream_exact_match"
+                    )
+                    return QualificationResult(
+                        state,
+                        reason_code,
+                        str(entry["evidence_id"]),
+                    )
+                if (
+                    entry.get("status") == "active"
+                    and near_miss_reason is None
+                ):
+                    for reason_code, section, field in _NEAR_MISS_RULES:
+                        if _matches_except_selector(
+                            entry_selectors,
+                            selectors,
+                            section,
+                            field,
+                        ):
+                            near_miss_reason = reason_code
+                            break
+        if near_miss_reason is not None:
+            return QualificationResult(
+                QualificationState.UNQUALIFIED_UNKNOWN,
+                near_miss_reason,
+            )
+        return QualificationResult(
+            QualificationState.UNQUALIFIED_UNKNOWN,
+            "evidence_unlisted",
+        )
+
+    def classify_installed(self) -> QualificationResult:
+        """Probe APSW and fail closed before any Operational Store path."""
+        from djsupport.operational_store.apsw import (
+            RuntimeProbeError,
+            probe_apsw_runtime,
+        )
+
+        try:
+            facts = probe_apsw_runtime()
+        except RuntimeProbeError as exc:
+            return QualificationResult(
+                QualificationState.UNQUALIFIED_UNKNOWN,
+                exc.reason_code,
+            )
+        return self.classify(facts)
+
+    def run_qualified(
+        self,
+        operation: Callable[[QualifiedRuntime], _T],
+    ) -> _T:
+        """Run an Operational Store operation only after exact qualification."""
+        result = self.classify_installed()
+        if not result.qualified or result.evidence_id is None:
+            raise SQLiteRuntimeUnavailable(result)
+        return operation(QualifiedRuntime(result.state, result.evidence_id))
+
+
+def _matches_except_selector(
+    expected: object,
+    actual: Mapping[str, object],
+    target_section: str,
+    target_field: str | None,
+) -> bool:
+    if not isinstance(expected, dict):
+        return False
+    sections = ("binding", "sqlite", "python", "platform")
+    for section in sections:
+        if section == target_section:
+            continue
+        if expected.get(section) != actual.get(section):
+            return False
+    expected_target = expected.get(target_section)
+    actual_target = actual.get(target_section)
+    if target_field is None:
+        return expected_target != actual_target
+    if not isinstance(expected_target, dict):
+        return False
+    if not isinstance(actual_target, dict):
+        return False
+    expected_without_field = {
+        key: value
+        for key, value in expected_target.items()
+        if key != target_field
+    }
+    actual_without_field = {
+        key: value
+        for key, value in actual_target.items()
+        if key != target_field
+    }
+    return (
+        expected_without_field == actual_without_field
+        and expected_target.get(target_field)
+        != actual_target.get(target_field)
+    )
+
+
+def _is_affected_release(version: str, ranges: object) -> bool:
+    parsed = _parse_sqlite_version(version)
+    if parsed is None or not isinstance(ranges, list):
+        return False
+    for item in ranges:
+        if not isinstance(item, dict):
+            continue
+        minimum = _parse_sqlite_version(item.get("minimum"))
+        maximum = _parse_sqlite_version(item.get("maximum"))
+        exceptions = item.get("exceptions", [])
+        if minimum is None or maximum is None:
+            continue
+        if version in exceptions:
+            continue
+        if minimum <= parsed <= maximum:
+            return True
+    return False
+
+
+def _parse_sqlite_version(value: object) -> tuple[int, int, int] | None:
+    if not isinstance(value, str):
+        return None
+    parts = value.split(".")
+    if len(parts) != 3 or any(not part.isdigit() for part in parts):
+        return None
+    parsed = int(parts[0]), int(parts[1]), int(parts[2])
+    if value != ".".join(str(part) for part in parsed):
+        return None
+    if parsed[1] >= 1000 or parsed[2] >= 1000:
+        return None
+    return parsed
+
+
+def _runtime_facts_are_well_formed(facts: RuntimeFacts) -> bool:
+    text_values = (
+        facts.binding_distribution,
+        facts.binding_distribution_version,
+        facts.binding_wrapper_version,
+        facts.binding_extension_sha256,
+        facts.sqlite_version,
+        facts.sqlite_source_id,
+        facts.sqlite_compile_options_sha256,
+        facts.python_implementation,
+        facts.python_version,
+        facts.python_abi,
+        facts.python_gil_mode,
+        facts.os_name,
+        facts.os_version,
+        facts.os_kernel_release,
+        facts.os_product_type,
+        facts.architecture,
+    )
+    if any(not isinstance(value, str) for value in text_values):
+        return False
+    if any(
+        re.fullmatch(r"[A-Za-z0-9_.+\-]+", value) is None
+        for value in (facts.binding_distribution, facts.os_kernel_release)
+    ):
+        return False
+    if (
+        re.fullmatch(
+            r"[0-9]+(?:\.[0-9]+){3}",
+            facts.binding_distribution_version,
+        )
+        is None
+        or re.fullmatch(
+            r"[0-9]+(?:\.[0-9]+){3}",
+            facts.binding_wrapper_version,
+        )
+        is None
+    ):
+        return False
+    python_version = _parse_python_version(facts.python_version)
+    if facts.python_implementation != "CPython" or python_version is None:
+        return False
+    python_abi_match = re.fullmatch(
+        rf"(?:cpython-{python_version[0]}{python_version[1]}|"
+        rf"cp{python_version[0]}{python_version[1]})(t)?"
+        r"(?:[-_][A-Za-z0-9_.+-]+)?",
+        facts.python_abi,
+    )
+    if python_abi_match is None:
+        return False
+    if facts.python_gil_mode not in {"gil", "free-threaded"}:
+        return False
+    is_free_threaded_abi = python_abi_match.group(1) == "t"
+    if is_free_threaded_abi != (
+        facts.python_gil_mode == "free-threaded"
+    ):
+        return False
+    if not _platform_facts_are_well_formed(facts):
+        return False
+    parsed_sqlite_version = _parse_sqlite_version(facts.sqlite_version)
+    if parsed_sqlite_version is None:
+        return False
+    if (
+        not isinstance(facts.sqlite_version_number, int)
+        or isinstance(facts.sqlite_version_number, bool)
+        or facts.sqlite_version_number <= 0
+    ):
+        return False
+    expected_version_number = (
+        parsed_sqlite_version[0] * 1_000_000
+        + parsed_sqlite_version[1] * 1_000
+        + parsed_sqlite_version[2]
+    )
+    if facts.sqlite_version_number != expected_version_number:
+        return False
+    if re.fullmatch(r"[0-9a-f]{64}", facts.binding_extension_sha256) is None:
+        return False
+    if re.fullmatch(
+        r"[0-9a-f]{64}",
+        facts.sqlite_compile_options_sha256,
+    ) is None:
+        return False
+    if re.fullmatch(
+        r"\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2} [0-9a-f]{64}",
+        facts.sqlite_source_id,
+    ) is None:
+        return False
+    return isinstance(facts.using_amalgamation, bool)
+
+
+def _parse_python_version(value: object) -> tuple[int, int, int] | None:
+    parsed = _parse_sqlite_version(value)
+    if parsed is None or parsed[0] != 3 or parsed[1] not in range(10, 15):
+        return None
+    return parsed
+
+
+def _platform_facts_are_well_formed(facts: RuntimeFacts) -> bool:
+    if facts.os_name not in {"Ubuntu", "macOS", "Windows"}:
+        return False
+    version_pattern = r"[0-9]+(?:\.[0-9]+){1,3}"
+    if re.fullmatch(version_pattern, facts.os_version) is None:
+        return False
+    if facts.os_name == "Windows":
+        if facts.os_product_type not in {
+            "domain_controller",
+            "server",
+            "workstation",
+        }:
+            return False
+    elif facts.os_product_type != "not_applicable":
+        return False
+    return facts.architecture in {
+        "AMD64",
+        "aarch64",
+        "amd64",
+        "arm64",
+        "x86_64",
+    }
+
+
+def _validate_manifest(manifest: Mapping[str, object]) -> None:
+    schema_text = (
+        resources.files("djsupport")
+        .joinpath("contracts", _MANIFEST_SCHEMA)
+        .read_text(encoding="utf-8")
+    )
+    schema = json.loads(schema_text)
+    errors = sorted(
+        Draft202012Validator(
+            schema,
+            format_checker=FormatChecker(),
+        ).iter_errors(manifest),
+        key=lambda error: list(error.absolute_path),
+    )
+    if errors:
+        error = errors[0]
+        location = ".".join(
+            str(part) for part in error.absolute_path
+        ) or "root"
+        raise QualificationManifestError(
+            f"sqlite_runtime_manifest_invalid:{error.validator}:{location}"
+        )
+    entries = manifest.get("entries", [])
+    if isinstance(entries, list):
+        evidence_ids = [
+            entry["evidence_id"]
+            for entry in entries
+            if isinstance(entry, dict)
+        ]
+        if len(evidence_ids) != len(set(evidence_ids)):
+            raise QualificationManifestError(
+                "sqlite_runtime_manifest_invalid:unique:evidence_id"
+            )
+        selector_identities = [
+            json.dumps(
+                entry["selectors"],
+                sort_keys=True,
+                separators=(",", ":"),
+            )
+            for entry in entries
+            if isinstance(entry, dict)
+        ]
+        if len(selector_identities) != len(set(selector_identities)):
+            raise QualificationManifestError(
+                "sqlite_runtime_manifest_invalid:unique:selectors"
+            )

--- a/tests/test_sqlite_runtime_qualification.py
+++ b/tests/test_sqlite_runtime_qualification.py
@@ -1,0 +1,1024 @@
+"""Fail-closed qualification at the Operational Store runtime seam."""
+
+import ast
+from copy import deepcopy
+from dataclasses import replace
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from djsupport.operational_store import (
+    QualificationManifestError,
+    QualificationState,
+    RuntimeFacts,
+    SQLiteRuntimeUnavailable,
+    SQLiteRuntimeQualification,
+    probe_apsw_runtime,
+)
+from djsupport.operational_store.apsw import RuntimeProbeError
+
+
+SQLITE_3534_SOURCE_ID = (
+    "2026-07-24 19:02:57 "
+    "bf7c7f30031888f4e796e429ab3978879485813aaca6f641c7b33e4e09459bcc"
+)
+
+
+def active_upstream_manifest():
+    return {
+        "schema_version": 1,
+        "policy_id": "sqlite-runtime-qualification/test-v1",
+        "selected_binding": {
+            "distribution": "apsw",
+            "version": "3.53.4.0",
+        },
+        "withdrawn_sqlite_versions": ["3.52.0"],
+        "affected_sqlite_ranges": [
+            {
+                "minimum": "3.7.0",
+                "maximum": "3.51.2",
+                "exceptions": ["3.44.6", "3.50.7"],
+            }
+        ],
+        "entries": [
+            {
+                "evidence_id": "apsw/3.53.4.0/test-wheel",
+                "classification": "qualified_upstream",
+                "status": "active",
+                "selectors": {
+                    "binding": {
+                        "distribution": "apsw",
+                        "distribution_version": "3.53.4.0",
+                        "wrapper_version": "3.53.4.0",
+                        "extension_sha256": "a" * 64,
+                    },
+                    "sqlite": {
+                        "version": "3.53.4",
+                        "version_number": 3053004,
+                        "source_id": SQLITE_3534_SOURCE_ID,
+                        "compile_options_sha256": "b" * 64,
+                        "using_amalgamation": True,
+                    },
+                    "python": {
+                        "implementation": "CPython",
+                        "version": "3.14.7",
+                        "abi": "cpython-314-darwin",
+                        "gil_mode": "gil",
+                    },
+                    "platform": {
+                        "os": "macOS",
+                        "version": "15.6.1",
+                        "kernel_release": "24.6.0",
+                        "product_type": "not_applicable",
+                        "architecture": "arm64",
+                    },
+                },
+                "artifact": {
+                    "vendor": "PyPI",
+                    "filename": (
+                        "apsw-3.53.4.0-cp314-cp314-macosx.whl"
+                    ),
+                    "download_url": (
+                        "https://files.example.test/apsw-test-wheel.whl"
+                    ),
+                    "size_bytes": 123456,
+                    "sha256": "c" * 64,
+                    "platform_tag": "cp314-cp314-macosx_15_0_arm64",
+                    "publisher": {
+                        "identity": "synthetic-publisher",
+                        "provenance_url": (
+                            "https://pypi.example/attestation/test-wheel"
+                        ),
+                    },
+                    "build": {
+                        "source_repository_url": (
+                            "https://example.test/apsw/source"
+                        ),
+                        "source_commit": "e" * 40,
+                        "workflow_url": "https://ci.example/run/1",
+                        "runner_image": {
+                            "label": "macos-15",
+                            "version": "20260815.1",
+                            "manifest_url": (
+                                "https://runner.example/macos-15"
+                            ),
+                        },
+                    },
+                },
+                "activated_at_utc": "2026-08-16T00:00:00Z",
+                "revoked_at_utc": None,
+                "supersedes_evidence_id": None,
+                "status_evidence_id": None,
+            }
+        ],
+    }
+
+
+def qualified_runtime_facts():
+    return RuntimeFacts(
+        binding_distribution="apsw",
+        binding_distribution_version="3.53.4.0",
+        binding_wrapper_version="3.53.4.0",
+        binding_extension_sha256="a" * 64,
+        sqlite_version="3.53.4",
+        sqlite_version_number=3053004,
+        sqlite_source_id=SQLITE_3534_SOURCE_ID,
+        sqlite_compile_options_sha256="b" * 64,
+        using_amalgamation=True,
+        python_implementation="CPython",
+        python_version="3.14.7",
+        python_abi="cpython-314-darwin",
+        python_gil_mode="gil",
+        os_name="macOS",
+        os_version="15.6.1",
+        os_kernel_release="24.6.0",
+        os_product_type="not_applicable",
+        architecture="arm64",
+    )
+
+
+def configure_synthetic_probe(
+    monkeypatch,
+    tmp_path,
+    *,
+    python_version=(3, 10, 11),
+    python_abi="cpython-310-darwin",
+    gil_enabled=None,
+    windows_product_type=None,
+):
+    extension_path = tmp_path / "apsw.so"
+    extension_path.write_bytes(b"synthetic apsw extension\n")
+    binding = SimpleNamespace(
+        __file__=str(extension_path),
+        SQLITE_VERSION_NUMBER=3053004,
+        apsw_version=lambda: "3.53.4.0",
+        sqlite_lib_version=lambda: "3.53.4",
+        sqlite3_sourceid=lambda: SQLITE_3534_SOURCE_ID,
+        compile_options=("THREADSAFE=1", "ENABLE_FTS5"),
+        using_amalgamation=True,
+    )
+    monkeypatch.setattr(
+        "djsupport.operational_store.apsw.import_module",
+        lambda name: binding,
+    )
+    monkeypatch.setattr(
+        "djsupport.operational_store.apsw.distribution_version",
+        lambda name: "3.53.4.0",
+    )
+    runtime = SimpleNamespace(
+        implementation=SimpleNamespace(name="cpython"),
+        version_info=SimpleNamespace(
+            major=python_version[0],
+            minor=python_version[1],
+            micro=python_version[2],
+        ),
+    )
+    if gil_enabled is not None:
+        runtime._is_gil_enabled = lambda: gil_enabled
+    if windows_product_type is not None:
+        runtime.getwindowsversion = lambda: SimpleNamespace(
+            product_type=windows_product_type
+        )
+    monkeypatch.setattr("djsupport.operational_store.apsw.sys", runtime)
+    monkeypatch.setattr(
+        "djsupport.operational_store.apsw.sysconfig.get_config_var",
+        lambda name: python_abi,
+    )
+    monkeypatch.setattr(
+        "djsupport.operational_store.apsw.platform.system",
+        lambda: "Darwin",
+    )
+    monkeypatch.setattr(
+        "djsupport.operational_store.apsw.platform.release",
+        lambda: "24.6.0",
+    )
+    monkeypatch.setattr(
+        "djsupport.operational_store.apsw.platform.mac_ver",
+        lambda: ("15.6.1", ("", "", ""), ""),
+    )
+    monkeypatch.setattr(
+        "djsupport.operational_store.apsw.platform.machine",
+        lambda: "arm64",
+    )
+    return extension_path
+
+
+class TestRuntimeClassifier:
+    def test_exact_reviewed_upstream_runtime_is_qualified(self):
+        qualification = SQLiteRuntimeQualification(active_upstream_manifest())
+
+        result = qualification.classify(qualified_runtime_facts())
+
+        assert result.state is QualificationState.QUALIFIED_UPSTREAM
+        assert result.evidence_id == "apsw/3.53.4.0/test-wheel"
+
+    def test_unapproved_native_extension_fails_closed(self):
+        qualification = SQLiteRuntimeQualification(active_upstream_manifest())
+        facts = replace(
+            qualified_runtime_facts(),
+            binding_extension_sha256="d" * 64,
+        )
+
+        result = qualification.classify(facts)
+
+        assert result.state is QualificationState.UNQUALIFIED_UNKNOWN
+        assert result.reason_code == "binding_artifact_unapproved"
+        assert result.evidence_id is None
+
+    def test_withdrawn_sqlite_release_is_denied_unconditionally(self):
+        qualification = SQLiteRuntimeQualification(active_upstream_manifest())
+        facts = replace(qualified_runtime_facts(), sqlite_version="3.52.0")
+
+        result = qualification.classify(facts)
+
+        assert result.state is QualificationState.UNQUALIFIED_WITHDRAWN
+        assert result.reason_code == "sqlite_release_withdrawn"
+
+    def test_environment_and_checkpoint_flags_cannot_override_rejection(
+        self,
+        monkeypatch,
+    ):
+        monkeypatch.setenv("DJSUPPORT_SQLITE_ALLOW_UNQUALIFIED", "1")
+        monkeypatch.setenv("DJSUPPORT_SQLITE_JOURNAL_MODE", "delete")
+        monkeypatch.setenv("DJSUPPORT_SQLITE_WAL_AUTOCHECKPOINT", "0")
+        monkeypatch.setenv("DJSUPPORT_SQLITE_MAINTENANCE_LEASE", "1")
+        qualification = SQLiteRuntimeQualification(active_upstream_manifest())
+        facts = replace(qualified_runtime_facts(), sqlite_version="3.52.0")
+
+        result = qualification.classify(facts)
+
+        assert result.state is QualificationState.UNQUALIFIED_WITHDRAWN
+        assert result.reason_code == "sqlite_release_withdrawn"
+
+    def test_known_wal_reset_affected_release_is_denied(self):
+        qualification = SQLiteRuntimeQualification(active_upstream_manifest())
+        facts = replace(
+            qualified_runtime_facts(),
+            sqlite_version="3.51.2",
+            sqlite_version_number=3051002,
+        )
+
+        result = qualification.classify(facts)
+
+        assert result.state is QualificationState.UNQUALIFIED_AFFECTED
+        assert result.reason_code == "sqlite_release_affected"
+
+    def test_active_manifest_entry_cannot_admit_an_affected_release(self):
+        manifest = deepcopy(active_upstream_manifest())
+        manifest["entries"][0]["selectors"]["sqlite"].update(
+            {
+                "version": "3.51.2",
+                "version_number": 3051002,
+                "source_id": "2026-01-01 00:00:00 " + "d" * 64,
+            }
+        )
+        facts = replace(
+            qualified_runtime_facts(),
+            sqlite_version="3.51.2",
+            sqlite_version_number=3051002,
+            sqlite_source_id="2026-01-01 00:00:00 " + "d" * 64,
+        )
+
+        result = SQLiteRuntimeQualification(manifest).classify(facts)
+
+        assert result.state is QualificationState.UNQUALIFIED_AFFECTED
+        assert result.reason_code == "sqlite_release_affected"
+
+    @pytest.mark.parametrize(
+        ("version", "version_number"),
+        [
+            ("3.50.7", 3050007),
+            ("3.54.0", 3054000),
+        ],
+    )
+    def test_eligible_or_future_versions_need_exact_evidence(
+        self,
+        version,
+        version_number,
+    ):
+        qualification = SQLiteRuntimeQualification(active_upstream_manifest())
+        facts = replace(
+            qualified_runtime_facts(),
+            sqlite_version=version,
+            sqlite_version_number=version_number,
+            sqlite_source_id="2026-08-16 00:00:00 " + "d" * 64,
+        )
+
+        result = qualification.classify(facts)
+
+        assert result.state is QualificationState.UNQUALIFIED_UNKNOWN
+        assert result.reason_code == "evidence_unlisted"
+
+    def test_revoked_exact_evidence_fails_closed(self):
+        manifest = deepcopy(active_upstream_manifest())
+        manifest["entries"][0]["status"] = "revoked"
+        manifest["entries"][0]["revoked_at_utc"] = "2026-08-17T00:00:00Z"
+        manifest["entries"][0]["status_evidence_id"] = (
+            "sqlite-policy/2026-08-17/revoked"
+        )
+        qualification = SQLiteRuntimeQualification(manifest)
+
+        result = qualification.classify(qualified_runtime_facts())
+
+        assert result.state is QualificationState.UNQUALIFIED_UNKNOWN
+        assert result.reason_code == "evidence_revoked"
+        assert result.evidence_id == "apsw/3.53.4.0/test-wheel"
+
+    def test_superseded_exact_evidence_fails_closed(self):
+        manifest = deepcopy(active_upstream_manifest())
+        manifest["entries"][0]["status"] = "superseded"
+        manifest["entries"][0]["status_evidence_id"] = (
+            "sqlite-policy/2026-08-17/superseded"
+        )
+        qualification = SQLiteRuntimeQualification(manifest)
+
+        result = qualification.classify(qualified_runtime_facts())
+
+        assert result.state is QualificationState.UNQUALIFIED_UNKNOWN
+        assert result.reason_code == "evidence_superseded"
+        assert result.evidence_id == "apsw/3.53.4.0/test-wheel"
+
+    def test_loaded_policy_is_immutable_from_caller_mutation(self):
+        manifest = active_upstream_manifest()
+        qualification = SQLiteRuntimeQualification(manifest)
+        manifest["entries"][0]["status"] = "revoked"
+        manifest["entries"][0]["revoked_at_utc"] = "2026-08-17T00:00:00Z"
+
+        result = qualification.classify(qualified_runtime_facts())
+
+        assert result.state is QualificationState.QUALIFIED_UPSTREAM
+
+    def test_exact_reviewed_downstream_attestation_is_qualified(self):
+        manifest = deepcopy(active_upstream_manifest())
+        manifest["entries"][0]["classification"] = (
+            "qualified_downstream_attestation"
+        )
+        manifest["entries"][0]["evidence_id"] = (
+            "sqlite-wal-reset/vendor/product/build"
+        )
+        manifest["entries"][0]["artifact"]["vendor"] = "Synthetic Vendor"
+        qualification = SQLiteRuntimeQualification(manifest)
+
+        result = qualification.classify(qualified_runtime_facts())
+
+        assert result.state is (
+            QualificationState.QUALIFIED_DOWNSTREAM_ATTESTATION
+        )
+        assert result.reason_code == "downstream_attestation_exact_match"
+        assert result.evidence_id == "sqlite-wal-reset/vendor/product/build"
+
+    def test_malformed_runtime_facts_fail_without_echoing_private_values(self):
+        private_value = "/Users/example/private/operational-store.sqlite3"
+        qualification = SQLiteRuntimeQualification(active_upstream_manifest())
+        facts = replace(
+            qualified_runtime_facts(),
+            sqlite_source_id=private_value,
+        )
+
+        result = qualification.classify(facts)
+
+        assert result.state is QualificationState.UNQUALIFIED_UNKNOWN
+        assert result.reason_code == "runtime_facts_malformed"
+        assert result.diagnostic == {
+            "state": "unqualified_unknown",
+            "reason_code": "runtime_facts_malformed",
+            "evidence_id": None,
+        }
+        assert private_value not in repr(result.diagnostic)
+
+    def test_non_string_runtime_selector_fails_closed(self):
+        qualification = SQLiteRuntimeQualification(active_upstream_manifest())
+        facts = replace(qualified_runtime_facts(), python_abi=None)
+
+        result = qualification.classify(facts)
+
+        assert result.state is QualificationState.UNQUALIFIED_UNKNOWN
+        assert result.reason_code == "runtime_facts_malformed"
+
+    def test_a_different_sqlite_binding_is_never_substituted(self):
+        qualification = SQLiteRuntimeQualification(active_upstream_manifest())
+        facts = replace(
+            qualified_runtime_facts(),
+            binding_distribution="sqlite3",
+        )
+
+        result = qualification.classify(facts)
+
+        assert result.state is QualificationState.UNQUALIFIED_UNKNOWN
+        assert result.reason_code == "binding_unapproved"
+
+    def test_unknown_source_id_is_rejected_despite_approved_versions(self):
+        qualification = SQLiteRuntimeQualification(active_upstream_manifest())
+        facts = replace(
+            qualified_runtime_facts(),
+            sqlite_source_id="2026-07-24 19:02:57 " + "d" * 64,
+        )
+
+        result = qualification.classify(facts)
+
+        assert result.state is QualificationState.UNQUALIFIED_UNKNOWN
+        assert result.reason_code == "sqlite_source_unapproved"
+
+    def test_unknown_compile_options_are_rejected(self):
+        qualification = SQLiteRuntimeQualification(active_upstream_manifest())
+        facts = replace(
+            qualified_runtime_facts(),
+            sqlite_compile_options_sha256="d" * 64,
+        )
+
+        result = qualification.classify(facts)
+
+        assert result.state is QualificationState.UNQUALIFIED_UNKNOWN
+        assert result.reason_code == "compile_options_unapproved"
+
+    def test_unapproved_sqlite_build_shape_is_rejected(self):
+        qualification = SQLiteRuntimeQualification(active_upstream_manifest())
+        facts = replace(
+            qualified_runtime_facts(),
+            using_amalgamation=False,
+        )
+
+        result = qualification.classify(facts)
+
+        assert result.state is QualificationState.UNQUALIFIED_UNKNOWN
+        assert result.reason_code == "sqlite_build_unapproved"
+
+    def test_sqlite_text_and_numeric_versions_must_be_internally_consistent(self):
+        qualification = SQLiteRuntimeQualification(active_upstream_manifest())
+        facts = replace(
+            qualified_runtime_facts(),
+            sqlite_version_number=3053003,
+        )
+
+        result = qualification.classify(facts)
+
+        assert result.state is QualificationState.UNQUALIFIED_UNKNOWN
+        assert result.reason_code == "runtime_facts_malformed"
+
+    def test_internally_inconsistent_sqlite_version_identity_is_malformed(self):
+        manifest = deepcopy(active_upstream_manifest())
+        manifest["entries"][0]["selectors"]["sqlite"][
+            "version_number"
+        ] = 3053003
+        facts = replace(
+            qualified_runtime_facts(),
+            sqlite_version_number=3053003,
+        )
+
+        result = SQLiteRuntimeQualification(manifest).classify(facts)
+
+        assert result.state is QualificationState.UNQUALIFIED_UNKNOWN
+        assert result.reason_code == "runtime_facts_malformed"
+
+    @pytest.mark.parametrize(
+        ("field", "value"),
+        [
+            ("python_implementation", "PyPy"),
+            ("python_version", "bogus"),
+            ("python_abi", "bogus"),
+            ("python_gil_mode", "unknown"),
+        ],
+    )
+    def test_malformed_python_runtime_domains_fail_closed(
+        self,
+        field,
+        value,
+    ):
+        qualification = SQLiteRuntimeQualification(
+            active_upstream_manifest()
+        )
+        facts = replace(qualified_runtime_facts(), **{field: value})
+
+        result = qualification.classify(facts)
+
+        assert result.state is QualificationState.UNQUALIFIED_UNKNOWN
+        assert result.reason_code == "runtime_facts_malformed"
+
+    def test_wrapper_and_distribution_version_disagreement_is_rejected(self):
+        qualification = SQLiteRuntimeQualification(active_upstream_manifest())
+        facts = replace(
+            qualified_runtime_facts(),
+            binding_wrapper_version="3.53.4.1",
+        )
+
+        result = qualification.classify(facts)
+
+        assert result.state is QualificationState.UNQUALIFIED_UNKNOWN
+        assert result.reason_code == "wrapper_version_unapproved"
+
+    def test_unapproved_platform_architecture_is_rejected(self):
+        qualification = SQLiteRuntimeQualification(active_upstream_manifest())
+        facts = replace(qualified_runtime_facts(), architecture="x86_64")
+
+        result = qualification.classify(facts)
+
+        assert result.state is QualificationState.UNQUALIFIED_UNKNOWN
+        assert result.reason_code == "platform_unapproved"
+
+    def test_qualification_does_not_transfer_between_python_cells(self):
+        qualification = SQLiteRuntimeQualification(active_upstream_manifest())
+        facts = replace(
+            qualified_runtime_facts(),
+            python_version="3.10.11",
+            python_abi="cpython-310-darwin",
+        )
+
+        result = qualification.classify(facts)
+
+        assert result.state is QualificationState.UNQUALIFIED_UNKNOWN
+        assert result.reason_code == "python_runtime_unapproved"
+
+
+class TestQualificationManifest:
+    def test_manifest_without_a_versioned_contract_is_rejected(self):
+        manifest = deepcopy(active_upstream_manifest())
+        del manifest["schema_version"]
+
+        with pytest.raises(
+            QualificationManifestError,
+            match="sqlite_runtime_manifest_invalid",
+        ):
+            SQLiteRuntimeQualification(manifest)
+
+    def test_revoked_manifest_entry_requires_revocation_data(self):
+        manifest = deepcopy(active_upstream_manifest())
+        manifest["entries"][0]["status"] = "revoked"
+
+        with pytest.raises(
+            QualificationManifestError,
+            match="sqlite_runtime_manifest_invalid",
+        ):
+            SQLiteRuntimeQualification(manifest)
+
+    def test_manifest_evidence_identities_are_unique(self):
+        manifest = deepcopy(active_upstream_manifest())
+        second_entry = deepcopy(manifest["entries"][0])
+        second_entry["selectors"]["platform"]["architecture"] = "x86_64"
+        second_entry["artifact"]["filename"] = "synthetic-second-wheel.whl"
+        second_entry["artifact"]["sha256"] = "d" * 64
+        manifest["entries"].append(second_entry)
+
+        with pytest.raises(
+            QualificationManifestError,
+            match="sqlite_runtime_manifest_invalid:unique:evidence_id",
+        ):
+            SQLiteRuntimeQualification(manifest)
+
+    def test_manifest_selector_tuples_are_unambiguous(self):
+        manifest = deepcopy(active_upstream_manifest())
+        second_entry = deepcopy(manifest["entries"][0])
+        second_entry["evidence_id"] = "apsw/3.53.4.0/second-test-wheel"
+        second_entry["artifact"]["filename"] = "synthetic-second-wheel.whl"
+        second_entry["artifact"]["sha256"] = "d" * 64
+        manifest["entries"].append(second_entry)
+
+        with pytest.raises(
+            QualificationManifestError,
+            match="sqlite_runtime_manifest_invalid:unique:selectors",
+        ):
+            SQLiteRuntimeQualification(manifest)
+
+    def test_manifest_rejects_path_shaped_diagnostic_evidence_identity(self):
+        manifest = deepcopy(active_upstream_manifest())
+        manifest["entries"][0]["evidence_id"] = (
+            "/Users/example/private/apsw-wheel"
+        )
+
+        with pytest.raises(
+            QualificationManifestError,
+            match="sqlite_runtime_manifest_invalid",
+        ):
+            SQLiteRuntimeQualification(manifest)
+
+    def test_manifest_can_record_complete_artifact_and_lifecycle_evidence(self):
+        manifest = deepcopy(active_upstream_manifest())
+        entry = manifest["entries"][0]
+        entry["artifact"] = {
+            "vendor": "PyPI",
+            "filename": "apsw-3.53.4.0-cp314-cp314-macosx.whl",
+            "download_url": "https://files.example.test/apsw-test-wheel.whl",
+            "size_bytes": 123456,
+            "sha256": "c" * 64,
+            "platform_tag": "cp314-cp314-macosx_15_0_arm64",
+            "publisher": {
+                "identity": "synthetic-publisher",
+                "provenance_url": (
+                    "https://pypi.example/attestation/test-wheel"
+                ),
+            },
+            "build": {
+                "source_repository_url": "https://example.test/apsw/source",
+                "source_commit": "e" * 40,
+                "workflow_url": "https://ci.example/run/1",
+                "runner_image": {
+                    "label": "macos-15",
+                    "version": "20260815.1",
+                    "manifest_url": "https://runner.example/macos-15",
+                },
+            },
+        }
+        entry["supersedes_evidence_id"] = None
+        entry["status_evidence_id"] = None
+
+        result = SQLiteRuntimeQualification(manifest).classify(
+            qualified_runtime_facts()
+        )
+
+        assert result.state is QualificationState.QUALIFIED_UPSTREAM
+
+    @pytest.mark.parametrize(
+        (
+            "os_name",
+            "os_version",
+            "kernel_release",
+            "product_type",
+            "architecture",
+            "runner_label",
+        ),
+        [
+            (
+                "Ubuntu",
+                "24.04",
+                "6.8.0-40-generic",
+                "not_applicable",
+                "x86_64",
+                "ubuntu-24.04",
+            ),
+            (
+                "macOS",
+                "15.6.1",
+                "24.6.0",
+                "not_applicable",
+                "arm64",
+                "macos-15",
+            ),
+            (
+                "Windows",
+                "10.0.26100",
+                "10.0.26100",
+                "server",
+                "AMD64",
+                "windows-2025",
+            ),
+        ],
+    )
+    def test_manifest_distinguishes_claimed_native_os_cells(
+        self,
+        os_name,
+        os_version,
+        kernel_release,
+        product_type,
+        architecture,
+        runner_label,
+    ):
+        manifest = deepcopy(active_upstream_manifest())
+        entry = manifest["entries"][0]
+        entry["selectors"]["platform"] = {
+            "os": os_name,
+            "version": os_version,
+            "kernel_release": kernel_release,
+            "product_type": product_type,
+            "architecture": architecture,
+        }
+        entry["artifact"]["filename"] = f"synthetic-{runner_label}.whl"
+        entry["artifact"]["platform_tag"] = runner_label
+        entry["artifact"]["build"]["runner_image"] = {
+            "label": runner_label,
+            "version": "20260815.1",
+            "manifest_url": f"https://runner.example/{runner_label}",
+        }
+        facts = replace(
+            qualified_runtime_facts(),
+            os_name=os_name,
+            os_version=os_version,
+            os_kernel_release=kernel_release,
+            os_product_type=product_type,
+            architecture=architecture,
+        )
+
+        result = SQLiteRuntimeQualification(manifest).classify(facts)
+
+        assert result.state is QualificationState.QUALIFIED_UPSTREAM
+
+    def test_manifest_rejects_malformed_lifecycle_timestamp(self):
+        manifest = deepcopy(active_upstream_manifest())
+        manifest["entries"][0]["activated_at_utc"] = "later"
+
+        with pytest.raises(
+            QualificationManifestError,
+            match="sqlite_runtime_manifest_invalid",
+        ):
+            SQLiteRuntimeQualification(manifest)
+
+    def test_packaged_policy_qualifies_no_artifact_before_issue_167(self):
+        qualification = SQLiteRuntimeQualification.packaged()
+
+        result = qualification.classify(qualified_runtime_facts())
+
+        assert result.state is QualificationState.UNQUALIFIED_UNKNOWN
+        assert result.reason_code == "evidence_unlisted"
+
+
+class TestApswRuntimeProbe:
+    def test_probe_interrogates_the_selected_binding_without_returning_its_path(
+        self,
+        monkeypatch,
+        tmp_path,
+    ):
+        extension_path = configure_synthetic_probe(monkeypatch, tmp_path)
+
+        facts = probe_apsw_runtime()
+
+        assert facts == RuntimeFacts(
+            binding_distribution="apsw",
+            binding_distribution_version="3.53.4.0",
+            binding_wrapper_version="3.53.4.0",
+            binding_extension_sha256=(
+                "dda3dd1718606f115a90df359bd0993d674ef383eb995a52a995dc6f86641c26"
+            ),
+            sqlite_version="3.53.4",
+            sqlite_version_number=3053004,
+            sqlite_source_id=SQLITE_3534_SOURCE_ID,
+            sqlite_compile_options_sha256=(
+                "e6bdc0de01d63b4910162c1847d37db5af394866c14ee461b1ce83920bf4ffd4"
+            ),
+            using_amalgamation=True,
+            python_implementation="CPython",
+            python_version="3.10.11",
+            python_abi="cpython-310-darwin",
+            python_gil_mode="gil",
+            os_name="macOS",
+            os_version="15.6.1",
+            os_kernel_release="24.6.0",
+            os_product_type="not_applicable",
+            architecture="arm64",
+        )
+        assert facts.sqlite_version_number == 3053004
+        assert str(extension_path) not in repr(facts)
+
+    def test_probe_records_python_314_free_threaded_runtime(
+        self,
+        monkeypatch,
+        tmp_path,
+    ):
+        configure_synthetic_probe(
+            monkeypatch,
+            tmp_path,
+            python_version=(3, 14, 7),
+            python_abi="cpython-314t-darwin",
+            gil_enabled=False,
+        )
+
+        facts = probe_apsw_runtime()
+
+        assert facts.python_version == "3.14.7"
+        assert facts.python_abi == "cpython-314t-darwin"
+        assert facts.python_gil_mode == "free-threaded"
+
+    def test_probe_separates_product_os_version_from_kernel_release(
+        self,
+        monkeypatch,
+        tmp_path,
+    ):
+        configure_synthetic_probe(monkeypatch, tmp_path)
+
+        facts = probe_apsw_runtime()
+
+        assert facts.os_name == "macOS"
+        assert facts.os_version == "15.6.1"
+        assert facts.os_kernel_release == "24.6.0"
+        assert facts.os_product_type == "not_applicable"
+
+    @pytest.mark.parametrize(
+        ("python_version", "python_abi", "release_label"),
+        [
+            ((3, 10, 11), "cp310-win_amd64", "10"),
+            ((3, 14, 7), "cp314-win_amd64", "2025Server"),
+        ],
+    )
+    def test_windows_2025_numeric_build_is_exactly_qualified(
+        self,
+        monkeypatch,
+        tmp_path,
+        python_version,
+        python_abi,
+        release_label,
+    ):
+        configure_synthetic_probe(
+            monkeypatch,
+            tmp_path,
+            python_version=python_version,
+            python_abi=python_abi,
+            windows_product_type=3,
+        )
+        monkeypatch.setattr(
+            "djsupport.operational_store.apsw.platform.system",
+            lambda: "Windows",
+        )
+        monkeypatch.setattr(
+            "djsupport.operational_store.apsw.platform.win32_ver",
+            lambda: (
+                release_label,
+                "10.0.26100",
+                "",
+                "Multiprocessor Free",
+            ),
+        )
+        monkeypatch.setattr(
+            "djsupport.operational_store.apsw.platform.release",
+            lambda: release_label,
+        )
+        monkeypatch.setattr(
+            "djsupport.operational_store.apsw.platform.machine",
+            lambda: "AMD64",
+        )
+        manifest = deepcopy(active_upstream_manifest())
+        entry = manifest["entries"][0]
+        entry["selectors"]["python"] = {
+            "implementation": "CPython",
+            "version": ".".join(str(part) for part in python_version),
+            "abi": python_abi,
+            "gil_mode": "gil",
+        }
+        entry["selectors"]["platform"] = {
+            "os": "Windows",
+            "version": "10.0.26100",
+            "kernel_release": release_label,
+            "product_type": "server",
+            "architecture": "AMD64",
+        }
+        entry["artifact"]["platform_tag"] = python_abi
+        entry["artifact"]["build"]["runner_image"] = {
+            "label": "windows-2025",
+            "version": "20260815.1",
+            "manifest_url": "https://runner.example/windows-2025",
+        }
+        entry["selectors"]["binding"]["extension_sha256"] = (
+            "dda3dd1718606f115a90df359bd0993d674ef383eb995a52a995dc6f86641c26"
+        )
+        entry["selectors"]["sqlite"]["compile_options_sha256"] = (
+            "e6bdc0de01d63b4910162c1847d37db5af394866c14ee461b1ce83920bf4ffd4"
+        )
+
+        facts = probe_apsw_runtime()
+        result = SQLiteRuntimeQualification(manifest).classify(facts)
+        near_miss = SQLiteRuntimeQualification(manifest).classify(
+            replace(facts, os_version="10.0.19045")
+        )
+        same_build_workstation = SQLiteRuntimeQualification(
+            manifest
+        ).classify(replace(facts, os_product_type="workstation"))
+
+        assert facts.os_version == "10.0.26100"
+        assert facts.os_product_type == "server"
+        assert result.state is QualificationState.QUALIFIED_UPSTREAM
+        assert near_miss.state is QualificationState.UNQUALIFIED_UNKNOWN
+        assert near_miss.reason_code == "platform_unapproved"
+        assert same_build_workstation.state is (
+            QualificationState.UNQUALIFIED_UNKNOWN
+        )
+        assert same_build_workstation.reason_code == "platform_unapproved"
+
+    def test_unavailable_binding_fails_closed_without_echoing_import_details(
+        self,
+        monkeypatch,
+    ):
+        private_value = "/Users/example/private/apsw.so"
+
+        def unavailable(name):
+            raise ModuleNotFoundError(private_value)
+
+        monkeypatch.setattr(
+            "djsupport.operational_store.apsw.import_module",
+            unavailable,
+        )
+        qualification = SQLiteRuntimeQualification.packaged()
+
+        result = qualification.classify_installed()
+
+        assert result.state is QualificationState.UNQUALIFIED_UNKNOWN
+        assert result.reason_code == "binding_unavailable"
+        assert private_value not in repr(result.diagnostic)
+
+    def test_probe_exception_does_not_chain_private_import_details(
+        self,
+        monkeypatch,
+    ):
+        private_value = "/Users/example/private/apsw.so"
+
+        def unavailable(name):
+            raise ModuleNotFoundError(private_value)
+
+        monkeypatch.setattr(
+            "djsupport.operational_store.apsw.import_module",
+            unavailable,
+        )
+
+        with pytest.raises(RuntimeProbeError) as caught:
+            probe_apsw_runtime()
+
+        assert private_value not in str(caught.value)
+        assert caught.value.__cause__ is None
+
+    def test_incomplete_binding_installation_fails_closed(
+        self,
+        monkeypatch,
+        tmp_path,
+    ):
+        configure_synthetic_probe(monkeypatch, tmp_path)
+        private_value = "/Users/example/private/site-packages"
+
+        def unavailable(name):
+            raise ModuleNotFoundError(private_value)
+
+        monkeypatch.setattr(
+            "djsupport.operational_store.apsw.distribution_version",
+            unavailable,
+        )
+
+        result = SQLiteRuntimeQualification.packaged().classify_installed()
+
+        assert result.state is QualificationState.UNQUALIFIED_UNKNOWN
+        assert result.reason_code == "runtime_facts_unavailable"
+        assert private_value not in repr(result.diagnostic)
+
+
+class TestRuntimeGate:
+    def test_rejected_runtime_stops_before_a_store_path_is_created(
+        self,
+        monkeypatch,
+        tmp_path,
+    ):
+        private_path = tmp_path / "operational-store.sqlite3"
+        facts = replace(
+            qualified_runtime_facts(),
+            binding_extension_sha256="d" * 64,
+        )
+        monkeypatch.setattr(
+            "djsupport.operational_store.apsw.probe_apsw_runtime",
+            lambda: facts,
+        )
+        qualification = SQLiteRuntimeQualification(active_upstream_manifest())
+
+        with pytest.raises(
+            SQLiteRuntimeUnavailable,
+            match="binding_artifact_unapproved",
+        ):
+            qualification.run_qualified(
+                lambda evidence: private_path.touch(),
+            )
+
+        assert not private_path.exists()
+
+    def test_exactly_qualified_runtime_can_enter_the_store_operation(
+        self,
+        monkeypatch,
+    ):
+        monkeypatch.setattr(
+            "djsupport.operational_store.apsw.probe_apsw_runtime",
+            qualified_runtime_facts,
+        )
+        qualification = SQLiteRuntimeQualification(active_upstream_manifest())
+
+        evidence_id = qualification.run_qualified(
+            lambda evidence: evidence.evidence_id,
+        )
+
+        assert evidence_id == "apsw/3.53.4.0/test-wheel"
+
+
+class TestBindingArchitecture:
+    def test_operational_store_has_one_direct_sqlite_binding_import(self):
+        repository_root = Path(__file__).parents[1]
+        package_root = repository_root / "djsupport" / "operational_store"
+        apsw_importers = set()
+        sqlite3_importers = set()
+
+        for path in package_root.rglob("*.py"):
+            relative_path = path.relative_to(repository_root).as_posix()
+            tree = ast.parse(path.read_text(encoding="utf-8"))
+            for node in ast.walk(tree):
+                if isinstance(node, ast.Import):
+                    for alias in node.names:
+                        if alias.name == "apsw":
+                            apsw_importers.add(relative_path)
+                        if alias.name == "sqlite3":
+                            sqlite3_importers.add(relative_path)
+                if isinstance(node, ast.ImportFrom):
+                    if node.module == "apsw":
+                        apsw_importers.add(relative_path)
+                    if node.module == "sqlite3":
+                        sqlite3_importers.add(relative_path)
+                if (
+                    isinstance(node, ast.Call)
+                    and isinstance(node.func, ast.Name)
+                    and node.func.id == "import_module"
+                    and node.args
+                    and isinstance(node.args[0], ast.Constant)
+                    and node.args[0].value == "apsw"
+                ):
+                    apsw_importers.add(relative_path)
+
+        assert apsw_importers == {"djsupport/operational_store/apsw.py"}
+        assert not sqlite3_importers


### PR DESCRIPTION
## What changed

- add a versioned, packaged SQLite runtime qualification schema and fail-closed policy manifest
- require complete artifact filename, URL, size, platform, publisher, build, and lifecycle evidence before an admission entry is valid
- classify exact upstream and downstream evidence into five typed states with stable, path-free reasons
- collect APSW wrapper, SQLite source/version/compile, native-extension, Python, OS, and architecture facts without returning filesystem paths
- distinguish product OS versions from kernel releases and retain exact runner-image evidence for #167's native matrix
- require qualification before any future Operational Store operation callback can resolve or create a private path
- enforce one direct APSW import location and no standard-library `sqlite3` import in the Operational Store package

## Why

#166 blocks every SQLite-backed Operational Store step. A version floor cannot prove the WAL-reset fix, and SQLite 3.52.0 is withdrawn despite being numerically newer. Exact reviewed evidence must admit a runtime before any store mutation is possible.

The shipped policy intentionally has no active artifact entries. #167 owns the APSW dependency, wheel/provenance evidence, native matrix, credits, and first admitted entries.

## Boundaries

This change does not add APSW as a dependency, create or open a database, enable WAL, migrate state, switch production authority from JSON, access owner data, call a live provider, create a tag or GitHub Release, or publish a package.

## Checks

- focused runtime/release/privacy/package-contract tests — 113 passed
- full offline suite — 844 passed
- compilation and release-record checker — passed
- local wheel and source archive build plus clean-wheel import — passed; both qualification JSON contracts present
- Standards review — zero findings
- Spec review — zero findings

Closes #166
