### PR TITLE
Add publication-free candidate qualification harness

### DIFF
--- a/.github/workflows/candidate-qualification.yml
+++ b/.github/workflows/candidate-qualification.yml
@@ -17,11 +17,11 @@ name: Candidate qualification
   workflow_dispatch:
     inputs:
       expected_product_commit:
-        description: Full merged product commit to qualify
+        description: Full product commit matching the selected workflow ref
         required: true
         type: string
       documentation_commit:
-        description: Full merged djsupport-docs commit to validate
+        description: Full current djsupport-docs main commit to validate
         required: true
         type: string
       expected_version:
@@ -79,11 +79,17 @@ jobs:
       source-date-epoch: ${{ steps.plan.outputs.source-date-epoch }}
       wheel-sha256: ${{ steps.plan.outputs.wheel-sha256 }}
     steps:
-      - name: Check out the exact candidate source
+      - name: Check out workflow product source
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
-          ref: ${{ inputs.expected_product_commit }}
+          ref: ${{ github.sha }}
           persist-credentials: false
+      - name: Require exact product workflow commit
+        env:
+          EXPECTED_PRODUCT_COMMIT: ${{ inputs.expected_product_commit }}
+          WORKFLOW_PRODUCT_COMMIT: ${{ github.sha }}
+        shell: bash
+        run: test "$EXPECTED_PRODUCT_COMMIT" = "$WORKFLOW_PRODUCT_COMMIT"
       - name: Set up canonical build Python
         uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97
         with:
@@ -133,11 +139,17 @@ jobs:
       fail-fast: false
       matrix: ${{ fromJSON(needs.plan.outputs.matrix) }}
     steps:
-      - name: Check out the exact candidate source
+      - name: Check out workflow product source
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
-          ref: ${{ inputs.expected_product_commit }}
+          ref: ${{ github.sha }}
           persist-credentials: false
+      - name: Require exact product workflow commit
+        env:
+          EXPECTED_PRODUCT_COMMIT: ${{ inputs.expected_product_commit }}
+          WORKFLOW_PRODUCT_COMMIT: ${{ github.sha }}
+        shell: bash
+        run: test "$EXPECTED_PRODUCT_COMMIT" = "$WORKFLOW_PRODUCT_COMMIT"
       - name: Set up exact native Python
         uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97
         with:
@@ -159,6 +171,7 @@ jobs:
           EXPECTED_VERSION: ${{ inputs.expected_version }}
           SOURCE_DATE_EPOCH: ${{ needs.plan.outputs.source-date-epoch }}
           EXPECTED_WHEEL_SHA256: ${{ needs.plan.outputs.wheel-sha256 }}
+        shell: bash
         run: >-
           python scripts/candidate_qualification.py rebuild-wheel
           --expected-commit "$EXPECTED_COMMIT"
@@ -185,19 +198,31 @@ jobs:
     runs-on: ubuntu-24.04
     timeout-minutes: 20
     steps:
-      - name: Check out exact product source
+      - name: Check out workflow product source
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
-          ref: ${{ inputs.expected_product_commit }}
+          ref: ${{ github.sha }}
           path: product
           persist-credentials: false
-      - name: Check out exact documentation source
+      - name: Require exact product workflow commit
+        env:
+          EXPECTED_PRODUCT_COMMIT: ${{ inputs.expected_product_commit }}
+          WORKFLOW_PRODUCT_COMMIT: ${{ github.sha }}
+        shell: bash
+        run: test "$EXPECTED_PRODUCT_COMMIT" = "$WORKFLOW_PRODUCT_COMMIT"
+      - name: Check out canonical documentation source
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           repository: spontain112/djsupport-docs
-          ref: ${{ inputs.documentation_commit }}
+          ref: main
           path: documentation
           persist-credentials: false
+      - name: Require exact documentation commit
+        working-directory: documentation
+        env:
+          EXPECTED_DOCUMENTATION_COMMIT: ${{ inputs.documentation_commit }}
+        shell: bash
+        run: test "$(git rev-parse HEAD)" = "$EXPECTED_DOCUMENTATION_COMMIT"
       - name: Set up documentation Node
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
         with:
@@ -243,11 +268,17 @@ jobs:
     runs-on: ubuntu-24.04
     timeout-minutes: 10
     steps:
-      - name: Check out exact product source
+      - name: Check out workflow product source
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
-          ref: ${{ inputs.expected_product_commit }}
+          ref: ${{ github.sha }}
           persist-credentials: false
+      - name: Require exact product workflow commit
+        env:
+          EXPECTED_PRODUCT_COMMIT: ${{ inputs.expected_product_commit }}
+          WORKFLOW_PRODUCT_COMMIT: ${{ github.sha }}
+        shell: bash
+        run: test "$EXPECTED_PRODUCT_COMMIT" = "$WORKFLOW_PRODUCT_COMMIT"
       - name: Set up evidence Python
         uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97
         with:

--- a/.github/workflows/candidate-qualification.yml
+++ b/.github/workflows/candidate-qualification.yml
@@ -1,0 +1,293 @@
+name: Candidate qualification
+
+'on':
+  pull_request:
+    paths:
+      - ".github/workflows/candidate-qualification.yml"
+      - ".github/workflows/sqlite-runtime.yml"
+      - "CHANGELOG.md"
+      - "djsupport/contracts/apsw-runtime-artifacts.v1.json"
+      - "djsupport/contracts/sqlite-runtime-qualification.v1.json"
+      - "pyproject.toml"
+      - "scripts/candidate_qualification.py"
+      - "scripts/contracts/candidate-qualification-*.json"
+      - "scripts/sqlite_runtime_delivery.py"
+      - "tests/test_candidate_qualification.py"
+      - "tests/test_sqlite_runtime_delivery.py"
+  workflow_dispatch:
+    inputs:
+      expected_product_commit:
+        description: Full merged product commit to qualify
+        required: true
+        type: string
+      documentation_commit:
+        description: Full merged djsupport-docs commit to validate
+        required: true
+        type: string
+      expected_version:
+        description: Exact candidate package version
+        required: true
+        type: string
+      changelog_identity:
+        description: Exact candidate changelog heading
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  contract:
+    name: Contract
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+    steps:
+      - name: Check out qualification source
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          persist-credentials: false
+      - name: Set up contract Python
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97
+        with:
+          python-version: "3.12.14"
+          architecture: x64
+      - name: Install pinned contract tools
+        run: >-
+          python -m pip install
+          "jsonschema==4.26.0"
+          "pytest==8.4.1"
+          "PyYAML==6.0.2"
+      - name: Prove the synthetic non-release contract
+        run: >-
+          python -m pytest
+          tests/test_candidate_qualification.py
+          tests/test_sqlite_runtime_delivery.py
+
+  plan:
+    name: Plan
+    if: github.event_name == 'workflow_dispatch'
+    needs: contract
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+    outputs:
+      matrix: ${{ steps.plan.outputs.matrix }}
+      preparation: ${{ steps.plan.outputs.preparation }}
+      source-date-epoch: ${{ steps.plan.outputs.source-date-epoch }}
+      wheel-sha256: ${{ steps.plan.outputs.wheel-sha256 }}
+    steps:
+      - name: Check out the exact candidate source
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          ref: ${{ inputs.expected_product_commit }}
+          persist-credentials: false
+      - name: Set up canonical build Python
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97
+        with:
+          python-version: "3.14.7"
+          architecture: x64
+      - name: Install pinned build and verification tools
+        run: >-
+          python -m pip install
+          "build==1.3.0"
+          "certifi==2026.7.22"
+          "jsonschema==4.26.0"
+          "pypi-attestations==0.0.30"
+          "setuptools==80.9.0"
+          "wheel==0.45.1"
+      - name: Install the exact checkout for offline validation
+        run: python -m pip install --only-binary=apsw ".[dev,web]"
+      - name: Run complete offline and privacy checks
+        run: |
+          python -m pytest
+          python -m compileall -q djsupport tests
+          python -m pytest tests/test_repository_privacy.py
+      - name: Build, inspect, and bind the exact source
+        id: plan
+        env:
+          EXPECTED_COMMIT: ${{ inputs.expected_product_commit }}
+          EXPECTED_VERSION: ${{ inputs.expected_version }}
+          CHANGELOG_IDENTITY: ${{ inputs.changelog_identity }}
+        run: |
+          source_epoch="$(git show -s --format=%ct HEAD)"
+          matrix="$(python scripts/candidate_qualification.py matrix)"
+          preparation="$(python scripts/candidate_qualification.py prepare --expected-commit "$EXPECTED_COMMIT" --expected-version "$EXPECTED_VERSION" --changelog-identity "$CHANGELOG_IDENTITY" --source-date-epoch "$source_epoch" --output-dir "$RUNNER_TEMP/candidate-dist")"
+          wheel_sha256="$(python -c 'import json,sys; print(json.loads(sys.argv[1])["archives"]["wheel"]["sha256"])' "$preparation")"
+          echo "matrix=$matrix" >> "$GITHUB_OUTPUT"
+          echo "preparation=$preparation" >> "$GITHUB_OUTPUT"
+          echo "source-date-epoch=$source_epoch" >> "$GITHUB_OUTPUT"
+          echo "wheel-sha256=$wheel_sha256" >> "$GITHUB_OUTPUT"
+
+  qualify:
+    if: github.event_name == 'workflow_dispatch'
+    needs: plan
+    name: >-
+      Qualify ${{ matrix.runner }} / Python ${{ matrix.python-version }} /
+      ${{ matrix.architecture }}
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: 35
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJSON(needs.plan.outputs.matrix) }}
+    steps:
+      - name: Check out the exact candidate source
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          ref: ${{ inputs.expected_product_commit }}
+          persist-credentials: false
+      - name: Set up exact native Python
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97
+        with:
+          python-version: ${{ matrix.python-version }}
+          architecture: ${{ matrix.setup-architecture }}
+      - name: Install pinned native qualification tools
+        run: >-
+          python -m pip install
+          "build==1.3.0"
+          "certifi==2026.7.22"
+          "jsonschema==4.26.0"
+          "pypi-attestations==0.0.30"
+          "setuptools==80.9.0"
+          "wheel==0.45.1"
+      - name: Require the canonical pure-Python wheel digest
+        env:
+          CHANGELOG_IDENTITY: ${{ inputs.changelog_identity }}
+          EXPECTED_COMMIT: ${{ inputs.expected_product_commit }}
+          EXPECTED_VERSION: ${{ inputs.expected_version }}
+          SOURCE_DATE_EPOCH: ${{ needs.plan.outputs.source-date-epoch }}
+          EXPECTED_WHEEL_SHA256: ${{ needs.plan.outputs.wheel-sha256 }}
+        run: >-
+          python scripts/candidate_qualification.py rebuild-wheel
+          --expected-commit "$EXPECTED_COMMIT"
+          --expected-version "$EXPECTED_VERSION"
+          --changelog-identity "$CHANGELOG_IDENTITY"
+          --source-date-epoch "$SOURCE_DATE_EPOCH"
+          --expected-sha256 "$EXPECTED_WHEEL_SHA256"
+          --output-dir "$RUNNER_TEMP/candidate-rebuild"
+      - name: Reuse exact APSW artifact and loaded-runtime qualification
+        env:
+          DJ_SUPPORT_EXPECTED_WHEEL_SHA256: ${{ needs.plan.outputs.wheel-sha256 }}
+          DJ_SUPPORT_RUNNER_LABEL: ${{ matrix.runner }}
+        run: python scripts/sqlite_runtime_delivery.py verify
+      - name: Exercise the installed synthetic scenario seam
+        run: >-
+          python scripts/candidate_qualification.py synthetic-scenarios
+          --platform "${{ matrix.platform }}"
+          --python-version "${{ matrix.python-version }}"
+
+  documentation:
+    name: Documentation
+    if: github.event_name == 'workflow_dispatch'
+    needs: plan
+    runs-on: ubuntu-24.04
+    timeout-minutes: 20
+    steps:
+      - name: Check out exact product source
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          ref: ${{ inputs.expected_product_commit }}
+          path: product
+          persist-credentials: false
+      - name: Check out exact documentation source
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          repository: spontain112/djsupport-docs
+          ref: ${{ inputs.documentation_commit }}
+          path: documentation
+          persist-credentials: false
+      - name: Set up documentation Node
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
+        with:
+          node-version: "22.23.1"
+      - name: Set up documentation Python
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97
+        with:
+          python-version: "3.12.14"
+          architecture: x64
+      - name: Install pinned documentation tools
+        working-directory: documentation
+        run: npm install --global mint@4.2.804
+      - name: Test documentation contract
+        working-directory: documentation
+        run: python -m unittest discover -s tests -p 'test_*.py'
+      - name: Check exact product contract
+        working-directory: documentation
+        run: python scripts/check_product_contract.py --product-repo ../product
+      - name: Validate documentation site
+        working-directory: documentation
+        run: mint validate
+      - name: Check documentation links and redirects
+        working-directory: documentation
+        run: mint broken-links --check-anchors --check-redirects
+      - name: Check documentation accessibility
+        working-directory: documentation
+        run: mint a11y
+
+  finalize:
+    name: Finalize
+    if: >-
+      always() &&
+      github.event_name == 'workflow_dispatch' &&
+      needs.contract.result == 'success' &&
+      needs.plan.result == 'success' &&
+      needs.qualify.result == 'success' &&
+      needs.documentation.result == 'success'
+    needs:
+      - contract
+      - plan
+      - qualify
+      - documentation
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    steps:
+      - name: Check out exact product source
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          ref: ${{ inputs.expected_product_commit }}
+          persist-credentials: false
+      - name: Set up evidence Python
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97
+        with:
+          python-version: "3.12.14"
+          architecture: x64
+      - name: Install pinned evidence validator
+        run: >-
+          python -m pip install
+          "certifi==2026.7.22"
+          "jsonschema==4.26.0"
+      - name: Materialize path-free preparation facts
+        env:
+          PREPARATION: ${{ needs.plan.outputs.preparation }}
+        run: >-
+          python -c
+          'import os,pathlib;
+          pathlib.Path(os.environ["RUNNER_TEMP"], "candidate-preparation.json").write_text(os.environ["PREPARATION"], encoding="utf-8")'
+      - name: Observe completed public workflow jobs
+        env:
+          REPOSITORY: ${{ github.repository }}
+          RUN_ID: ${{ github.run_id }}
+        run: >-
+          python scripts/candidate_qualification.py observe-run
+          --repository "$REPOSITORY"
+          --run-id "$RUN_ID"
+          > "$RUNNER_TEMP/candidate-run-jobs.json"
+      - name: Emit the one schema-validated evidence document
+        env:
+          DOCUMENTATION_COMMIT: ${{ inputs.documentation_commit }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: >-
+          python scripts/candidate_qualification.py finalize
+          --preparation "$RUNNER_TEMP/candidate-preparation.json"
+          --run-jobs "$RUNNER_TEMP/candidate-run-jobs.json"
+          --qualification-kind synthetic_non_release
+          --scenario-evidence-kind synthetic_contract
+          --documentation-commit "$DOCUMENTATION_COMMIT"
+          --repository "${{ github.repository }}"
+          --run-id "${{ github.run_id }}"
+          --run-url "$RUN_URL"
+          --action actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+          --action actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97
+          --action actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020

--- a/.github/workflows/sqlite-runtime.yml
+++ b/.github/workflows/sqlite-runtime.yml
@@ -158,6 +158,8 @@ jobs:
           "certifi==2026.7.22"
           "jsonschema==4.26.0"
           "pypi-attestations==0.0.30"
+          "setuptools==80.9.0"
+          "wheel==0.45.1"
       - name: Verify binary provenance and loaded-runtime admission
         env:
           DJ_SUPPORT_RUNNER_LABEL: ${{ matrix.runner }}

--- a/.release-notes/candidate-qualification.md
+++ b/.release-notes/candidate-qualification.md
@@ -1,0 +1,7 @@
+---
+bump: minor
+section: Added
+---
+
+Add a read-only, publication-free candidate qualification workflow that binds
+exact source, package, native APSW, documentation, and synthetic check evidence.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -49,7 +49,9 @@ djsupport/
   local_audio.py Optional local-only Chromaprint boundary
   local_audition.py Process-local, path-redacted selected-media boundary
 tests/           Offline behavior, adapter, migration, privacy, and package tests
+scripts/candidate_qualification.py Publication-free candidate evidence gate
 scripts/sqlite_runtime_delivery.py Binary-only clean-install/provenance gate
+scripts/contracts/ Versioned release-tooling input and evidence contracts
 docs/adr/        Architecture decisions
 docs/plans/      Product roadmap and retained implementation history
 docs/research/   Durable research findings

--- a/README.md
+++ b/README.md
@@ -423,11 +423,11 @@ is `$XDG_DATA_HOME/djsupport` or `~/.local/share/djsupport`.
 - [Maintainer release checklist](docs/releasing.md)
 - [Changelog](CHANGELOG.md)
 - [Security policy](SECURITY.md)
-- [Open-source acknowledgements](THIRD_PARTY.md)
+- [Third-party acknowledgements](THIRD_PARTY.md)
 - [Contributing](CONTRIBUTING.md)
 
 ## License and acknowledgements
 
 DJ Support is available under the [MIT License](LICENSE). It is built with
-open-source projects maintained by people and communities we gratefully credit
-in [Open-source acknowledgements](THIRD_PARTY.md).
+open-source and source-available projects maintained by people and communities
+we gratefully credit in [Third-party acknowledgements](THIRD_PARTY.md).

--- a/THIRD_PARTY.md
+++ b/THIRD_PARTY.md
@@ -1,8 +1,8 @@
-# Open-source acknowledgements
+# Third-party acknowledgements
 
 DJ Support is possible because people maintain and share excellent open-source
-software. Thank you to every author, maintainer, reviewer, documentarian, and
-contributor behind the projects below.
+and source-available software. Thank you to every author, maintainer, reviewer,
+documentarian, and contributor behind the projects below.
 
 This is an acknowledgement and navigation index, not a replacement for the
 projects' license texts. DJ Support does not vendor these projects. Python
@@ -35,6 +35,8 @@ the exact version and complete license material in a particular environment.
 | Project | How DJ Support uses it | License |
 | --- | --- | --- |
 | [Python](https://github.com/python/cpython) | Language and standard library | PSF-2.0 |
+| [Node.js](https://github.com/nodejs/node) | Exact JavaScript runtime for documentation-site checks in candidate qualification | MIT |
+| [npm CLI](https://github.com/npm/cli) | Installs the exact Mint CLI used for documentation-site checks | Artistic-2.0 |
 | [Git](https://github.com/git/git) | Source history and contribution workflow | GPL-2.0-only |
 | [setuptools](https://github.com/pypa/setuptools) | Package build backend | MIT |
 | [wheel](https://github.com/pypa/wheel) | Wheel build format tooling | MIT |
@@ -51,9 +53,11 @@ the exact version and complete license material in a particular environment.
 | --- | --- | --- |
 | [checkout](https://github.com/actions/checkout) | GitHub Actions source checkout | MIT |
 | [setup-python](https://github.com/actions/setup-python) | GitHub Actions Python toolchains | MIT |
+| [setup-node](https://github.com/actions/setup-node) | GitHub Actions Node.js toolchain for exact documentation-site checks | MIT |
 | [CodeQL](https://github.com/github/codeql-action) | Static security analysis for Python and GitHub Actions workflows | MIT |
 | [certifi](https://github.com/certifi/python-certifi) | CA bundle for CI-only PyPI attestation HTTPS verification | MPL-2.0 |
 | [PyPI Attestations](https://github.com/pypi/pypi-attestations) | Pinned CI verifier for APSW wheel Trusted Publisher attestations | Apache-2.0 |
+| [Mint CLI](https://github.com/mintlify/mint) | Exact documentation validation, link, redirect, and accessibility checks for candidate qualification | Elastic-2.0 |
 
 ## Independent external tools
 

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -97,6 +97,26 @@ authorize any tag, GitHub Release, or package publication.
 - [ ] Resolve every validation failure. A skipped or partially run command is not
       a passing release gate.
 
+### Publication-free candidate qualification
+
+Candidate qualification is validation-only. The read-only
+`candidate-qualification.yml` workflow binds an exact product commit, exact
+`djsupport-docs` commit, expected package version, changelog heading, pinned
+build tools, all 25 qualified APSW native cells, reproducible DJ Support wheel
+identity, installed synthetic checks, and documentation validation into one
+path-free evidence document. Finalization consumes the completed public
+workflow job and step observations; missing, failed, or duplicate observations
+fail closed instead of being inferred as passing.
+
+The harness does not add `.release-notes/next-version`, does not consume release
+records, does not change `pyproject.toml`, and does not upload its source archive
+or wheel. A green evidence document is not authority to create a tag, GitHub
+Release, release asset, package upload, advisory publication, live-provider
+call, or owner-data test. The exact final Operational Store scenarios are added
+only after their owning behavior is merged; the checked-in harness proves the
+same versioned interface now with invented, synthetic facts. Synthetic evidence
+is always labelled non-release and cannot qualify a release candidate.
+
 ## 5. Require green CI on the release commit
 
 - [ ] Confirm the exact release commit has green CI for Python 3.10 and 3.14,

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -100,13 +100,15 @@ authorize any tag, GitHub Release, or package publication.
 ### Publication-free candidate qualification
 
 Candidate qualification is validation-only. The read-only
-`candidate-qualification.yml` workflow binds an exact product commit, exact
-`djsupport-docs` commit, expected package version, changelog heading, pinned
-build tools, all 25 qualified APSW native cells, reproducible DJ Support wheel
-identity, installed synthetic checks, and documentation validation into one
-path-free evidence document. Finalization consumes the completed public
-workflow job and step observations; missing, failed, or duplicate observations
-fail closed instead of being inferred as passing.
+`candidate-qualification.yml` workflow binds its selected workflow ref to the
+exact expected product commit, and binds the canonical `djsupport-docs` `main`
+checkout to the exact expected documentation commit. It then binds the expected
+package version, changelog heading, pinned build tools, all 25 qualified APSW
+native cells, reproducible DJ Support wheel identity, installed synthetic
+checks, and documentation validation into one path-free evidence document.
+Dispatch inputs never select executable checkout refs. Finalization consumes
+the completed public workflow job and step observations; missing, failed, or
+duplicate observations fail closed instead of being inferred as passing.
 
 The harness does not add `.release-notes/next-version`, does not consume release
 records, does not change `pyproject.toml`, and does not upload its source archive

--- a/scripts/candidate_qualification.py
+++ b/scripts/candidate_qualification.py
@@ -1,0 +1,1138 @@
+#!/usr/bin/env python3
+"""Qualify an exact DJ Support candidate without publishing artifacts."""
+
+from __future__ import annotations
+
+import argparse
+from collections.abc import Mapping
+import hashlib
+from importlib.metadata import PackageNotFoundError, version as distribution_version
+import json
+import os
+from pathlib import Path
+import re
+import ssl
+import subprocess
+import sys
+import tarfile
+from urllib.error import HTTPError, URLError
+from urllib.request import Request, urlopen
+import zipfile
+
+from jsonschema import Draft202012Validator, FormatChecker
+from jsonschema.exceptions import SchemaError, ValidationError
+
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[1]
+if str(REPOSITORY_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPOSITORY_ROOT))
+QUALIFICATION_CONTRACTS = REPOSITORY_ROOT / "scripts" / "contracts"
+INPUT_SCHEMA_PATH = (
+    QUALIFICATION_CONTRACTS / "candidate-qualification-input.v1.schema.json"
+)
+EVIDENCE_SCHEMA_PATH = (
+    QUALIFICATION_CONTRACTS
+    / "candidate-qualification-evidence.v1.schema.json"
+)
+RUNTIME_CATALOG_PATH = (
+    REPOSITORY_ROOT
+    / "djsupport"
+    / "contracts"
+    / "apsw-runtime-artifacts.v1.json"
+)
+RUNTIME_POLICY_PATH = (
+    REPOSITORY_ROOT
+    / "djsupport"
+    / "contracts"
+    / "sqlite-runtime-qualification.v1.json"
+)
+SCENARIO_ORDER = (
+    "preview",
+    "apply_cutover",
+    "resume",
+    "backup",
+    "restore",
+    "rollback",
+    "diagnostics",
+)
+REQUIRED_SCENARIOS = frozenset(SCENARIO_ORDER)
+REQUIRED_PLATFORMS = frozenset({"Linux", "macOS", "Windows"})
+REQUIRED_CHECKS = frozenset(
+    {
+        "offline_suite",
+        "compilation",
+        "repository_privacy",
+        "archive_inspection",
+        "clean_install",
+    }
+)
+QUALIFICATION_WORKFLOW_NAME = "Candidate qualification"
+PINNED_BUILD_TOOLS = {
+    "build": "1.3.0",
+    "setuptools": "80.9.0",
+    "wheel": "0.45.1",
+}
+CONTRACT_JOB_STEPS = (
+    "Check out qualification source",
+    "Set up contract Python",
+    "Install pinned contract tools",
+    "Prove the synthetic non-release contract",
+)
+PLAN_JOB_STEPS = (
+    "Check out the exact candidate source",
+    "Set up canonical build Python",
+    "Install pinned build and verification tools",
+    "Install the exact checkout for offline validation",
+    "Run complete offline and privacy checks",
+    "Build, inspect, and bind the exact source",
+)
+QUALIFICATION_JOB_STEPS = (
+    "Check out the exact candidate source",
+    "Set up exact native Python",
+    "Install pinned native qualification tools",
+    "Require the canonical pure-Python wheel digest",
+    "Reuse exact APSW artifact and loaded-runtime qualification",
+    "Exercise the installed synthetic scenario seam",
+)
+DOCUMENTATION_JOB_STEPS = (
+    "Check out exact product source",
+    "Check out exact documentation source",
+    "Set up documentation Node",
+    "Set up documentation Python",
+    "Install pinned documentation tools",
+    "Test documentation contract",
+    "Check exact product contract",
+    "Validate documentation site",
+    "Check documentation links and redirects",
+    "Check documentation accessibility",
+)
+WINDOWS_PATH = re.compile(r"^[A-Za-z]:[\\/]")
+
+try:
+    import tomllib
+except ModuleNotFoundError:  # pragma: no cover - exercised on Python 3.10
+    import tomli as tomllib
+
+
+class CandidateQualificationError(ValueError):
+    """A stable, path-free qualification failure."""
+
+
+def candidate_matrix() -> list[dict[str, str]]:
+    """Return the exact qualified native matrix from the reviewed catalogs."""
+
+    catalog = _load_json(RUNTIME_CATALOG_PATH)
+    policy = _load_json(RUNTIME_POLICY_PATH)
+    artifacts = catalog.get("artifacts")
+    entries = policy.get("entries")
+    if not isinstance(artifacts, list) or not isinstance(entries, list):
+        _fail("runtime_contract_mismatch")
+    active_ids = {
+        entry.get("artifact_id")
+        for entry in entries
+        if isinstance(entry, Mapping) and entry.get("status") == "active"
+    }
+    artifact_ids = {
+        artifact.get("artifact_id")
+        for artifact in artifacts
+        if isinstance(artifact, Mapping)
+    }
+    if len(artifact_ids) != len(artifacts) or artifact_ids != active_ids:
+        _fail("runtime_contract_mismatch")
+
+    matrix = []
+    for artifact in artifacts:
+        architecture = artifact.get("architecture")
+        if architecture in {"arm64", "aarch64"}:
+            setup_architecture = "arm64"
+        elif architecture in {"x86_64", "AMD64"}:
+            setup_architecture = "x64"
+        else:
+            _fail("runtime_contract_mismatch")
+        matrix.append(
+            {
+                "runner": artifact["runner_label"],
+                "python-version": artifact["python_version"],
+                "architecture": architecture,
+                "setup-architecture": setup_architecture,
+                "platform": _platform_name(artifact.get("os")),
+            }
+        )
+    return matrix
+
+
+def inspect_distribution(path: Path, kind: str) -> dict[str, object]:
+    """Inspect one built distribution and return public archive facts."""
+
+    from scripts.sqlite_runtime_delivery import _inspect_source, _inspect_wheel
+
+    try:
+        if kind == "wheel":
+            _inspect_wheel(path)
+            with zipfile.ZipFile(path) as archive:
+                member_count = len(archive.infolist())
+        elif kind == "source":
+            _inspect_source(path)
+            with tarfile.open(path, "r:gz") as archive:
+                member_count = len(archive.getmembers())
+        else:
+            _fail("archive_kind")
+    except (OSError, tarfile.TarError, zipfile.BadZipFile):
+        _fail("archive_inspection")
+    except SystemExit as exc:
+        reason = str(exc)
+        if "private_package_member" in reason:
+            _fail("private_archive_member")
+        _fail("archive_inspection")
+    try:
+        size_bytes = path.stat().st_size
+        digest = hashlib.sha256(path.read_bytes()).hexdigest()
+    except OSError:
+        _fail("archive_inspection")
+    if size_bytes < 1 or member_count < 1:
+        _fail("archive_inspection")
+    return {
+        "filename": path.name,
+        "size_bytes": size_bytes,
+        "sha256": digest,
+        "member_count": member_count,
+        "inspection": "passed",
+    }
+
+
+def observe_source(
+    *,
+    expected_commit: str,
+    expected_version: str,
+    changelog_identity: str,
+    source_date_epoch: int,
+    repository_root: Path = REPOSITORY_ROOT,
+) -> dict[str, object]:
+    """Bind qualification to the exact checkout and its source-derived epoch."""
+
+    status = _git_output(
+        "status",
+        "--porcelain=v1",
+        "--untracked-files=all",
+        repository_root=repository_root,
+    )
+    if status:
+        _fail("source_checkout_dirty")
+    observed_commit = _git_output(
+        "rev-parse",
+        "HEAD",
+        repository_root=repository_root,
+    )
+    if observed_commit != expected_commit:
+        _fail("product_commit_mismatch")
+    try:
+        with (repository_root / "pyproject.toml").open("rb") as source:
+            observed_version = tomllib.load(source)["project"]["version"]
+        changelog = (repository_root / "CHANGELOG.md").read_text(
+            encoding="utf-8"
+        )
+    except (OSError, KeyError, TypeError, tomllib.TOMLDecodeError):
+        _fail("source_contract_unavailable")
+    if observed_version != expected_version:
+        _fail("package_version_mismatch")
+    observed_changelog_headings = [
+        line.removeprefix("## ")
+        for line in changelog.splitlines()
+        if line.startswith("## ")
+    ]
+    if observed_changelog_headings.count(changelog_identity) != 1:
+        _fail("changelog_identity_mismatch")
+    observed_epoch = _git_output(
+        "show",
+        "-s",
+        "--format=%ct",
+        "HEAD",
+        repository_root=repository_root,
+    )
+    if not observed_epoch.isdigit() or int(observed_epoch) != source_date_epoch:
+        _fail("source_date_epoch_mismatch")
+    return {
+        "product_commit": expected_commit,
+        "observed_product_commit": observed_commit,
+        "expected_version": expected_version,
+        "observed_version": observed_version,
+        "changelog_identity": changelog_identity,
+        "observed_changelog_identity": changelog_identity,
+        "source_date_epoch": source_date_epoch,
+    }
+
+
+def collect_candidate_archives(
+    destination: Path,
+    *,
+    expected_version: str,
+) -> dict[str, dict[str, object]]:
+    """Build once with the reviewed adapter and inspect both distributions."""
+
+    from scripts.sqlite_runtime_delivery import _build_and_inspect
+
+    verify_build_tools()
+    try:
+        destination.mkdir(parents=True, exist_ok=False)
+    except OSError:
+        _fail("build_destination")
+    try:
+        wheel = _build_and_inspect(destination, quiet=True)
+    except (OSError, subprocess.CalledProcessError, SystemExit):
+        _fail("package_build")
+    sources = list(destination.glob("djsupport-*.tar.gz"))
+    if len(sources) != 1:
+        _fail("package_build_shape")
+    source = sources[0]
+    expected_stem = f"djsupport-{expected_version}"
+    if source.name != f"{expected_stem}.tar.gz":
+        _fail("archive_identity_mismatch")
+    if wheel.name != f"{expected_stem}-py3-none-any.whl":
+        _fail("archive_identity_mismatch")
+    return {
+        "source": inspect_distribution(source, "source"),
+        "wheel": inspect_distribution(wheel, "wheel"),
+    }
+
+
+def verify_build_tools(
+    installed_versions: Mapping[str, str] | None = None,
+) -> dict[str, str]:
+    """Require the actual build frontend and backends to equal their pins."""
+
+    if installed_versions is None:
+        try:
+            installed_versions = {
+                name: distribution_version(name) for name in PINNED_BUILD_TOOLS
+            }
+        except PackageNotFoundError:
+            _fail("build_tool_mismatch")
+    observed = dict(installed_versions)
+    if observed != PINNED_BUILD_TOOLS:
+        _fail("build_tool_mismatch")
+    return observed
+
+
+def verify_wheel_rebuild(
+    destination: Path,
+    *,
+    expected_commit: str,
+    expected_version: str,
+    changelog_identity: str,
+    source_date_epoch: int,
+    expected_sha256: str,
+) -> dict[str, object]:
+    """Require an independently rebuilt wheel to equal the canonical digest."""
+
+    observe_source(
+        expected_commit=expected_commit,
+        expected_version=expected_version,
+        changelog_identity=changelog_identity,
+        source_date_epoch=source_date_epoch,
+    )
+    archives = collect_candidate_archives(
+        destination,
+        expected_version=expected_version,
+    )
+    wheel = archives["wheel"]
+    if wheel["sha256"] != expected_sha256:
+        _fail("wheel_digest_mismatch")
+    return wheel
+
+
+def synthetic_scenario_observation(
+    *, platform_name: str,
+    python_version: str,
+) -> dict[str, object]:
+    """Prove the installed-scenario seam without claiming product scenarios."""
+
+    provider_markers = (
+        "SPOTIPY_CLIENT_ID",
+        "SPOTIPY_CLIENT_SECRET",
+        "SPOTIPY_REDIRECT_URI",
+        "BEATPORT_ACCESS_TOKEN",
+    )
+    if any(os.environ.get(name) for name in provider_markers):
+        _fail("live_provider_capability")
+    if platform_name not in REQUIRED_PLATFORMS:
+        _fail("scenario_platform_missing")
+    if not re.fullmatch(r"[0-9]+\.[0-9]+\.[0-9]+", python_version):
+        _fail("scenario_python_version")
+    return {
+        "platform": platform_name,
+        "python_version": python_version,
+        "synthetic_data": True,
+        "live_provider_capability": False,
+        "scenarios": list(SCENARIO_ORDER),
+        "conclusion": "passed",
+    }
+
+
+def fetch_public_run_jobs(
+    *,
+    repository: str,
+    run_id: str,
+    opener=urlopen,
+    ssl_context: ssl.SSLContext | None = None,
+) -> dict[str, object]:
+    """Read and bound public GitHub job observations without credentials."""
+
+    if not re.fullmatch(r"[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+", repository):
+        _fail("workflow_observation")
+    if not run_id.isdigit():
+        _fail("workflow_observation")
+    request = Request(
+        (
+            f"https://api.github.com/repos/{repository}/actions/runs/"
+            f"{run_id}/jobs?filter=latest&per_page=100"
+        ),
+        headers={
+            "Accept": "application/vnd.github+json",
+            "X-GitHub-Api-Version": "2022-11-28",
+            "User-Agent": "djsupport-candidate-qualification",
+        },
+    )
+    if ssl_context is None:
+        try:
+            import certifi
+        except ModuleNotFoundError:
+            _fail("workflow_observation")
+        ssl_context = ssl.create_default_context(cafile=certifi.where())
+    try:
+        with opener(request, timeout=30, context=ssl_context) as response:
+            document = json.load(response)
+    except (
+        HTTPError,
+        URLError,
+        OSError,
+        UnicodeDecodeError,
+        json.JSONDecodeError,
+    ):
+        _fail("workflow_observation")
+    if not isinstance(document, Mapping) or not isinstance(
+        document.get("jobs"), list
+    ):
+        _fail("workflow_observation")
+
+    jobs = []
+    for job in document["jobs"]:
+        if not isinstance(job, Mapping) or not isinstance(
+            job.get("steps"), list
+        ):
+            _fail("workflow_observation")
+        steps = []
+        for step in job["steps"]:
+            if not isinstance(step, Mapping):
+                _fail("workflow_observation")
+            steps.append(
+                {
+                    "name": step.get("name"),
+                    "status": step.get("status"),
+                    "conclusion": step.get("conclusion"),
+                }
+            )
+        jobs.append(
+            {
+                "name": job.get("name"),
+                "status": job.get("status"),
+                "conclusion": job.get("conclusion"),
+                "head_sha": job.get("head_sha"),
+                "workflow_name": job.get("workflow_name"),
+                "steps": steps,
+            }
+        )
+    return {
+        "repository": repository,
+        "run_id": run_id,
+        "total_count": len(jobs),
+        "jobs": jobs,
+    }
+
+
+def finalize_qualification(
+    *,
+    preparation: Mapping[str, object],
+    qualification_kind: str,
+    documentation_commit: str,
+    run: Mapping[str, object],
+    run_jobs: Mapping[str, object],
+    actions: list[str],
+    scenario_evidence_kind: str = "synthetic_contract",
+) -> dict[str, object]:
+    """Concentrate successful job facts into the one validated evidence record."""
+
+    try:
+        prepared_candidate = preparation["candidate"]
+        archives = preparation["archives"]
+        product_commit = prepared_candidate["product_commit"]
+        wheel_sha256 = archives["wheel"]["sha256"]
+    except (KeyError, TypeError):
+        _fail("input_contract")
+    if (
+        qualification_kind != "synthetic_non_release"
+        or scenario_evidence_kind != "synthetic_contract"
+    ):
+        _fail("installed_scenarios_required")
+
+    jobs = _successful_job_observations(
+        run_jobs,
+        expected_run=run,
+        expected_product_commit=product_commit,
+    )
+    _require_successful_job(jobs, "Contract", CONTRACT_JOB_STEPS)
+    _require_successful_job(jobs, "Plan", PLAN_JOB_STEPS)
+    _require_successful_job(
+        jobs,
+        "Documentation",
+        DOCUMENTATION_JOB_STEPS,
+    )
+
+    catalog = _load_json(RUNTIME_CATALOG_PATH)
+    policy = _load_json(RUNTIME_POLICY_PATH)
+    policy_entries = {
+        entry["artifact_id"]: entry for entry in policy["entries"]
+    }
+    runtime_cells = []
+    wheel_rebuilds = []
+    scenario_observations = []
+    for artifact in catalog["artifacts"]:
+        entry = policy_entries.get(artifact["artifact_id"])
+        if entry is None:
+            _fail("runtime_contract_mismatch")
+        _require_successful_job(
+            jobs,
+            (
+                f"Qualify {artifact['runner_label']} / Python "
+                f"{artifact['python_version']} / {artifact['architecture']}"
+            ),
+            QUALIFICATION_JOB_STEPS,
+        )
+        runner_image = entry["artifact"]["build"]["runner_image"]
+        runtime_cells.append(
+            {
+                "artifact_id": artifact["artifact_id"],
+                "runner_label": artifact["runner_label"],
+                "runner_image_version": runner_image["version"],
+                "runner_manifest_url": runner_image["manifest_url"],
+                "python_version": artifact["python_version"],
+                "architecture": artifact["architecture"],
+                "apsw_filename": artifact["filename"],
+                "apsw_sha256": artifact["sha256"],
+                "runtime_evidence_id": entry["evidence_id"],
+                "binding_resolution": "binary_only",
+                "source_build": False,
+                "conclusion": "passed",
+            }
+        )
+        scenario_observations.append(
+            synthetic_scenario_observation(
+                platform_name=_platform_name(artifact["os"]),
+                python_version=artifact["python_version"],
+            )
+        )
+        wheel_rebuilds.append(
+            {
+                "runner_label": artifact["runner_label"],
+                "python_version": artifact["python_version"],
+                "architecture": artifact["architecture"],
+                "wheel_sha256": wheel_sha256,
+                "conclusion": "passed",
+            }
+        )
+
+    source_epoch = prepared_candidate.get("source_date_epoch")
+    candidate = dict(prepared_candidate)
+    candidate.update(
+        {
+            "documentation_commit": documentation_commit,
+            "observed_documentation_commit": documentation_commit,
+        }
+    )
+    document = {
+        "contract_id": "djsupport/candidate-qualification-input/1",
+        "contract_version": 1,
+        "qualification_kind": qualification_kind,
+        "run": dict(run),
+        "candidate": candidate,
+        "build": {
+            "tools": dict(PINNED_BUILD_TOOLS),
+            "build_isolation": False,
+            "source_date_epoch": source_epoch,
+            "archives": archives,
+            "wheel_rebuilds": wheel_rebuilds,
+        },
+        "runtime": {
+            "artifact_catalog_id": catalog["catalog_id"],
+            "artifact_catalog_sha256": _sha256(RUNTIME_CATALOG_PATH),
+            "qualification_policy_id": policy["policy_id"],
+            "qualification_policy_sha256": _sha256(RUNTIME_POLICY_PATH),
+            "cells": runtime_cells,
+        },
+        "installed_scenarios": {
+            "evidence_kind": scenario_evidence_kind,
+            "required": list(SCENARIO_ORDER),
+            "observations": scenario_observations,
+        },
+        "documentation": {
+            "product_commit": product_commit,
+            "documentation_commit": documentation_commit,
+            "checkout": "exact_commit",
+            "product_contract": "passed",
+            "site_checks": {
+                "validate": "passed",
+                "broken_links": "passed",
+                "accessibility": "passed",
+            },
+        },
+        "checks": {
+            "required": [
+                "offline_suite",
+                "compilation",
+                "repository_privacy",
+                "archive_inspection",
+                "clean_install",
+            ],
+            "conclusions": {
+                check: "passed" for check in REQUIRED_CHECKS
+            },
+        },
+        "workflow": {
+            "permissions": {"contents": "read"},
+            "persist_credentials": False,
+            "actions": list(actions),
+            "secrets": False,
+            "continue_on_error": False,
+            "artifact_upload": False,
+            "publication_capability": False,
+        },
+    }
+    return qualify_candidate(document)
+
+
+def _successful_job_observations(
+    run_jobs: Mapping[str, object],
+    *,
+    expected_run: Mapping[str, object],
+    expected_product_commit: object,
+) -> dict[str, Mapping[str, object]]:
+    if (
+        run_jobs.get("repository") != expected_run.get("repository")
+        or run_jobs.get("run_id") != expected_run.get("run_id")
+    ):
+        _fail("workflow_observation")
+    raw_jobs = run_jobs.get("jobs")
+    if not isinstance(raw_jobs, list):
+        _fail("workflow_observation")
+    jobs: dict[str, Mapping[str, object]] = {}
+    for job in raw_jobs:
+        if (
+            not isinstance(job, Mapping)
+            or not isinstance(job.get("name"), str)
+            or job.get("head_sha") != expected_product_commit
+            or job.get("workflow_name") != QUALIFICATION_WORKFLOW_NAME
+        ):
+            _fail("workflow_observation")
+        name = job["name"]
+        if name in jobs:
+            _fail("workflow_observation")
+        jobs[name] = job
+    return jobs
+
+
+def _platform_name(os_name: object) -> str:
+    platform_name = {
+        "Ubuntu": "Linux",
+        "macOS": "macOS",
+        "Windows": "Windows",
+    }.get(os_name)
+    if platform_name is None:
+        _fail("runtime_contract_mismatch")
+    return platform_name
+
+
+def _require_successful_job(
+    jobs: Mapping[str, Mapping[str, object]],
+    name: str,
+    required_steps: tuple[str, ...],
+) -> None:
+    job = jobs.get(name)
+    if (
+        job is None
+        or job.get("status") != "completed"
+        or job.get("conclusion") != "success"
+        or not isinstance(job.get("steps"), list)
+    ):
+        _fail("workflow_observation")
+    steps: dict[str, Mapping[str, object]] = {}
+    for step in job["steps"]:
+        if not isinstance(step, Mapping) or not isinstance(
+            step.get("name"), str
+        ):
+            _fail("workflow_observation")
+        step_name = step["name"]
+        if step_name in steps:
+            _fail("workflow_observation")
+        steps[step_name] = step
+    for required_step in required_steps:
+        step = steps.get(required_step)
+        if (
+            step is None
+            or step.get("status") != "completed"
+            or step.get("conclusion") != "success"
+        ):
+            _fail("workflow_observation")
+
+
+def qualify_candidate(document: Mapping[str, object]) -> dict[str, object]:
+    """Return public evidence only when every candidate identity agrees."""
+
+    candidate = document.get("candidate")
+    if not isinstance(candidate, Mapping):
+        raise CandidateQualificationError(
+            "candidate_qualification_failed:input_contract"
+        )
+    if candidate.get("product_commit") != candidate.get(
+        "observed_product_commit"
+    ):
+        raise CandidateQualificationError(
+            "candidate_qualification_failed:product_commit_mismatch"
+        )
+    _validate(document, INPUT_SCHEMA_PATH, "input_contract")
+    _reject_private_values(document)
+
+    if candidate["documentation_commit"] != candidate[
+        "observed_documentation_commit"
+    ]:
+        _fail("documentation_commit_mismatch")
+    if candidate["expected_version"] != candidate["observed_version"]:
+        _fail("package_version_mismatch")
+    if candidate["changelog_identity"] != candidate[
+        "observed_changelog_identity"
+    ]:
+        _fail("changelog_identity_mismatch")
+
+    kind = document["qualification_kind"]
+    expected_version = candidate["expected_version"]
+    if kind == "release_candidate" and not re.fullmatch(
+        r"[0-9]+\.[0-9]+\.[0-9]+rc[1-9][0-9]*",
+        expected_version,
+    ):
+        _fail("release_version_required")
+
+    build = document["build"]
+    if build["tools"] != PINNED_BUILD_TOOLS:
+        _fail("build_tool_mismatch")
+    if build["source_date_epoch"] != candidate["source_date_epoch"]:
+        _fail("source_date_epoch_mismatch")
+    archives = build["archives"]
+    expected_stem = f"djsupport-{expected_version}"
+    if archives["source"]["filename"] != f"{expected_stem}.tar.gz":
+        _fail("archive_identity_mismatch")
+    if archives["wheel"]["filename"] != f"{expected_stem}-py3-none-any.whl":
+        _fail("archive_identity_mismatch")
+
+    catalog = _load_json(RUNTIME_CATALOG_PATH)
+    policy = _load_json(RUNTIME_POLICY_PATH)
+    runtime = document["runtime"]
+    if (
+        runtime["artifact_catalog_id"] != catalog["catalog_id"]
+        or runtime["artifact_catalog_sha256"]
+        != _sha256(RUNTIME_CATALOG_PATH)
+        or runtime["qualification_policy_id"] != policy["policy_id"]
+        or runtime["qualification_policy_sha256"]
+        != _sha256(RUNTIME_POLICY_PATH)
+    ):
+        _fail("runtime_contract_mismatch")
+
+    artifacts = {
+        artifact["artifact_id"]: artifact for artifact in catalog["artifacts"]
+    }
+    policy_entries = {
+        entry["artifact_id"]: entry for entry in policy["entries"]
+    }
+    runtime_cells = runtime["cells"]
+    runtime_by_id = {cell["artifact_id"]: cell for cell in runtime_cells}
+    if len(runtime_by_id) != len(runtime_cells):
+        _fail("runtime_cell_duplicate")
+    if set(runtime_by_id) != set(artifacts):
+        _fail("runtime_cell_missing")
+    for artifact_id, artifact in artifacts.items():
+        cell = runtime_by_id[artifact_id]
+        entry = policy_entries.get(artifact_id)
+        if entry is None or entry.get("status") != "active":
+            _fail("runtime_cell_unqualified")
+        runner_image = entry["artifact"]["build"]["runner_image"]
+        exact_facts = {
+            "runner_label": artifact["runner_label"],
+            "runner_image_version": runner_image["version"],
+            "runner_manifest_url": runner_image["manifest_url"],
+            "python_version": artifact["python_version"],
+            "architecture": artifact["architecture"],
+            "apsw_filename": artifact["filename"],
+            "apsw_sha256": artifact["sha256"],
+            "runtime_evidence_id": entry["evidence_id"],
+        }
+        if any(cell[name] != value for name, value in exact_facts.items()):
+            _fail("runtime_cell_unqualified")
+        if cell["source_build"] or cell["binding_resolution"] != "binary_only":
+            _fail("runtime_source_build")
+
+    wheel_sha256 = archives["wheel"]["sha256"]
+    rebuilds = build["wheel_rebuilds"]
+    rebuild_by_cell = {
+        (
+            rebuild["runner_label"],
+            rebuild["python_version"],
+            rebuild["architecture"],
+        ): rebuild
+        for rebuild in rebuilds
+    }
+    expected_cells = {
+        (
+            artifact["runner_label"],
+            artifact["python_version"],
+            artifact["architecture"],
+        )
+        for artifact in artifacts.values()
+    }
+    if len(rebuild_by_cell) != len(rebuilds):
+        _fail("wheel_rebuild_duplicate")
+    if set(rebuild_by_cell) != expected_cells:
+        _fail("wheel_rebuild_missing")
+    if any(
+        rebuild["wheel_sha256"] != wheel_sha256
+        for rebuild in rebuilds
+    ):
+        _fail("wheel_digest_mismatch")
+
+    scenarios = document["installed_scenarios"]
+    if (
+        kind == "release_candidate"
+        and scenarios["evidence_kind"] != "installed_product"
+    ):
+        _fail("installed_scenarios_required")
+    if set(scenarios["required"]) != REQUIRED_SCENARIOS:
+        _fail("scenario_contract_mismatch")
+    observed_platforms = {
+        observation["platform"] for observation in scenarios["observations"]
+    }
+    if observed_platforms != REQUIRED_PLATFORMS:
+        _fail("scenario_platform_missing")
+    for observation in scenarios["observations"]:
+        if observation["live_provider_capability"]:
+            _fail("live_provider_capability")
+        if not observation["synthetic_data"]:
+            _fail("owner_data_forbidden")
+        if set(observation["scenarios"]) != REQUIRED_SCENARIOS:
+            _fail("scenario_missing")
+
+    documentation = document["documentation"]
+    if (
+        documentation["product_commit"] != candidate["product_commit"]
+        or documentation["documentation_commit"]
+        != candidate["documentation_commit"]
+    ):
+        _fail("documentation_evidence_mismatch")
+
+    checks = document["checks"]
+    if set(checks["required"]) != REQUIRED_CHECKS:
+        _fail("check_contract_mismatch")
+    if set(checks["conclusions"]) != REQUIRED_CHECKS:
+        _fail("check_missing")
+
+    workflow = document["workflow"]
+    if workflow != {
+        "permissions": {"contents": "read"},
+        "persist_credentials": False,
+        "actions": workflow["actions"],
+        "secrets": False,
+        "continue_on_error": False,
+        "artifact_upload": False,
+        "publication_capability": False,
+    }:
+        _fail("workflow_capability")
+
+    evidence = {
+        "schema_id": "djsupport/candidate-qualification-evidence/1",
+        "schema_version": 1,
+        "conclusion": "passed",
+        "qualification_kind": kind,
+        "run": dict(document["run"]),
+        "candidate": {
+            "product_commit": candidate["product_commit"],
+            "documentation_commit": candidate["documentation_commit"],
+            "package_version": expected_version,
+            "changelog_identity": candidate["changelog_identity"],
+        },
+        "build": {
+            "source": _public_archive(archives["source"]),
+            "wheel": _public_archive(archives["wheel"]),
+            "reproducible_cells": len(rebuilds),
+        },
+        "runtime": {
+            "artifact_catalog_id": runtime["artifact_catalog_id"],
+            "qualification_policy_id": runtime["qualification_policy_id"],
+            "qualified_cells": len(runtime_cells),
+            "binding_resolution": "binary_only",
+        },
+        "installed_scenarios": {
+            "evidence_kind": scenarios["evidence_kind"],
+            "required": list(scenarios["required"]),
+            "platforms": sorted(
+                observed_platforms,
+                key=("Linux", "macOS", "Windows").index,
+            ),
+            "conclusion": "passed",
+        },
+        "documentation": {
+            "product_commit": documentation["product_commit"],
+            "documentation_commit": documentation["documentation_commit"],
+            "product_contract": "passed",
+            "site_checks": dict(documentation["site_checks"]),
+        },
+        "checks": dict(sorted(checks["conclusions"].items())),
+        "publication": {
+            "tag": False,
+            "github_release": False,
+            "artifact_upload": False,
+            "package_upload": False,
+            "advisory_publication": False,
+        },
+        "data_provider_state": {
+            "synthetic_only": True,
+            "live_provider_call": False,
+            "owner_data": False,
+        },
+    }
+    _validate(evidence, EVIDENCE_SCHEMA_PATH, "evidence_contract")
+    _reject_private_values(evidence)
+    return evidence
+
+
+def _public_archive(archive: Mapping[str, object]) -> dict[str, object]:
+    return {
+        "filename": archive["filename"],
+        "size_bytes": archive["size_bytes"],
+        "sha256": archive["sha256"],
+        "member_count": archive["member_count"],
+    }
+
+
+def _load_json(path: Path) -> dict[str, object]:
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        _fail("contract_unavailable")
+    if not isinstance(value, dict):
+        _fail("contract_unavailable")
+    return value
+
+
+def _sha256(path: Path) -> str:
+    try:
+        payload = path.read_bytes()
+    except OSError:
+        _fail("contract_unavailable")
+    return hashlib.sha256(payload).hexdigest()
+
+
+def _git_output(
+    *arguments: str,
+    repository_root: Path = REPOSITORY_ROOT,
+) -> str:
+    try:
+        result = subprocess.run(
+            ["git", *arguments],
+            cwd=repository_root,
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+    except (OSError, subprocess.CalledProcessError):
+        _fail("source_contract_unavailable")
+    return result.stdout.strip()
+
+
+def _validate(
+    document: Mapping[str, object],
+    schema_path: Path,
+    reason: str,
+) -> None:
+    schema = _load_json(schema_path)
+    try:
+        Draft202012Validator.check_schema(schema)
+        Draft202012Validator(
+            schema,
+            format_checker=FormatChecker(),
+        ).validate(document)
+    except (SchemaError, ValidationError):
+        _fail(reason)
+
+
+def _reject_private_values(value: object) -> None:
+    if isinstance(value, Mapping):
+        for key, child in value.items():
+            normalized = str(key).casefold()
+            if normalized in {
+                "path",
+                "local_path",
+                "raw_exception",
+                "raw_log",
+                "raw_sql",
+                "credentials",
+                "owner_facts",
+            }:
+                _fail("private_evidence")
+            _reject_private_values(child)
+        return
+    if isinstance(value, list):
+        for child in value:
+            _reject_private_values(child)
+        return
+    if isinstance(value, str):
+        normalized = value.casefold()
+        if (
+            value.startswith(("/", "~/"))
+            or WINDOWS_PATH.match(value)
+            or normalized.startswith("file://")
+            or "\\users\\" in normalized
+        ):
+            _fail("private_evidence")
+
+
+def _fail(reason: str) -> None:
+    raise CandidateQualificationError(
+        f"candidate_qualification_failed:{reason}"
+    )
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    subparsers = parser.add_subparsers(dest="command", required=True)
+    qualify_parser = subparsers.add_parser("qualify")
+    qualify_parser.add_argument("--input", required=True)
+    subparsers.add_parser("matrix")
+    prepare_parser = subparsers.add_parser("prepare")
+    prepare_parser.add_argument("--expected-commit", required=True)
+    prepare_parser.add_argument("--expected-version", required=True)
+    prepare_parser.add_argument("--changelog-identity", required=True)
+    prepare_parser.add_argument("--source-date-epoch", required=True, type=int)
+    prepare_parser.add_argument("--output-dir", required=True)
+    rebuild_parser = subparsers.add_parser("rebuild-wheel")
+    rebuild_parser.add_argument("--expected-commit", required=True)
+    rebuild_parser.add_argument("--expected-version", required=True)
+    rebuild_parser.add_argument("--changelog-identity", required=True)
+    rebuild_parser.add_argument(
+        "--source-date-epoch",
+        required=True,
+        type=int,
+    )
+    rebuild_parser.add_argument("--expected-sha256", required=True)
+    rebuild_parser.add_argument("--output-dir", required=True)
+    scenario_parser = subparsers.add_parser("synthetic-scenarios")
+    scenario_parser.add_argument("--platform", required=True)
+    scenario_parser.add_argument("--python-version", required=True)
+    observe_run_parser = subparsers.add_parser("observe-run")
+    observe_run_parser.add_argument("--repository", required=True)
+    observe_run_parser.add_argument("--run-id", required=True)
+    finalize_parser = subparsers.add_parser("finalize")
+    finalize_parser.add_argument("--preparation", required=True)
+    finalize_parser.add_argument("--run-jobs", required=True)
+    finalize_parser.add_argument(
+        "--qualification-kind",
+        choices=("synthetic_non_release", "release_candidate"),
+        required=True,
+    )
+    finalize_parser.add_argument("--documentation-commit", required=True)
+    finalize_parser.add_argument("--repository", required=True)
+    finalize_parser.add_argument("--run-id", required=True)
+    finalize_parser.add_argument("--run-url", required=True)
+    finalize_parser.add_argument("--action", action="append", required=True)
+    finalize_parser.add_argument(
+        "--scenario-evidence-kind",
+        choices=("synthetic_contract", "installed_product"),
+        default="synthetic_contract",
+    )
+    args = parser.parse_args()
+
+    try:
+        if args.command == "matrix":
+            result: object = {"include": candidate_matrix()}
+        elif args.command == "prepare":
+            source = observe_source(
+                expected_commit=args.expected_commit,
+                expected_version=args.expected_version,
+                changelog_identity=args.changelog_identity,
+                source_date_epoch=args.source_date_epoch,
+            )
+            result = {
+                "candidate": source,
+                "archives": collect_candidate_archives(
+                    Path(args.output_dir),
+                    expected_version=args.expected_version,
+                ),
+            }
+        elif args.command == "rebuild-wheel":
+            result = verify_wheel_rebuild(
+                Path(args.output_dir),
+                expected_commit=args.expected_commit,
+                expected_version=args.expected_version,
+                changelog_identity=args.changelog_identity,
+                source_date_epoch=args.source_date_epoch,
+                expected_sha256=args.expected_sha256,
+            )
+        elif args.command == "synthetic-scenarios":
+            result = synthetic_scenario_observation(
+                platform_name=args.platform,
+                python_version=args.python_version,
+            )
+        elif args.command == "observe-run":
+            result = fetch_public_run_jobs(
+                repository=args.repository,
+                run_id=args.run_id,
+            )
+        elif args.command == "finalize":
+            try:
+                preparation = json.loads(
+                    Path(args.preparation).read_text(encoding="utf-8")
+                )
+                run_jobs = json.loads(
+                    Path(args.run_jobs).read_text(encoding="utf-8")
+                )
+            except (OSError, json.JSONDecodeError):
+                _fail("input_contract")
+            if not isinstance(preparation, dict) or not isinstance(
+                run_jobs, dict
+            ):
+                _fail("input_contract")
+            result = finalize_qualification(
+                preparation=preparation,
+                qualification_kind=args.qualification_kind,
+                documentation_commit=args.documentation_commit,
+                run={
+                    "repository": args.repository,
+                    "run_id": args.run_id,
+                    "run_url": args.run_url,
+                },
+                run_jobs=run_jobs,
+                actions=args.action,
+                scenario_evidence_kind=args.scenario_evidence_kind,
+            )
+        else:
+            try:
+                document = json.loads(
+                    Path(args.input).read_text(encoding="utf-8")
+                )
+            except (OSError, json.JSONDecodeError):
+                _fail("input_contract")
+            if not isinstance(document, dict):
+                _fail("input_contract")
+            result = qualify_candidate(document)
+    except CandidateQualificationError as exc:
+        print(str(exc), file=sys.stderr)
+        raise SystemExit(1) from None
+    print(json.dumps(result, sort_keys=True, separators=(",", ":")))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/candidate_qualification.py
+++ b/scripts/candidate_qualification.py
@@ -79,7 +79,8 @@ CONTRACT_JOB_STEPS = (
     "Prove the synthetic non-release contract",
 )
 PLAN_JOB_STEPS = (
-    "Check out the exact candidate source",
+    "Check out workflow product source",
+    "Require exact product workflow commit",
     "Set up canonical build Python",
     "Install pinned build and verification tools",
     "Install the exact checkout for offline validation",
@@ -87,7 +88,8 @@ PLAN_JOB_STEPS = (
     "Build, inspect, and bind the exact source",
 )
 QUALIFICATION_JOB_STEPS = (
-    "Check out the exact candidate source",
+    "Check out workflow product source",
+    "Require exact product workflow commit",
     "Set up exact native Python",
     "Install pinned native qualification tools",
     "Require the canonical pure-Python wheel digest",
@@ -95,8 +97,10 @@ QUALIFICATION_JOB_STEPS = (
     "Exercise the installed synthetic scenario seam",
 )
 DOCUMENTATION_JOB_STEPS = (
-    "Check out exact product source",
-    "Check out exact documentation source",
+    "Check out workflow product source",
+    "Require exact product workflow commit",
+    "Check out canonical documentation source",
+    "Require exact documentation commit",
     "Set up documentation Node",
     "Set up documentation Python",
     "Install pinned documentation tools",

--- a/scripts/contracts/candidate-qualification-evidence.v1.schema.json
+++ b/scripts/contracts/candidate-qualification-evidence.v1.schema.json
@@ -1,0 +1,193 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/spontain112/djsupport/blob/main/scripts/contracts/candidate-qualification-evidence.v1.schema.json",
+  "title": "DJ Support candidate qualification evidence v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_id",
+    "schema_version",
+    "conclusion",
+    "qualification_kind",
+    "run",
+    "candidate",
+    "build",
+    "runtime",
+    "installed_scenarios",
+    "documentation",
+    "checks",
+    "publication",
+    "data_provider_state"
+  ],
+  "properties": {
+    "schema_id": {
+      "const": "djsupport/candidate-qualification-evidence/1"
+    },
+    "schema_version": { "const": 1 },
+    "conclusion": { "const": "passed" },
+    "qualification_kind": {
+      "enum": ["synthetic_non_release", "release_candidate"]
+    },
+    "run": { "$ref": "#/$defs/run" },
+    "candidate": { "$ref": "#/$defs/candidate" },
+    "build": { "$ref": "#/$defs/build" },
+    "runtime": { "$ref": "#/$defs/runtime" },
+    "installed_scenarios": { "$ref": "#/$defs/installedScenarios" },
+    "documentation": { "$ref": "#/$defs/documentation" },
+    "checks": {
+      "type": "object",
+      "minProperties": 1,
+      "additionalProperties": { "const": "passed" },
+      "propertyNames": { "pattern": "^[a-z][a-z0-9_]*$" }
+    },
+    "publication": { "$ref": "#/$defs/publication" },
+    "data_provider_state": { "$ref": "#/$defs/dataProviderState" }
+  },
+  "$defs": {
+    "sha": { "type": "string", "pattern": "^[0-9a-f]{40}$" },
+    "sha256": { "type": "string", "pattern": "^[0-9a-f]{64}$" },
+    "version": {
+      "type": "string",
+      "pattern": "^[0-9]+\\.[0-9]+\\.[0-9]+(?:(?:\\.dev|rc)[0-9]+)?$"
+    },
+    "run": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["repository", "run_id", "run_url"],
+      "properties": {
+        "repository": { "type": "string", "pattern": "^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$" },
+        "run_id": { "type": "string", "pattern": "^[A-Za-z0-9_.-]+$", "maxLength": 100 },
+        "run_url": { "type": "string", "format": "uri", "pattern": "^https://github\\.com/" }
+      }
+    },
+    "candidate": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "product_commit",
+        "documentation_commit",
+        "package_version",
+        "changelog_identity"
+      ],
+      "properties": {
+        "product_commit": { "$ref": "#/$defs/sha" },
+        "documentation_commit": { "$ref": "#/$defs/sha" },
+        "package_version": { "$ref": "#/$defs/version" },
+        "changelog_identity": { "type": "string", "minLength": 1, "maxLength": 160 }
+      }
+    },
+    "archive": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["filename", "size_bytes", "sha256", "member_count"],
+      "properties": {
+        "filename": { "type": "string", "pattern": "^[A-Za-z0-9_.+-]+$", "maxLength": 160 },
+        "size_bytes": { "type": "integer", "minimum": 1 },
+        "sha256": { "$ref": "#/$defs/sha256" },
+        "member_count": { "type": "integer", "minimum": 1 }
+      }
+    },
+    "build": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["source", "wheel", "reproducible_cells"],
+      "properties": {
+        "source": { "$ref": "#/$defs/archive" },
+        "wheel": { "$ref": "#/$defs/archive" },
+        "reproducible_cells": { "type": "integer", "minimum": 1 }
+      }
+    },
+    "runtime": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "artifact_catalog_id",
+        "qualification_policy_id",
+        "qualified_cells",
+        "binding_resolution"
+      ],
+      "properties": {
+        "artifact_catalog_id": { "type": "string", "minLength": 1, "maxLength": 160 },
+        "qualification_policy_id": { "type": "string", "minLength": 1, "maxLength": 160 },
+        "qualified_cells": { "type": "integer", "minimum": 1 },
+        "binding_resolution": { "const": "binary_only" }
+      }
+    },
+    "installedScenarios": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["evidence_kind", "required", "platforms", "conclusion"],
+      "properties": {
+        "evidence_kind": {
+          "enum": ["synthetic_contract", "installed_product"]
+        },
+        "required": {
+          "type": "array",
+          "minItems": 1,
+          "uniqueItems": true,
+          "items": { "type": "string", "pattern": "^[a-z][a-z0-9_]*$" }
+        },
+        "platforms": {
+          "type": "array",
+          "minItems": 3,
+          "uniqueItems": true,
+          "items": { "enum": ["Linux", "macOS", "Windows"] }
+        },
+        "conclusion": { "const": "passed" }
+      }
+    },
+    "documentation": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "product_commit",
+        "documentation_commit",
+        "product_contract",
+        "site_checks"
+      ],
+      "properties": {
+        "product_commit": { "$ref": "#/$defs/sha" },
+        "documentation_commit": { "$ref": "#/$defs/sha" },
+        "product_contract": { "const": "passed" },
+        "site_checks": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["validate", "broken_links", "accessibility"],
+          "properties": {
+            "validate": { "const": "passed" },
+            "broken_links": { "const": "passed" },
+            "accessibility": { "const": "passed" }
+          }
+        }
+      }
+    },
+    "publication": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "tag",
+        "github_release",
+        "artifact_upload",
+        "package_upload",
+        "advisory_publication"
+      ],
+      "properties": {
+        "tag": { "const": false },
+        "github_release": { "const": false },
+        "artifact_upload": { "const": false },
+        "package_upload": { "const": false },
+        "advisory_publication": { "const": false }
+      }
+    },
+    "dataProviderState": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["synthetic_only", "live_provider_call", "owner_data"],
+      "properties": {
+        "synthetic_only": { "const": true },
+        "live_provider_call": { "const": false },
+        "owner_data": { "const": false }
+      }
+    }
+  }
+}

--- a/scripts/contracts/candidate-qualification-input.v1.schema.json
+++ b/scripts/contracts/candidate-qualification-input.v1.schema.json
@@ -1,0 +1,370 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/spontain112/djsupport/blob/main/scripts/contracts/candidate-qualification-input.v1.schema.json",
+  "title": "DJ Support candidate qualification input v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "contract_id",
+    "contract_version",
+    "qualification_kind",
+    "run",
+    "candidate",
+    "build",
+    "runtime",
+    "installed_scenarios",
+    "documentation",
+    "checks",
+    "workflow"
+  ],
+  "properties": {
+    "contract_id": {
+      "const": "djsupport/candidate-qualification-input/1"
+    },
+    "contract_version": { "const": 1 },
+    "qualification_kind": {
+      "enum": ["synthetic_non_release", "release_candidate"]
+    },
+    "run": { "$ref": "#/$defs/run" },
+    "candidate": { "$ref": "#/$defs/candidate" },
+    "build": { "$ref": "#/$defs/build" },
+    "runtime": { "$ref": "#/$defs/runtime" },
+    "installed_scenarios": { "$ref": "#/$defs/installedScenarios" },
+    "documentation": { "$ref": "#/$defs/documentation" },
+    "checks": { "$ref": "#/$defs/checks" },
+    "workflow": { "$ref": "#/$defs/workflow" }
+  },
+  "$defs": {
+    "sha": {
+      "type": "string",
+      "pattern": "^[0-9a-f]{40}$"
+    },
+    "sha256": {
+      "type": "string",
+      "pattern": "^[0-9a-f]{64}$"
+    },
+    "version": {
+      "type": "string",
+      "pattern": "^[0-9]+\\.[0-9]+\\.[0-9]+(?:(?:\\.dev|rc)[0-9]+)?$"
+    },
+    "conclusion": { "const": "passed" },
+    "run": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["repository", "run_id", "run_url"],
+      "properties": {
+        "repository": {
+          "type": "string",
+          "pattern": "^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$"
+        },
+        "run_id": {
+          "type": "string",
+          "pattern": "^[A-Za-z0-9_.-]+$",
+          "maxLength": 100
+        },
+        "run_url": {
+          "type": "string",
+          "format": "uri",
+          "pattern": "^https://github\\.com/"
+        }
+      }
+    },
+    "candidate": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "product_commit",
+        "observed_product_commit",
+        "documentation_commit",
+        "observed_documentation_commit",
+        "expected_version",
+        "observed_version",
+        "changelog_identity",
+        "observed_changelog_identity",
+        "source_date_epoch"
+      ],
+      "properties": {
+        "product_commit": { "$ref": "#/$defs/sha" },
+        "observed_product_commit": { "$ref": "#/$defs/sha" },
+        "documentation_commit": { "$ref": "#/$defs/sha" },
+        "observed_documentation_commit": { "$ref": "#/$defs/sha" },
+        "expected_version": { "$ref": "#/$defs/version" },
+        "observed_version": { "$ref": "#/$defs/version" },
+        "changelog_identity": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 160
+        },
+        "observed_changelog_identity": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 160
+        },
+        "source_date_epoch": {
+          "type": "integer",
+          "minimum": 1
+        }
+      }
+    },
+    "archive": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "filename",
+        "size_bytes",
+        "sha256",
+        "member_count",
+        "inspection"
+      ],
+      "properties": {
+        "filename": {
+          "type": "string",
+          "pattern": "^[A-Za-z0-9_.+-]+$",
+          "maxLength": 160
+        },
+        "size_bytes": { "type": "integer", "minimum": 1 },
+        "sha256": { "$ref": "#/$defs/sha256" },
+        "member_count": { "type": "integer", "minimum": 1 },
+        "inspection": { "$ref": "#/$defs/conclusion" }
+      }
+    },
+    "wheelRebuild": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "runner_label",
+        "python_version",
+        "architecture",
+        "wheel_sha256",
+        "conclusion"
+      ],
+      "properties": {
+        "runner_label": { "type": "string", "minLength": 1, "maxLength": 80 },
+        "python_version": { "type": "string", "pattern": "^[0-9]+\\.[0-9]+\\.[0-9]+$" },
+        "architecture": { "type": "string", "minLength": 1, "maxLength": 40 },
+        "wheel_sha256": { "$ref": "#/$defs/sha256" },
+        "conclusion": { "$ref": "#/$defs/conclusion" }
+      }
+    },
+    "build": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "tools",
+        "build_isolation",
+        "source_date_epoch",
+        "archives",
+        "wheel_rebuilds"
+      ],
+      "properties": {
+        "tools": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["build", "setuptools", "wheel"],
+          "properties": {
+            "build": { "type": "string", "pattern": "^[0-9]+(?:\\.[0-9]+)+$" },
+            "setuptools": { "type": "string", "pattern": "^[0-9]+(?:\\.[0-9]+)+$" },
+            "wheel": { "type": "string", "pattern": "^[0-9]+(?:\\.[0-9]+)+$" }
+          }
+        },
+        "build_isolation": { "const": false },
+        "source_date_epoch": { "type": "integer", "minimum": 1 },
+        "archives": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["source", "wheel"],
+          "properties": {
+            "source": { "$ref": "#/$defs/archive" },
+            "wheel": { "$ref": "#/$defs/archive" }
+          }
+        },
+        "wheel_rebuilds": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "$ref": "#/$defs/wheelRebuild" }
+        }
+      }
+    },
+    "runtimeCell": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "artifact_id",
+        "runner_label",
+        "runner_image_version",
+        "runner_manifest_url",
+        "python_version",
+        "architecture",
+        "apsw_filename",
+        "apsw_sha256",
+        "runtime_evidence_id",
+        "binding_resolution",
+        "source_build",
+        "conclusion"
+      ],
+      "properties": {
+        "artifact_id": { "type": "string", "minLength": 1, "maxLength": 180 },
+        "runner_label": { "type": "string", "minLength": 1, "maxLength": 80 },
+        "runner_image_version": { "type": "string", "minLength": 1, "maxLength": 80 },
+        "runner_manifest_url": { "type": "string", "format": "uri", "pattern": "^https://github\\.com/actions/runner-images/" },
+        "python_version": { "type": "string", "pattern": "^[0-9]+\\.[0-9]+\\.[0-9]+$" },
+        "architecture": { "type": "string", "minLength": 1, "maxLength": 40 },
+        "apsw_filename": { "type": "string", "pattern": "^apsw-[A-Za-z0-9_.+-]+\\.whl$" },
+        "apsw_sha256": { "$ref": "#/$defs/sha256" },
+        "runtime_evidence_id": { "type": "string", "minLength": 1, "maxLength": 220 },
+        "binding_resolution": { "const": "binary_only" },
+        "source_build": { "const": false },
+        "conclusion": { "$ref": "#/$defs/conclusion" }
+      }
+    },
+    "runtime": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "artifact_catalog_id",
+        "artifact_catalog_sha256",
+        "qualification_policy_id",
+        "qualification_policy_sha256",
+        "cells"
+      ],
+      "properties": {
+        "artifact_catalog_id": { "type": "string", "minLength": 1, "maxLength": 160 },
+        "artifact_catalog_sha256": { "$ref": "#/$defs/sha256" },
+        "qualification_policy_id": { "type": "string", "minLength": 1, "maxLength": 160 },
+        "qualification_policy_sha256": { "$ref": "#/$defs/sha256" },
+        "cells": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "$ref": "#/$defs/runtimeCell" }
+        }
+      }
+    },
+    "scenarioObservation": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "platform",
+        "python_version",
+        "synthetic_data",
+        "live_provider_capability",
+        "scenarios",
+        "conclusion"
+      ],
+      "properties": {
+        "platform": { "enum": ["Linux", "macOS", "Windows"] },
+        "python_version": { "type": "string", "pattern": "^[0-9]+\\.[0-9]+\\.[0-9]+$" },
+        "synthetic_data": { "const": true },
+        "live_provider_capability": { "const": false },
+        "scenarios": {
+          "type": "array",
+          "minItems": 1,
+          "uniqueItems": true,
+          "items": { "type": "string", "pattern": "^[a-z][a-z0-9_]*$" }
+        },
+        "conclusion": { "$ref": "#/$defs/conclusion" }
+      }
+    },
+    "installedScenarios": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["evidence_kind", "required", "observations"],
+      "properties": {
+        "evidence_kind": {
+          "enum": ["synthetic_contract", "installed_product"]
+        },
+        "required": {
+          "type": "array",
+          "minItems": 1,
+          "uniqueItems": true,
+          "items": { "type": "string", "pattern": "^[a-z][a-z0-9_]*$" }
+        },
+        "observations": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "$ref": "#/$defs/scenarioObservation" }
+        }
+      }
+    },
+    "documentation": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "product_commit",
+        "documentation_commit",
+        "checkout",
+        "product_contract",
+        "site_checks"
+      ],
+      "properties": {
+        "product_commit": { "$ref": "#/$defs/sha" },
+        "documentation_commit": { "$ref": "#/$defs/sha" },
+        "checkout": { "const": "exact_commit" },
+        "product_contract": { "$ref": "#/$defs/conclusion" },
+        "site_checks": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["validate", "broken_links", "accessibility"],
+          "properties": {
+            "validate": { "$ref": "#/$defs/conclusion" },
+            "broken_links": { "$ref": "#/$defs/conclusion" },
+            "accessibility": { "$ref": "#/$defs/conclusion" }
+          }
+        }
+      }
+    },
+    "checks": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["required", "conclusions"],
+      "properties": {
+        "required": {
+          "type": "array",
+          "minItems": 1,
+          "uniqueItems": true,
+          "items": { "type": "string", "pattern": "^[a-z][a-z0-9_]*$" }
+        },
+        "conclusions": {
+          "type": "object",
+          "minProperties": 1,
+          "additionalProperties": { "$ref": "#/$defs/conclusion" },
+          "propertyNames": { "pattern": "^[a-z][a-z0-9_]*$" }
+        }
+      }
+    },
+    "workflow": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "permissions",
+        "persist_credentials",
+        "actions",
+        "secrets",
+        "continue_on_error",
+        "artifact_upload",
+        "publication_capability"
+      ],
+      "properties": {
+        "permissions": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["contents"],
+          "properties": { "contents": { "const": "read" } }
+        },
+        "persist_credentials": { "const": false },
+        "actions": {
+          "type": "array",
+          "minItems": 1,
+          "uniqueItems": true,
+          "items": {
+            "type": "string",
+            "pattern": "^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+@[0-9a-f]{40}$"
+          }
+        },
+        "secrets": { "const": false },
+        "continue_on_error": { "const": false },
+        "artifact_upload": { "const": false },
+        "publication_capability": { "const": false }
+      }
+    }
+  }
+}

--- a/scripts/sqlite_runtime_delivery.py
+++ b/scripts/sqlite_runtime_delivery.py
@@ -5,9 +5,11 @@ from __future__ import annotations
 
 import argparse
 from functools import lru_cache
+import hashlib
 import json
 import os
 from pathlib import Path, PurePosixPath, PureWindowsPath
+import re
 import subprocess
 import sys
 import tarfile
@@ -107,11 +109,24 @@ def _outer(mode: str) -> None:
         verify_downloaded_wheel(apsw_wheel, artifact)
         _verify_provenance(str(artifact["download_url"]))
         djsupport_wheel = _build_and_inspect(workspace / "dist")
+        expected_djsupport_wheel = os.environ.get(
+            "DJ_SUPPORT_EXPECTED_WHEEL_SHA256"
+        )
+        if expected_djsupport_wheel is not None:
+            _verify_expected_djsupport_wheel(
+                djsupport_wheel,
+                expected_djsupport_wheel,
+            )
         clean_python = _create_clean_install(
             workspace / "clean",
             apsw_wheel,
             djsupport_wheel,
         )
+        if expected_djsupport_wheel is not None:
+            _verify_installed_candidate_smoke(
+                clean_python,
+                _candidate_version_from_wheel(djsupport_wheel),
+            )
         subprocess.run(
             [
                 str(clean_python),
@@ -231,17 +246,25 @@ def _verify_provenance(download_url: str) -> None:
     )
 
 
-def _build_and_inspect(destination: Path) -> Path:
+def _build_and_inspect(destination: Path, *, quiet: bool = False) -> Path:
+    environment = dict(os.environ)
+    environment["SOURCE_DATE_EPOCH"] = _source_date_epoch()
+    environment["PYTHONHASHSEED"] = "0"
+    environment["TZ"] = "UTC"
     subprocess.run(
         [
             sys.executable,
             "-m",
             "build",
+            "--no-isolation",
             "--outdir",
             str(destination),
             str(REPOSITORY_ROOT),
         ],
+        env=environment,
         check=True,
+        capture_output=quiet,
+        text=quiet,
     )
     wheels = list(destination.glob("djsupport-*.whl"))
     sources = list(destination.glob("djsupport-*.tar.gz"))
@@ -269,6 +292,88 @@ def _inspect_wheel(path: Path) -> None:
                 )
             with archive.open(member) as source:
                 _reject_build_root(source.read())
+
+
+def _verify_expected_djsupport_wheel(path: Path, expected_sha256: str) -> None:
+    if not re.fullmatch(r"[0-9a-f]{64}", expected_sha256):
+        raise SystemExit(
+            "sqlite_runtime_delivery_failed:djsupport_wheel_digest"
+        )
+    try:
+        digest = hashlib.sha256(path.read_bytes()).hexdigest()
+    except OSError:
+        raise SystemExit(
+            "sqlite_runtime_delivery_failed:djsupport_wheel_digest"
+        ) from None
+    if digest != expected_sha256:
+        raise SystemExit(
+            "sqlite_runtime_delivery_failed:djsupport_wheel_digest"
+        )
+
+
+def _candidate_version_from_wheel(path: Path) -> str:
+    prefix = "djsupport-"
+    suffix = "-py3-none-any.whl"
+    if not path.name.startswith(prefix) or not path.name.endswith(suffix):
+        raise SystemExit(
+            "sqlite_runtime_delivery_failed:djsupport_wheel_identity"
+        )
+    version = path.name[len(prefix) : -len(suffix)]
+    if (
+        re.fullmatch(
+            r"[0-9]+\.[0-9]+\.[0-9]+(?:(?:\.dev|rc)[0-9]+)?",
+            version,
+        )
+        is None
+    ):
+        raise SystemExit(
+            "sqlite_runtime_delivery_failed:djsupport_wheel_identity"
+        )
+    return version
+
+
+def _verify_installed_candidate_smoke(python: Path, expected_version: str) -> None:
+    environment = dict(os.environ)
+    for name in (
+        "SPOTIPY_CLIENT_ID",
+        "SPOTIPY_CLIENT_SECRET",
+        "SPOTIPY_REDIRECT_URI",
+        "BEATPORT_ACCESS_TOKEN",
+    ):
+        environment.pop(name, None)
+    environment["PYTHONNOUSERSITE"] = "1"
+    code = (
+        "from importlib.metadata import version; "
+        "import djsupport; "
+        "raise SystemExit(0 if version('djsupport') == __import__('sys').argv[1] "
+        "else 1)"
+    )
+    cli = (
+        python.parent / "djsupport.exe"
+        if os.name == "nt"
+        else python.parent / "djsupport"
+    )
+    try:
+        subprocess.run(
+            [str(python), "-I", "-c", code, expected_version],
+            cwd=python.parent,
+            env=environment,
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+        subprocess.run(
+            [str(cli), "--help"],
+            cwd=python.parent,
+            env=environment,
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+    except (OSError, subprocess.CalledProcessError):
+        raise SystemExit(
+            "sqlite_runtime_delivery_failed:installed_candidate_smoke"
+        ) from None
 
 
 def _inspect_source(path: Path) -> None:
@@ -425,6 +530,27 @@ def _architecture() -> str:
     import platform
 
     return platform.machine()
+
+
+def _source_date_epoch() -> str:
+    try:
+        result = subprocess.run(
+            ["git", "show", "-s", "--format=%ct", "HEAD"],
+            cwd=REPOSITORY_ROOT,
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+    except (OSError, subprocess.CalledProcessError):
+        raise SystemExit(
+            "sqlite_runtime_delivery_failed:source_epoch_unavailable"
+        ) from None
+    value = result.stdout.strip()
+    if not value.isdigit() or int(value) < 1:
+        raise SystemExit(
+            "sqlite_runtime_delivery_failed:source_epoch_unavailable"
+        )
+    return value
 
 
 if __name__ == "__main__":

--- a/tests/test_candidate_qualification.py
+++ b/tests/test_candidate_qualification.py
@@ -238,7 +238,8 @@ def synthetic_workflow_run_observation() -> dict[str, object]:
         successful_job(
             "Plan",
             (
-                "Check out the exact candidate source",
+                "Check out workflow product source",
+                "Require exact product workflow commit",
                 "Set up canonical build Python",
                 "Install pinned build and verification tools",
                 "Install the exact checkout for offline validation",
@@ -249,8 +250,10 @@ def synthetic_workflow_run_observation() -> dict[str, object]:
         successful_job(
             "Documentation",
             (
-                "Check out exact product source",
-                "Check out exact documentation source",
+                "Check out workflow product source",
+                "Require exact product workflow commit",
+                "Check out canonical documentation source",
+                "Require exact documentation commit",
                 "Set up documentation Node",
                 "Set up documentation Python",
                 "Install pinned documentation tools",
@@ -263,7 +266,8 @@ def synthetic_workflow_run_observation() -> dict[str, object]:
         ),
     ]
     qualification_steps = (
-        "Check out the exact candidate source",
+        "Check out workflow product source",
+        "Require exact product workflow commit",
         "Set up exact native Python",
         "Install pinned native qualification tools",
         "Require the canonical pure-Python wheel digest",
@@ -800,6 +804,41 @@ class TestCandidateWorkflowAssembly:
         ]
         assert checkouts
         assert all(step["with"]["persist-credentials"] is False for step in checkouts)
+        assert not any(
+            str(step["with"].get("ref", "")).startswith("${{ inputs.")
+            for step in checkouts
+        )
+        product_checkouts = [
+            step
+            for step in checkouts
+            if "repository" not in step["with"]
+            and "ref" in step["with"]
+        ]
+        assert product_checkouts
+        assert {
+            step["with"]["ref"] for step in product_checkouts
+        } == {"${{ github.sha }}"}
+        documentation_checkout = next(
+            step
+            for step in checkouts
+            if step["with"].get("repository")
+            == "spontain112/djsupport-docs"
+        )
+        assert documentation_checkout["with"]["ref"] == "main"
+        for job_name in ("plan", "qualify", "documentation", "finalize"):
+            assert "Require exact product workflow commit" in {
+                step["name"] for step in jobs[job_name]["steps"]
+            }
+        assert "Require exact documentation commit" in {
+            step["name"] for step in jobs["documentation"]["steps"]
+        }
+        wheel_rebuild = next(
+            step
+            for step in jobs["qualify"]["steps"]
+            if step["name"]
+            == "Require the canonical pure-Python wheel digest"
+        )
+        assert wheel_rebuild["shell"] == "bash"
         setup_node = next(
             step
             for step in steps

--- a/tests/test_candidate_qualification.py
+++ b/tests/test_candidate_qualification.py
@@ -1,0 +1,960 @@
+"""Publication-free release-candidate qualification contract."""
+
+from __future__ import annotations
+
+from copy import deepcopy
+import hashlib
+from io import BytesIO
+import json
+import os
+from pathlib import Path
+import re
+import subprocess
+import sys
+import zipfile
+
+from jsonschema import Draft202012Validator
+import pytest
+import yaml
+
+from scripts.candidate_qualification import (
+    CandidateQualificationError,
+    candidate_matrix,
+    fetch_public_run_jobs,
+    finalize_qualification,
+    inspect_distribution,
+    observe_source,
+    qualify_candidate,
+    verify_build_tools,
+)
+
+
+ROOT = Path(__file__).parents[1]
+CONTRACTS = ROOT / "djsupport" / "contracts"
+QUALIFICATION_CONTRACTS = ROOT / "scripts" / "contracts"
+INPUT_SCHEMA = (
+    QUALIFICATION_CONTRACTS / "candidate-qualification-input.v1.schema.json"
+)
+EVIDENCE_SCHEMA = (
+    QUALIFICATION_CONTRACTS / "candidate-qualification-evidence.v1.schema.json"
+)
+RUNTIME_CATALOG = CONTRACTS / "apsw-runtime-artifacts.v1.json"
+RUNTIME_POLICY = CONTRACTS / "sqlite-runtime-qualification.v1.json"
+CANDIDATE_WORKFLOW = ROOT / ".github" / "workflows" / "candidate-qualification.yml"
+
+
+def _load_json(path: Path) -> dict[str, object]:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _sha256(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def synthetic_qualification_input() -> dict[str, object]:
+    catalog = _load_json(RUNTIME_CATALOG)
+    policy = _load_json(RUNTIME_POLICY)
+    policy_entries = {
+        entry["artifact_id"]: entry for entry in policy["entries"]
+    }
+    runtime_cells = []
+    wheel_rebuilds = []
+    wheel_sha256 = "a" * 64
+    for artifact in catalog["artifacts"]:
+        entry = policy_entries[artifact["artifact_id"]]
+        runner_image = entry["artifact"]["build"]["runner_image"]
+        cell = {
+            "artifact_id": artifact["artifact_id"],
+            "runner_label": artifact["runner_label"],
+            "runner_image_version": runner_image["version"],
+            "runner_manifest_url": runner_image["manifest_url"],
+            "python_version": artifact["python_version"],
+            "architecture": artifact["architecture"],
+            "apsw_filename": artifact["filename"],
+            "apsw_sha256": artifact["sha256"],
+            "runtime_evidence_id": entry["evidence_id"],
+            "binding_resolution": "binary_only",
+            "source_build": False,
+            "conclusion": "passed",
+        }
+        runtime_cells.append(cell)
+        wheel_rebuilds.append(
+            {
+                "runner_label": artifact["runner_label"],
+                "python_version": artifact["python_version"],
+                "architecture": artifact["architecture"],
+                "wheel_sha256": wheel_sha256,
+                "conclusion": "passed",
+            }
+        )
+
+    scenarios = [
+        "preview",
+        "apply_cutover",
+        "resume",
+        "backup",
+        "restore",
+        "rollback",
+        "diagnostics",
+    ]
+    return {
+        "contract_id": "djsupport/candidate-qualification-input/1",
+        "contract_version": 1,
+        "qualification_kind": "synthetic_non_release",
+        "run": {
+            "repository": "spontain112/djsupport",
+            "run_id": "synthetic-181",
+            "run_url": "https://github.com/spontain112/djsupport/actions/runs/181",
+        },
+        "candidate": {
+            "product_commit": "1" * 40,
+            "observed_product_commit": "1" * 40,
+            "documentation_commit": "2" * 40,
+            "observed_documentation_commit": "2" * 40,
+            "expected_version": "0.0.0.dev181",
+            "observed_version": "0.0.0.dev181",
+            "changelog_identity": "[Synthetic 0.0.0.dev181]",
+            "observed_changelog_identity": "[Synthetic 0.0.0.dev181]",
+            "source_date_epoch": 1_786_867_310,
+        },
+        "build": {
+            "tools": {
+                "build": "1.3.0",
+                "setuptools": "80.9.0",
+                "wheel": "0.45.1",
+            },
+            "build_isolation": False,
+            "source_date_epoch": 1_786_867_310,
+            "archives": {
+                "source": {
+                    "filename": "djsupport-0.0.0.dev181.tar.gz",
+                    "size_bytes": 1000,
+                    "sha256": "b" * 64,
+                    "member_count": 100,
+                    "inspection": "passed",
+                },
+                "wheel": {
+                    "filename": "djsupport-0.0.0.dev181-py3-none-any.whl",
+                    "size_bytes": 900,
+                    "sha256": wheel_sha256,
+                    "member_count": 80,
+                    "inspection": "passed",
+                },
+            },
+            "wheel_rebuilds": wheel_rebuilds,
+        },
+        "runtime": {
+            "artifact_catalog_id": catalog["catalog_id"],
+            "artifact_catalog_sha256": _sha256(RUNTIME_CATALOG),
+            "qualification_policy_id": policy["policy_id"],
+            "qualification_policy_sha256": _sha256(RUNTIME_POLICY),
+            "cells": runtime_cells,
+        },
+        "installed_scenarios": {
+            "evidence_kind": "synthetic_contract",
+            "required": scenarios,
+            "observations": [
+                {
+                    "platform": platform,
+                    "python_version": python_version,
+                    "synthetic_data": True,
+                    "live_provider_capability": False,
+                    "scenarios": scenarios,
+                    "conclusion": "passed",
+                }
+                for platform, python_version in (
+                    ("Linux", "3.10.21"),
+                    ("macOS", "3.14.7"),
+                    ("Windows", "3.14.7"),
+                )
+            ],
+        },
+        "documentation": {
+            "product_commit": "1" * 40,
+            "documentation_commit": "2" * 40,
+            "checkout": "exact_commit",
+            "product_contract": "passed",
+            "site_checks": {
+                "validate": "passed",
+                "broken_links": "passed",
+                "accessibility": "passed",
+            },
+        },
+        "checks": {
+            "required": [
+                "offline_suite",
+                "compilation",
+                "repository_privacy",
+                "archive_inspection",
+                "clean_install",
+            ],
+            "conclusions": {
+                "offline_suite": "passed",
+                "compilation": "passed",
+                "repository_privacy": "passed",
+                "archive_inspection": "passed",
+                "clean_install": "passed",
+            },
+        },
+        "workflow": {
+            "permissions": {"contents": "read"},
+            "persist_credentials": False,
+            "actions": [
+                "actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd",
+                "actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97",
+            ],
+            "secrets": False,
+            "continue_on_error": False,
+            "artifact_upload": False,
+            "publication_capability": False,
+        },
+    }
+
+
+def synthetic_workflow_run_observation() -> dict[str, object]:
+    def successful_job(name: str, steps: tuple[str, ...]) -> dict[str, object]:
+        return {
+            "name": name,
+            "head_sha": "1" * 40,
+            "workflow_name": "Candidate qualification",
+            "status": "completed",
+            "conclusion": "success",
+            "steps": [
+                {"name": step, "status": "completed", "conclusion": "success"}
+                for step in steps
+            ],
+        }
+
+    jobs = [
+        successful_job(
+            "Contract",
+            (
+                "Check out qualification source",
+                "Set up contract Python",
+                "Install pinned contract tools",
+                "Prove the synthetic non-release contract",
+            ),
+        ),
+        successful_job(
+            "Plan",
+            (
+                "Check out the exact candidate source",
+                "Set up canonical build Python",
+                "Install pinned build and verification tools",
+                "Install the exact checkout for offline validation",
+                "Run complete offline and privacy checks",
+                "Build, inspect, and bind the exact source",
+            ),
+        ),
+        successful_job(
+            "Documentation",
+            (
+                "Check out exact product source",
+                "Check out exact documentation source",
+                "Set up documentation Node",
+                "Set up documentation Python",
+                "Install pinned documentation tools",
+                "Test documentation contract",
+                "Check exact product contract",
+                "Validate documentation site",
+                "Check documentation links and redirects",
+                "Check documentation accessibility",
+            ),
+        ),
+    ]
+    qualification_steps = (
+        "Check out the exact candidate source",
+        "Set up exact native Python",
+        "Install pinned native qualification tools",
+        "Require the canonical pure-Python wheel digest",
+        "Reuse exact APSW artifact and loaded-runtime qualification",
+        "Exercise the installed synthetic scenario seam",
+    )
+    jobs.extend(
+        successful_job(
+            (
+                f"Qualify {cell['runner']} / Python "
+                f"{cell['python-version']} / {cell['architecture']}"
+            ),
+            qualification_steps,
+        )
+        for cell in candidate_matrix()
+    )
+    return {
+        "repository": "spontain112/djsupport",
+        "run_id": "synthetic-181",
+        "total_count": len(jobs),
+        "jobs": jobs,
+    }
+
+
+class TestCandidateQualificationContract:
+    def test_wrong_product_commit_fails_closed(self) -> None:
+        document = deepcopy(synthetic_qualification_input())
+        document["candidate"]["observed_product_commit"] = "3" * 40
+
+        with pytest.raises(
+            CandidateQualificationError,
+            match="candidate_qualification_failed:product_commit_mismatch",
+        ):
+            qualify_candidate(document)
+
+    def test_complete_synthetic_contract_returns_schema_valid_path_free_evidence(
+        self,
+    ) -> None:
+        input_schema = _load_json(INPUT_SCHEMA)
+        evidence_schema = _load_json(EVIDENCE_SCHEMA)
+        Draft202012Validator.check_schema(input_schema)
+        Draft202012Validator.check_schema(evidence_schema)
+        document = synthetic_qualification_input()
+        Draft202012Validator(input_schema).validate(document)
+
+        evidence = qualify_candidate(document)
+
+        Draft202012Validator(evidence_schema).validate(evidence)
+        assert evidence == {
+            "schema_id": "djsupport/candidate-qualification-evidence/1",
+            "schema_version": 1,
+            "conclusion": "passed",
+            "qualification_kind": "synthetic_non_release",
+            "run": {
+                "repository": "spontain112/djsupport",
+                "run_id": "synthetic-181",
+                "run_url": "https://github.com/spontain112/djsupport/actions/runs/181",
+            },
+            "candidate": {
+                "product_commit": "1" * 40,
+                "documentation_commit": "2" * 40,
+                "package_version": "0.0.0.dev181",
+                "changelog_identity": "[Synthetic 0.0.0.dev181]",
+            },
+            "build": {
+                "source": {
+                    "filename": "djsupport-0.0.0.dev181.tar.gz",
+                    "size_bytes": 1000,
+                    "sha256": "b" * 64,
+                    "member_count": 100,
+                },
+                "wheel": {
+                    "filename": "djsupport-0.0.0.dev181-py3-none-any.whl",
+                    "size_bytes": 900,
+                    "sha256": "a" * 64,
+                    "member_count": 80,
+                },
+                "reproducible_cells": 25,
+            },
+            "runtime": {
+                "artifact_catalog_id": "djsupport/apsw-runtime-artifacts/1",
+                "qualification_policy_id": (
+                    "djsupport/sqlite-runtime-qualification/1"
+                ),
+                "qualified_cells": 25,
+                "binding_resolution": "binary_only",
+            },
+            "installed_scenarios": {
+                "evidence_kind": "synthetic_contract",
+                "required": [
+                    "preview",
+                    "apply_cutover",
+                    "resume",
+                    "backup",
+                    "restore",
+                    "rollback",
+                    "diagnostics",
+                ],
+                "platforms": ["Linux", "macOS", "Windows"],
+                "conclusion": "passed",
+            },
+            "documentation": {
+                "product_commit": "1" * 40,
+                "documentation_commit": "2" * 40,
+                "product_contract": "passed",
+                "site_checks": {
+                    "validate": "passed",
+                    "broken_links": "passed",
+                    "accessibility": "passed",
+                },
+            },
+            "checks": {
+                "archive_inspection": "passed",
+                "clean_install": "passed",
+                "compilation": "passed",
+                "offline_suite": "passed",
+                "repository_privacy": "passed",
+            },
+            "publication": {
+                "tag": False,
+                "github_release": False,
+                "artifact_upload": False,
+                "package_upload": False,
+                "advisory_publication": False,
+            },
+            "data_provider_state": {
+                "synthetic_only": True,
+                "live_provider_call": False,
+                "owner_data": False,
+            },
+        }
+        serialized = json.dumps(evidence, sort_keys=True)
+        assert "/private/" not in serialized
+        assert "\\Users\\" not in serialized
+
+    def test_release_candidate_cannot_claim_synthetic_scenarios_as_product_proof(
+        self,
+    ) -> None:
+        document = synthetic_qualification_input()
+        document["qualification_kind"] = "release_candidate"
+        candidate = document["candidate"]
+        candidate["expected_version"] = "0.7.0rc1"
+        candidate["observed_version"] = "0.7.0rc1"
+        candidate["changelog_identity"] = "[0.7.0rc1] - 2026-08-16"
+        candidate["observed_changelog_identity"] = "[0.7.0rc1] - 2026-08-16"
+        document["build"]["archives"]["source"]["filename"] = (
+            "djsupport-0.7.0rc1.tar.gz"
+        )
+        document["build"]["archives"]["wheel"]["filename"] = (
+            "djsupport-0.7.0rc1-py3-none-any.whl"
+        )
+
+        with pytest.raises(
+            CandidateQualificationError,
+            match="candidate_qualification_failed:installed_scenarios_required",
+        ):
+            qualify_candidate(document)
+
+
+class TestCandidateArchiveAndCliAdapters:
+    def test_archive_inspection_rejects_private_members_without_echoing_the_path(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        wheel = tmp_path / "djsupport-0.0.0.dev181-py3-none-any.whl"
+        with zipfile.ZipFile(wheel, "w") as archive:
+            archive.writestr("djsupport/operational-store.sqlite3", b"private")
+
+        with pytest.raises(
+            CandidateQualificationError,
+            match="candidate_qualification_failed:private_archive_member",
+        ) as exc_info:
+            inspect_distribution(wheel, "wheel")
+
+        assert str(tmp_path) not in str(exc_info.value)
+
+    def test_cli_emits_only_the_schema_validated_evidence_document(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        input_path = tmp_path / "qualification.json"
+        input_path.write_text(
+            json.dumps(synthetic_qualification_input()),
+            encoding="utf-8",
+        )
+
+        result = subprocess.run(
+            [
+                sys.executable,
+                str(ROOT / "scripts" / "candidate_qualification.py"),
+                "qualify",
+                "--input",
+                str(input_path),
+            ],
+            cwd=ROOT,
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+
+        assert result.returncode == 0, result.stderr
+        evidence = json.loads(result.stdout)
+        Draft202012Validator(_load_json(EVIDENCE_SCHEMA)).validate(evidence)
+        assert str(tmp_path) not in result.stdout
+        assert result.stderr == ""
+
+    def test_public_run_adapter_returns_only_bounded_job_observations(self) -> None:
+        raw = {
+            "jobs": [
+                {
+                    "name": "Plan",
+                    "head_sha": "1" * 40,
+                    "workflow_name": "Candidate qualification",
+                    "status": "completed",
+                    "conclusion": "success",
+                    "runner_name": "/private/runner-name",
+                    "steps": [
+                        {
+                            "name": "Build, inspect, and bind the exact source",
+                            "status": "completed",
+                            "conclusion": "success",
+                            "number": 7,
+                        }
+                    ],
+                }
+            ]
+        }
+
+        expected_context = object()
+
+        def opener(request, *, timeout, context):
+            assert request.full_url == (
+                "https://api.github.com/repos/spontain112/djsupport/actions/"
+                "runs/181/jobs?filter=latest&per_page=100"
+            )
+            assert timeout == 30
+            assert context is expected_context
+            return BytesIO(json.dumps(raw).encode())
+
+        observed = fetch_public_run_jobs(
+            repository="spontain112/djsupport",
+            run_id="181",
+            opener=opener,
+            ssl_context=expected_context,
+        )
+
+        assert observed == {
+            "repository": "spontain112/djsupport",
+            "run_id": "181",
+            "total_count": 1,
+            "jobs": [
+                {
+                    "name": "Plan",
+                    "head_sha": "1" * 40,
+                    "workflow_name": "Candidate qualification",
+                    "status": "completed",
+                    "conclusion": "success",
+                    "steps": [
+                        {
+                            "name": "Build, inspect, and bind the exact source",
+                            "status": "completed",
+                            "conclusion": "success",
+                        }
+                    ],
+                }
+            ],
+        }
+        assert "/private/" not in json.dumps(observed)
+
+
+class TestCandidateInputRejection:
+    @pytest.mark.parametrize(
+        ("mutation", "reason"),
+        [
+            (
+                lambda document: document["candidate"].__setitem__(
+                    "observed_documentation_commit", "4" * 40
+                ),
+                "documentation_commit_mismatch",
+            ),
+            (
+                lambda document: document["candidate"].__setitem__(
+                    "observed_version", "0.0.0.dev182"
+                ),
+                "package_version_mismatch",
+            ),
+            (
+                lambda document: document["candidate"].__setitem__(
+                    "observed_changelog_identity", "[Synthetic mismatch]"
+                ),
+                "changelog_identity_mismatch",
+            ),
+            (
+                lambda document: document["build"]["wheel_rebuilds"][0].__setitem__(
+                    "wheel_sha256", "c" * 64
+                ),
+                "wheel_digest_mismatch",
+            ),
+            (
+                lambda document: document["build"]["tools"].__setitem__(
+                    "build", "1.4.0"
+                ),
+                "build_tool_mismatch",
+            ),
+            (
+                lambda document: document["runtime"]["cells"].pop(),
+                "runtime_cell_missing",
+            ),
+            (
+                lambda document: document["documentation"].__setitem__(
+                    "documentation_commit", "5" * 40
+                ),
+                "documentation_evidence_mismatch",
+            ),
+        ],
+    )
+    def test_identity_and_completeness_mismatches_fail_closed(
+        self,
+        mutation,
+        reason: str,
+    ) -> None:
+        document = deepcopy(synthetic_qualification_input())
+        mutation(document)
+
+        with pytest.raises(
+            CandidateQualificationError,
+            match=f"candidate_qualification_failed:{reason}",
+        ):
+            qualify_candidate(document)
+
+    @pytest.mark.parametrize(
+        "mutation",
+        [
+            lambda document: document["runtime"]["cells"][0].__setitem__(
+                "source_build", True
+            ),
+            lambda document: document["installed_scenarios"]["observations"][
+                0
+            ].__setitem__("live_provider_capability", True),
+            lambda document: document["workflow"].__setitem__(
+                "artifact_upload", True
+            ),
+            lambda document: document["checks"]["conclusions"].pop(
+                "repository_privacy"
+            ),
+            lambda document: document.__setitem__(
+                "raw_log", "/private/example/qualification.log"
+            ),
+        ],
+    )
+    def test_malformed_private_or_capability_broadening_input_fails_closed(
+        self,
+        mutation,
+    ) -> None:
+        document = deepcopy(synthetic_qualification_input())
+        mutation(document)
+
+        with pytest.raises(
+            CandidateQualificationError,
+            match="^candidate_qualification_failed:",
+        ) as exc_info:
+            qualify_candidate(document)
+
+        assert "/private/" not in str(exc_info.value)
+
+
+class TestCandidateWorkflowAssembly:
+    def test_candidate_matrix_is_derived_from_every_qualified_runtime_cell(
+        self,
+    ) -> None:
+        matrix = candidate_matrix()
+
+        assert len(matrix) == 25
+        assert len(
+            {
+                (
+                    cell["runner"],
+                    cell["python-version"],
+                    cell["architecture"],
+                )
+                for cell in matrix
+            }
+        ) == 25
+        assert {cell["setup-architecture"] for cell in matrix} == {"x64", "arm64"}
+        assert {
+            (cell["runner"], cell["python-version"], cell["architecture"])
+            for cell in matrix
+            if cell["runner"] == "windows-2025"
+        } == {
+            ("windows-2025", "3.10.11", "AMD64"),
+            ("windows-2025", "3.11.9", "AMD64"),
+            ("windows-2025", "3.12.10", "AMD64"),
+            ("windows-2025", "3.13.15", "AMD64"),
+            ("windows-2025", "3.14.7", "AMD64"),
+        }
+
+    def test_finalizer_concentrates_job_facts_into_one_evidence_document(self) -> None:
+        complete = synthetic_qualification_input()
+        preparation = {
+            "candidate": {
+                key: complete["candidate"][key]
+                for key in (
+                    "product_commit",
+                    "observed_product_commit",
+                    "expected_version",
+                    "observed_version",
+                    "changelog_identity",
+                    "observed_changelog_identity",
+                    "source_date_epoch",
+                )
+            },
+            "archives": complete["build"]["archives"],
+        }
+
+        evidence = finalize_qualification(
+            preparation=preparation,
+            qualification_kind="synthetic_non_release",
+            documentation_commit="2" * 40,
+            run=complete["run"],
+            run_jobs=synthetic_workflow_run_observation(),
+            actions=complete["workflow"]["actions"],
+        )
+
+        assert evidence == qualify_candidate(complete)
+
+    @pytest.mark.parametrize(
+        "mutation",
+        [
+            lambda observation: observation["jobs"].pop(),
+            lambda observation: observation.__setitem__(
+                "run_id", "synthetic-elsewhere"
+            ),
+            lambda observation: observation["jobs"][0].__setitem__(
+                "head_sha", "9" * 40
+            ),
+            lambda observation: observation["jobs"][0].__setitem__(
+                "workflow_name", "Different workflow"
+            ),
+            lambda observation: observation["jobs"][1]["steps"][4].__setitem__(
+                "conclusion", "failure"
+            ),
+            lambda observation: observation["jobs"].append(
+                deepcopy(observation["jobs"][0])
+            ),
+        ],
+    )
+    def test_finalizer_rejects_missing_failed_or_duplicate_job_observations(
+        self,
+        mutation,
+    ) -> None:
+        complete = synthetic_qualification_input()
+        observation = synthetic_workflow_run_observation()
+        mutation(observation)
+        preparation = {
+            "candidate": {
+                key: complete["candidate"][key]
+                for key in (
+                    "product_commit",
+                    "observed_product_commit",
+                    "expected_version",
+                    "observed_version",
+                    "changelog_identity",
+                    "observed_changelog_identity",
+                    "source_date_epoch",
+                )
+            },
+            "archives": complete["build"]["archives"],
+        }
+
+        with pytest.raises(
+            CandidateQualificationError,
+            match="candidate_qualification_failed:workflow_observation",
+        ):
+            finalize_qualification(
+                preparation=preparation,
+                qualification_kind="synthetic_non_release",
+                documentation_commit="2" * 40,
+                run=complete["run"],
+                run_jobs=observation,
+                actions=complete["workflow"]["actions"],
+            )
+
+    def test_candidate_workflow_is_read_only_exact_and_publication_free(self) -> None:
+        workflow_text = CANDIDATE_WORKFLOW.read_text(encoding="utf-8")
+        workflow = yaml.safe_load(workflow_text)
+
+        assert workflow["permissions"] == {"contents": "read"}
+        assert set(workflow["on"]) == {"pull_request", "workflow_dispatch"}
+        dispatch_inputs = workflow["on"]["workflow_dispatch"]["inputs"]
+        assert set(dispatch_inputs) == {
+            "expected_product_commit",
+            "documentation_commit",
+            "expected_version",
+            "changelog_identity",
+        }
+        assert all(
+            input_contract["required"] is True
+            for input_contract in dispatch_inputs.values()
+        )
+
+        jobs = workflow["jobs"]
+        assert set(jobs) == {"contract", "plan", "qualify", "documentation", "finalize"}
+        assert all("permissions" not in job for job in jobs.values())
+        assert jobs["plan"]["if"] == "github.event_name == 'workflow_dispatch'"
+        assert jobs["qualify"]["strategy"]["fail-fast"] is False
+        assert jobs["qualify"]["name"] == (
+            "Qualify ${{ matrix.runner }} / Python "
+            "${{ matrix.python-version }} / ${{ matrix.architecture }}"
+        )
+        assert jobs["qualify"]["strategy"]["matrix"] == (
+            "${{ fromJSON(needs.plan.outputs.matrix) }}"
+        )
+        assert set(jobs["finalize"]["needs"]) == {
+            "contract",
+            "plan",
+            "qualify",
+            "documentation",
+        }
+
+        steps = [step for job in jobs.values() for step in job.get("steps", [])]
+        uses = [step["uses"] for step in steps if "uses" in step]
+        assert uses
+        assert all(
+            re.fullmatch(
+                r"actions/(?:checkout|setup-python|setup-node)@[0-9a-f]{40}",
+                action,
+            )
+            for action in uses
+        )
+        checkouts = [
+            step
+            for step in steps
+            if step.get("uses", "").startswith("actions/checkout@")
+        ]
+        assert checkouts
+        assert all(step["with"]["persist-credentials"] is False for step in checkouts)
+        setup_node = next(
+            step
+            for step in steps
+            if step.get("uses", "").startswith("actions/setup-node@")
+        )
+        assert setup_node["with"]["node-version"] == "22.23.1"
+
+        commands = "\n".join(step.get("run", "") for step in steps)
+        for command in (
+            "candidate_qualification.py matrix",
+            "candidate_qualification.py prepare",
+            "candidate_qualification.py rebuild-wheel",
+            "sqlite_runtime_delivery.py verify",
+            "candidate_qualification.py synthetic-scenarios",
+            "check_product_contract.py",
+            "mint validate",
+            "mint broken-links --check-anchors --check-redirects",
+            "mint a11y",
+            "candidate_qualification.py observe-run",
+            "candidate_qualification.py finalize",
+        ):
+            assert command in commands
+        assert "--run-jobs" in commands
+        assert "--qualification-kind synthetic_non_release" in commands
+        assert "--scenario-evidence-kind synthetic_contract" in commands
+        assert "--qualification-kind release_candidate" not in commands
+
+        normalized = workflow_text.casefold()
+        forbidden = (
+            "pull_request_target",
+            "secrets.",
+            "permissions: write",
+            "continue-on-error",
+            "upload-artifact",
+            "git tag",
+            "gh release",
+            "twine",
+            ".release-notes/next-version",
+            "spotify",
+            "beatport",
+        )
+        assert not [marker for marker in forbidden if marker in normalized]
+
+        contributing = (ROOT / "CONTRIBUTING.md").read_text(encoding="utf-8")
+        assert "scripts/candidate_qualification.py" in contributing
+        assert "scripts/contracts/" in contributing
+
+
+class TestCandidateSourceAndBuildAdapters:
+    def test_source_observation_requires_the_exact_clean_commit(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        repository = tmp_path / "source"
+        repository.mkdir()
+        subprocess.run(["git", "init", "-q"], cwd=repository, check=True)
+        subprocess.run(
+            ["git", "config", "user.name", "Synthetic Test"],
+            cwd=repository,
+            check=True,
+        )
+        subprocess.run(
+            ["git", "config", "user.email", "synthetic@example.invalid"],
+            cwd=repository,
+            check=True,
+        )
+        (repository / "pyproject.toml").write_text(
+            '[project]\nname = "synthetic"\nversion = "0.0.0.dev181"\n',
+            encoding="utf-8",
+        )
+        (repository / "CHANGELOG.md").write_text(
+            "# Changelog\n\n## [Synthetic 0.0.0.dev181]\n",
+            encoding="utf-8",
+        )
+        subprocess.run(
+            ["git", "add", "pyproject.toml", "CHANGELOG.md"],
+            cwd=repository,
+            check=True,
+        )
+        environment = dict(os.environ)
+        environment.update(
+            {
+                "GIT_AUTHOR_DATE": "2026-08-16T08:00:00Z",
+                "GIT_COMMITTER_DATE": "2026-08-16T08:00:00Z",
+            }
+        )
+        subprocess.run(
+            ["git", "commit", "-q", "-m", "synthetic"],
+            cwd=repository,
+            env=environment,
+            check=True,
+        )
+        commit = subprocess.run(
+            ["git", "rev-parse", "HEAD"],
+            cwd=repository,
+            check=True,
+            capture_output=True,
+            text=True,
+        ).stdout.strip()
+        epoch = int(
+            subprocess.run(
+                ["git", "show", "-s", "--format=%ct", "HEAD"],
+                cwd=repository,
+                check=True,
+                capture_output=True,
+                text=True,
+            ).stdout.strip()
+        )
+
+        observed = observe_source(
+            expected_commit=commit,
+            expected_version="0.0.0.dev181",
+            changelog_identity="[Synthetic 0.0.0.dev181]",
+            source_date_epoch=epoch,
+            repository_root=repository,
+        )
+        assert observed["product_commit"] == commit
+
+        with pytest.raises(
+            CandidateQualificationError,
+            match="candidate_qualification_failed:changelog_identity_mismatch",
+        ):
+            observe_source(
+                expected_commit=commit,
+                expected_version="0.0.0.dev181",
+                changelog_identity="Synthetic",
+                source_date_epoch=epoch,
+                repository_root=repository,
+            )
+
+        (repository / "untracked-private.txt").write_text(
+            "must not enter an exact build",
+            encoding="utf-8",
+        )
+        with pytest.raises(
+            CandidateQualificationError,
+            match="candidate_qualification_failed:source_checkout_dirty",
+        ):
+            observe_source(
+                expected_commit=commit,
+                expected_version="0.0.0.dev181",
+                changelog_identity="[Synthetic 0.0.0.dev181]",
+                source_date_epoch=epoch,
+                repository_root=repository,
+            )
+
+    def test_build_adapter_rejects_an_unpinned_installed_tool(self) -> None:
+        with pytest.raises(
+            CandidateQualificationError,
+            match="candidate_qualification_failed:build_tool_mismatch",
+        ):
+            verify_build_tools(
+                {
+                    "build": "1.3.0",
+                    "setuptools": "81.0.0",
+                    "wheel": "0.45.1",
+                }
+            )

--- a/tests/test_release_channels.py
+++ b/tests/test_release_channels.py
@@ -34,6 +34,11 @@ def test_direct_tools_are_credited_and_source_archive_includes_acknowledgements(
     assert not [name for name in package_names if name not in credits.lower()]
     assert "Chromaprint" in credits and "beatport-pp-cli" in credits
     assert "[CodeQL](https://github.com/github/codeql-action)" in credits
+    assert "[Node.js](https://github.com/nodejs/node)" in credits
+    assert "[npm CLI](https://github.com/npm/cli)" in credits
+    assert "[setup-node](https://github.com/actions/setup-node)" in credits
+    assert "[Mint CLI](https://github.com/mintlify/mint)" in credits
+    assert "Elastic-2.0" in credits
     assert "issue #133" in credits and "Unverified" in credits
     assert "include THIRD_PARTY.md" in (REPOSITORY_ROOT / "MANIFEST.in").read_text()
     assert (REPOSITORY_ROOT / "THIRD_PARTY.md").is_file()
@@ -88,6 +93,10 @@ def test_manual_release_checklist_separates_validation_from_publication():
         "green CI on the exact final commit",
         "version PR does not authorize tagging or publication",
         "separate gated operations",
+        "Candidate qualification is validation-only",
+        "does not add `.release-notes/next-version`",
+        "does not consume release records",
+        "does not upload its source archive or wheel",
     )
 
     assert not [

--- a/tests/test_sqlite_runtime_delivery.py
+++ b/tests/test_sqlite_runtime_delivery.py
@@ -3,7 +3,9 @@
 from __future__ import annotations
 
 import json
+import os
 import re
+import subprocess
 import tarfile
 from io import BytesIO
 from pathlib import Path
@@ -19,7 +21,12 @@ from djsupport.operational_store.delivery import (
     load_artifact_catalog,
     verify_downloaded_wheel,
 )
-from scripts.sqlite_runtime_delivery import _inspect_source, _inspect_wheel
+from scripts.sqlite_runtime_delivery import (
+    _inspect_source,
+    _inspect_wheel,
+    _verify_expected_djsupport_wheel,
+    _verify_installed_candidate_smoke,
+)
 
 try:
     import tomllib
@@ -70,6 +77,62 @@ def _load_json(path: Path) -> dict:
 
 
 class TestRuntimeDeliveryContract:
+    def test_installed_candidate_smoke_invokes_import_and_cli(
+        self,
+        monkeypatch,
+        tmp_path,
+    ):
+        python = tmp_path / "bin" / "python"
+        calls = []
+
+        def run(arguments, **kwargs):
+            calls.append((arguments, kwargs))
+            return subprocess.CompletedProcess(arguments, 0)
+
+        monkeypatch.setattr(subprocess, "run", run)
+
+        _verify_installed_candidate_smoke(python, "0.7.0rc1")
+
+        assert len(calls) == 2
+        assert calls[0][0][:3] == [str(python), "-I", "-c"]
+        assert calls[0][0][-1] == "0.7.0rc1"
+        cli_name = "djsupport.exe" if os.name == "nt" else "djsupport"
+        assert calls[1][0] == [str(python.parent / cli_name), "--help"]
+        assert all(call[1]["check"] is True for call in calls)
+
+    def test_installed_candidate_smoke_fails_when_cli_does_not_start(
+        self,
+        monkeypatch,
+        tmp_path,
+    ):
+        python = tmp_path / "bin" / "python"
+
+        def run(arguments, **kwargs):
+            if arguments[-1] == "--help":
+                raise subprocess.CalledProcessError(1, arguments)
+            return subprocess.CompletedProcess(arguments, 0)
+
+        monkeypatch.setattr(subprocess, "run", run)
+
+        with pytest.raises(
+            SystemExit,
+            match="sqlite_runtime_delivery_failed:installed_candidate_smoke",
+        ):
+            _verify_installed_candidate_smoke(python, "0.7.0rc1")
+
+    def test_candidate_digest_gate_rejects_an_independent_wheel_mismatch(
+        self,
+        tmp_path,
+    ):
+        wheel = tmp_path / "djsupport-synthetic-py3-none-any.whl"
+        wheel.write_bytes(b"synthetic wheel")
+
+        with pytest.raises(
+            SystemExit,
+            match="sqlite_runtime_delivery_failed:djsupport_wheel_digest",
+        ):
+            _verify_expected_djsupport_wheel(wheel, "0" * 64)
+
     def test_package_pins_the_only_production_binding_and_python_surface(self):
         with (REPOSITORY_ROOT / "pyproject.toml").open("rb") as source:
             project = tomllib.load(source)["project"]
@@ -214,6 +277,8 @@ class TestRuntimeDeliveryContract:
             '"certifi==2026.7.22"',
             '"jsonschema==4.26.0"',
             '"pypi-attestations==0.0.30"',
+            '"setuptools==80.9.0"',
+            '"wheel==0.45.1"',
         ):
             assert tool in commands
         assert "python scripts/sqlite_runtime_delivery.py verify" in commands
@@ -223,7 +288,12 @@ class TestRuntimeDeliveryContract:
         assert "--only-binary=:all:" in script
         assert "pypi_attestations" in script
         assert '"-m",\n            "build",' in script
+        assert '"--no-isolation"' in script
+        assert 'environment["SOURCE_DATE_EPOCH"]' in script
+        assert "capture_output=quiet" in script
         assert "_inspect_wheel" in script and "_inspect_source" in script
+        assert "_verify_installed_candidate_smoke" in script
+        assert '"-I"' in script
 
         forbidden = (
             "pull_request_target",


### PR DESCRIPTION
Closes #181

## What changed
- add strict, versioned candidate-input and public-evidence contracts with one publication-free qualification CLI
- bind the exact product and documentation commits, reproducible package artifacts, all 25 qualified APSW cells, installed synthetic scenario observations, and successful workflow jobs into one path-free evidence document
- add a read-only workflow, installed CLI smoke check, maintainer guidance, third-party acknowledgements, and the required release-note record
- fail closed unless every observed job carries the exact prepared product SHA and the expected Candidate qualification workflow identity
- keep executable checkouts on trusted refs: the selected workflow SHA for product code and canonical `djsupport-docs/main`, each checked against the expected commit before repository code runs

## Safety
- synthetic evidence is explicitly non-release and cannot qualify a release candidate
- the workflow has read-only contents permission and no configured secrets, artifact upload, publication commands, provider capability, or owner-data access
- dispatch inputs cannot select executable checkout refs
- evidence rejects missing, failed, or duplicate jobs; identity drift; private values; source-built APSW; and wheel-digest drift

## Validation
- complete offline test suite passed
- 98 privacy, migration, and backup tests passed
- compilation and release-record validation passed
- two exact pinned builds produced the identical wheel SHA-256 `5578a971dfd716f9bb6d42cc3a9a3206a271bc43e066486d94faac311220f9cc`
- fresh binary-only APSW install passed package import/version and installed `djsupport --help`
- independent Spec and Standards reviews reported no findings