### PR TITLE
docs: define Operational Store implementation contracts

### DIFF
--- a/docs/research/2026-08-16-operational-store-cutover-retirement-contract.md
+++ b/docs/research/2026-08-16-operational-store-cutover-retirement-contract.md
@@ -1,0 +1,698 @@
+# Operational Store cutover and JSON-retirement contract
+
+**Date:** 2026-08-16
+
+**Current baseline:**
+[`origin/main` at `3e6ae7f`](https://github.com/spontain112/djsupport/commit/3e6ae7f6157364eeedaa2667d2a1deabed9efcee)
+
+**Scope:** implementation-readiness research for
+[#144](https://github.com/spontain112/djsupport/issues/144),
+[#145](https://github.com/spontain112/djsupport/issues/145),
+[#146](https://github.com/spontain112/djsupport/issues/146), and
+[#147](https://github.com/spontain112/djsupport/issues/147). No owner data,
+live service, database, backup, credential, tag, release, or package was
+accessed or changed.
+
+**Contract precedence:** The ready-to-paste issue amendments are the proposed
+normative execution delta; the preceding sections explain and source that delta.
+Once an amendment is accepted into an issue, the issue body is authoritative.
+Do not combine conflicting versions—reconcile the amendment first.
+
+**Relationship to earlier research:** this note reuses, and does not edit, the
+existing
+[migration/backup/cutover](2026-08-16-sqlite-migration-backup-cutover-contract.md),
+[concurrency/durability](2026-08-16-sqlite-concurrency-durability-contract.md),
+and
+[APSW integration](https://github.com/spontain112/djsupport/blob/3e6ae7f6157364eeedaa2667d2a1deabed9efcee/docs/research/2026-08-16-apsw-operational-store-integration-contract.md)
+contracts. Where the older cutover note uses Python's standard-library
+`sqlite3` API as an example, ADR-0005 and #165 now supersede that mechanism:
+APSW 3.53.4.0 is the sole production binding and Python `sqlite3` must never
+open an Operational Store
+([ADR-0005](https://github.com/spontain112/djsupport/blob/3e6ae7f6157364eeedaa2667d2a1deabed9efcee/docs/adr/0005-use-one-local-transactional-operational-store.md)).
+
+## Decision summary
+
+The four issues have the right dependency order, but their current acceptance
+criteria leave six production-significant decisions implicit. They should be
+amended before implementation is claimed:
+
+1. **Freeze the exact legacy input catalog and semantic projection.** The
+   phrase “every documented supported JSON schema version” currently conflates
+   the three canonical authorities with archive-only compatibility names and
+   migration records. A count-only comparison or permissive `json.loads()` is
+   not exact verification.
+2. **Add one cross-process maintenance gate.** The three current files do not
+   form one transaction. Preview can claim one coherent snapshot only if every
+   JSON writer participates in a shared/exclusive gate and source bytes are
+   revalidated before the exclusive lease is released.
+3. **Make the authority selector a strict state machine, not an optional
+   pointer.** “No pointer” cannot safely mean both “old installation” and
+   “activated pointer was lost.” Ordinary 0.7 startup must never infer either
+   legacy authority or a fresh empty store.
+4. **Isolate retained JSON from old runtime paths.** Leaving byte-identical
+   JSON at the 0.6 canonical filenames makes it inert only to new code; an old
+   binary can still write it and create split authority. Cutover must retain
+   the bytes in a rollback generation outside all legacy production paths.
+5. **Define the rollback window as a compatibility boundary, not a deletion
+   timer.** Support should span the complete 0.7.x release line. Expiry removes
+   a support promise, never data. Cleanup is a separate Previewed and explicitly
+   confirmed operation.
+6. **Make crash evidence native and binding-specific.** APSW's Online Backup
+   API, a test-only APSW VFS, subprocess hard exits, and native filesystem tests
+   must cover the selected macOS, Linux, and Windows cells. An injected Python
+   exception alone is not process-crash evidence.
+
+The final authority rule is deliberately simple: before the final selector
+replacement, legacy JSON remains the recoverable authority; after it, the
+selected, validated SQLite generation is the only production authority. An
+invalid, missing, unsupported, or ambiguous selector or generation is an
+explicit recovery state—not permission to open JSON, create an empty database,
+or select another generation.
+
+## Current evidence and gaps
+
+### Accepted foundation
+
+- ADR-0005 fixes one SQLite Operational Store, one deep internal interface, no
+  ORM, no dual-write, no silent fallback, one atomic selector, Online Backup
+  API snapshots, inert retained JSON, and an Effect Journal around external
+  effects
+  ([ADR-0005](https://github.com/spontain112/djsupport/blob/3e6ae7f6157364eeedaa2667d2a1deabed9efcee/docs/adr/0005-use-one-local-transactional-operational-store.md)).
+- The exact APSW 3.53.4.0 artifact and SQLite 3.53.4 runtime are admitted only
+  for the versioned native cells from #166/#167. Qualification happens before
+  any owner-data path is resolved; unavailable evidence has no JSON,
+  rollback-journal, warning, configuration, or dual-binding fallback
+  ([qualified runtime delivery](https://github.com/spontain112/djsupport/blob/3e6ae7f6157364eeedaa2667d2a1deabed9efcee/docs/sqlite-runtime-delivery.md)).
+- Runtime Assembly is already the common CLI, web, and Agent Client
+  construction seam, but it still constructs `MatchCache`,
+  `FilePublicationStorage`, and `FileTransferStorage` from two paths and a
+  derived third path
+  ([current assembly](https://github.com/spontain112/djsupport/blob/3e6ae7f6157364eeedaa2667d2a1deabed9efcee/djsupport/runtime.py)).
+- Current storage documentation records matching-knowledge versions 1–3,
+  publication versions 1–7, Transfer-state versions 1–6, plus archive-only
+  compatibility members and two version-1 migration records
+  ([storage inventory](https://github.com/spontain112/djsupport/blob/3e6ae7f6157364eeedaa2667d2a1deabed9efcee/docs/storage.md)).
+
+### Gaps visible in current code
+
+- `MatchCache.load()` treats an initially missing file as empty and catches a
+  JSON parse failure by returning without facts; its later
+  `reload_strict()` is stricter. The migration path must not call the permissive
+  initial loader or interpret malformed authority as empty
+  ([matching reader](https://github.com/spontain112/djsupport/blob/3e6ae7f6157364eeedaa2667d2a1deabed9efcee/djsupport/cache.py)).
+- Publication and Transfer files have independent write paths; only Transfer
+  state owns a process/thread lock. There is no one lease honored by all three
+  writers, so three sequential reads are not yet one coherent source snapshot
+  ([file stores](https://github.com/spontain112/djsupport/blob/3e6ae7f6157364eeedaa2667d2a1deabed9efcee/djsupport/transfer.py)).
+- `LocalDataBackup` is a JSON merge archive. It does not implement an APSW
+  Online Backup snapshot, a closed standalone SQLite member, SQLite integrity
+  checks, or generation activation. It is reusable behavior evidence, not the
+  #145 implementation
+  ([current backup](https://github.com/spontain112/djsupport/blob/3e6ae7f6157364eeedaa2667d2a1deabed9efcee/djsupport/backup.py)).
+- Current behavior physically removes a revoked matching entry and an active
+  Mirror relationship, while it retains Publication history, Approval outcomes,
+  discarded/superseded Qualification Drafts, and abandoned publication history.
+  Migration must preserve the resulting current facts; it cannot invent a
+  tombstone or historical event that JSON never retained
+  ([matching revocation](https://github.com/spontain112/djsupport/blob/3e6ae7f6157364eeedaa2667d2a1deabed9efcee/djsupport/cache.py),
+  [Mirror removal and Qualification retention](https://github.com/spontain112/djsupport/blob/3e6ae7f6157364eeedaa2667d2a1deabed9efcee/djsupport/transfer.py)).
+- No authority selector, transition state, rollback catalog, JSON quarantine,
+  Operational Store bootstrap, or post-cutover fail-closed startup path exists
+  yet. The merged Operational Store package currently contains only runtime
+  qualification and delivery seams
+  ([package interface](https://github.com/spontain112/djsupport/blob/3e6ae7f6157364eeedaa2667d2a1deabed9efcee/djsupport/operational_store/__init__.py)).
+
+## Primary-source constraints
+
+### APSW backup and failure mechanics
+
+APSW reverses the standard-library-looking backup call: the **destination**
+connection creates `destination.backup("main", source, "main")`. The source and
+destination must be distinct; `Backup.step()` may raise `BusyError` or
+`LockedError`; `finish()` commits a complete copy or rolls an incomplete copy
+back; and the destination remains write-locked for the backup lifetime. APSW
+also states that page-level backup copies free pages
+([APSW 3.53.4.0 backup](https://rogerbinns.github.io/apsw/backup.html)).
+
+SQLite's Online Backup API produces a consistent destination while allowing
+incremental source access. Concurrent source writes can restart the copy, so an
+application deadline is necessary to prevent an unbounded operation
+([SQLite backup API](https://www.sqlite.org/backup.html)). A live main file must
+not be copied independently of a hot WAL: SQLite identifies the Online Backup
+API and `VACUUM INTO` as safe live-copy methods and warns that a mismatched or
+deleted hot journal can lose committed data or corrupt recovery
+([corruption hazards](https://www.sqlite.org/howtocorrupt.html)).
+
+### WAL and store-family lifecycle
+
+In WAL mode, committed transactions may live only in `-wal`; the main file,
+WAL, and SHM are one live family. A clean final read/write close normally
+checkpoints and removes sidecars, but a crash or final read-only close can leave
+them. The WAL must remain paired with its database until SQLite performs
+recovery
+([WAL lifecycle](https://www.sqlite.org/wal.html#the_wal_file),
+[WAL file format](https://www.sqlite.org/walformat.html#file_lifecycles)).
+That is why backup produces a new, closed, DELETE-mode destination rather than
+archiving any live member.
+
+### Opening selected and restored databases
+
+`sqlite3_open_v2()` supports `SQLITE_OPEN_NOFOLLOW`; `READWRITE` can historically
+fall back to read-only when permissions prevent writing, so the caller must
+verify the resulting mode. `READWRITE` without `CREATE` rejects a missing file.
+URI parameters can alter mode, cache, locking, immutability, or VFS selection,
+so production generation opens must not accept URI interpretation
+([SQLite open flags](https://www.sqlite.org/c3ref/open.html),
+[URI cautions](https://www.sqlite.org/uri.html)). APSW exposes those open flags
+directly through `Connection`
+([APSW connection](https://rogerbinns.github.io/apsw/connection.html)).
+
+A restored database is untrusted input even when it claims DJ Support
+provenance. SQLite recommends disabling trusted schema immediately and, for
+sensitive readers, enabling defensive mode, reducing limits, disabling
+memory-mapped I/O, and checking integrity before other work
+([SQLite untrusted-database guidance](https://www.sqlite.org/security.html)).
+`integrity_check` does not check foreign keys; `foreign_key_check` is separate
+([SQLite pragmas](https://www.sqlite.org/pragma.html#pragma_integrity_check)).
+
+### JSON, archives, and atomic replacement
+
+Python's default JSON decoder accepts `NaN`/infinities and duplicate object
+names, keeping only the last duplicate. `parse_constant` and
+`object_pairs_hook` are therefore required for a fail-closed authority parser
+([Python JSON compliance](https://docs.python.org/3.14/library/json.html#standard-compliance-and-interoperability)).
+Python also warns that ZIP input can contain duplicate names, path surprises,
+unsupported or corrupt members, resource-exhaustion payloads, and incomplete
+extraction after interruption; restore must inspect and stream allowlisted
+members rather than call `extractall()`
+([Python `zipfile`](https://docs.python.org/3.14/library/zipfile.html)).
+
+`os.replace()` cannot cross filesystems and provides atomic rename semantics
+where the platform supplies them. `fsync()` flushes a file descriptor through
+the platform API, but Python does not provide a portable multi-file power-loss
+transaction
+([Python `os.replace` and `fsync`](https://docs.python.org/3.14/library/os.html#os.replace)).
+The selector protocol must therefore use one same-directory replacement as its
+only activation point, validate after every restart, and prove native behavior;
+it must not claim stronger hardware durability than the operating system.
+
+### Logical deletion is not physical erasure
+
+SQLite normally leaves deleted bytes in free pages. `secure_delete=ON` can
+overwrite ordinary deleted table content, while `VACUUM` rebuilds a database;
+APSW's Online Backup API copies free pages. A retained backup or old generation
+may therefore contain facts deleted from the current logical state
+([SQLite secure delete](https://www.sqlite.org/pragma.html#pragma_secure_delete),
+[`VACUUM INTO`](https://www.sqlite.org/lang_vacuum.html),
+[APSW backup](https://rogerbinns.github.io/apsw/backup.html)). Neither #145 nor
+#147 should promise forensic erasure. A later erasure feature would need its own
+scrubbed-generation, backup-retention, and verification contract.
+
+## Shared authority and maintenance contract
+
+All four tickets depend on one gate owned by Runtime Assembly and the
+Operational Store interface:
+
+- Ordinary JSON writers before cutover and all SQLite operations after cutover
+  acquire a shared **operation lease** for the full high-level operation. An
+  Effect Journal transaction may close around a Spotify call, but its enclosing
+  operation lease remains held so cutover cannot split the intent and observed
+  result across generations.
+- Migration Preview, backup apply, restore apply, cutover, generation rollback,
+  and old-version rollback acquire the exclusive **maintenance lease**. The
+  exclusive path blocks new graphs, waits a bounded time for active operations,
+  then requires every connection, cursor, backup, and pointer handle closed.
+- The lease is process-crash-releasing and works natively on macOS, Linux, and
+  Windows. A process-local mutex or the current Transfer-state lock alone is not
+  sufficient.
+- A failure to acquire or drain by the deadline returns a redacted busy/recovery
+  outcome and performs no authority change. It never kills another process or
+  bypasses the gate.
+
+This is coordination, not authority. The selector determines authority; the
+lease only prevents a client from retaining or writing through a stale
+selection during a transition.
+
+## #144 exact JSON-to-SQLite Preview contract
+
+### Freeze the input catalog
+
+The issue should name these inputs explicitly:
+
+| Role | Canonical member | Supported versions | Migration treatment |
+| --- | --- | --- | --- |
+| Matching authority | `matching-knowledge.json` | 1, 2, 3 | Strict version codec into canonical Matching Knowledge facts. |
+| Publication authority | `publication-manifests.json` | 1–7 | Strict version codec into manifests, ordered items, Approvals, active Mirrors, and retained publication facts. |
+| Transfer authority | `publication-manifests.transfers.json` | 1–6 | Strict version codec into Transfers, Batches, Qualification Drafts, checkpoints, and incomplete-effect facts. |
+| Ancillary legacy facts | `legacy-migration.json` | 1 | Import as explicit non-authorizing migration/relink/history facts. |
+| Ancillary foundation fact | `foundation-migration.json` | 1 | Import the accepted stable-account migration fact; never a credential. |
+
+`config.json`, environment values, Spotipy token storage, reports, source XML,
+audio, and generated diagnostics are outside the importer. The backup-only
+compatibility names `transfers.json` and `playlist-state.json` are not current
+Runtime Assembly authorities. Their presence alongside canonical state is
+ambiguous and must fail with a safe code unless an explicit supported legacy
+normalization workflow first produces the canonical three-file family. This
+distinction should be reflected in both #144 and `docs/storage.md`.
+
+### Acquire one stable source snapshot
+
+1. Qualify the exact APSW runtime and artifact before resolving a database path.
+2. Acquire the exclusive maintenance lease; then acquire any existing
+   per-file locks in one documented order.
+3. Open only exact allowlisted regular files beneath the canonical private
+   root. Reject symlinks, special files, aliases, duplicate logical inputs, and
+   oversized input before parsing.
+4. Read bounded bytes once, record a private presence bitmap, size, file
+   identity, and SHA-256, and parse with duplicate-key, non-finite-number,
+   unknown-version, shape, and domain validation. A file that is absent is
+   distinct from a present empty document; cross-store references must still
+   validate.
+5. Import the typed snapshot into a uniquely created, non-selectable staging
+   generation through one APSW `BEGIN IMMEDIATE` unit. Do not use a generic
+   JSON merge or the permissive runtime cache loader.
+6. Commit, run exact semantic verification plus application/schema/migration
+   identity, schema fingerprint, full integrity, and foreign-key checks.
+7. Re-stat and re-hash every present source before releasing the lease. Any
+   replacement or byte change invalidates the Preview. Original bytes remain
+   byte-identical.
+
+### Freeze one semantic projection
+
+Legacy codecs and both Operational Store adapters must produce the same
+versioned canonical projection. The projection contract is executable test
+data, not report output:
+
+- a fixed category registry and field registry with explicit type tags;
+- explicit distinction among absent, null, false, zero, and empty collection;
+- deterministic logical-key ordering for maps and sets;
+- zero-based ordinal for every ordered collection, with duplicate Source
+  Occurrences emitted as separate records;
+- exact integer/boolean/string values, finite floats represented by their exact
+  binary value, and version-codec-defined timestamp semantics;
+- imported revisions unchanged—migration itself does not consume an entity
+  revision;
+- relationships checked in both directions so an orphan, duplicate key, or
+  silently dropped child fails;
+- a fixed mapping for every legacy incomplete checkpoint into “not attempted,”
+  “observed complete,” or “uncertain/review required”; no absence may be
+  promoted to a completed effect; and
+- zero fabricated Approval, Matching Knowledge, Effect Journal, or Operational
+  Event history. A current JSON absence remains absent unless a documented
+  version codec defines a semantic default.
+
+Compare the complete typed sequences and per-category counts/digests from both
+readers. A mismatch may be narrowed internally, but the public Preview exposes
+only category, equality, bounded counts, and a stable reason code—not record
+values, identifiers, paths, SQL, or raw exceptions.
+
+The Preview token binds the source presence/digests, importer and projection
+versions, target schema/migration identity, staging semantic digest, and an
+expiry. It is not authority and cannot be used if any bound value changes. A
+#144 staging file is structurally outside the generation directory selected by
+Runtime Assembly and is deleted only when the current process proves it created
+and never selected it; crash-orphaned staging is quarantined until the same
+proof can be made.
+
+## #145 APSW backup and restore contract
+
+### Backup
+
+1. Qualify the runtime before resolving the active private path. Acquire a
+   shared operation lease and resolve the exact `sqlite` selector generation.
+2. Create an unpredictable, exclusive, empty destination in the private
+   same-filesystem staging root; close its creator handle before APSW opens it,
+   which is required for portable Windows behavior.
+3. Use distinct qualified APSW connections and
+   `destination.backup("main", source, "main")`. Copy bounded page batches;
+   retry `BusyError`/`LockedError` only within one injected monotonic deadline;
+   always call `finish()` through the backup context.
+4. Read store generation, authority revision, schema/migration identity, and
+   canonical semantic digest from the completed destination—not from a value
+   sampled before backup.
+5. Convert the destination to `journal_mode=DELETE`, require the returned mode,
+   close every handle, and require no destination WAL, SHM, or hot journal.
+6. Reopen read-only with no URI, no create, no symlink following, trusted schema
+   off, defensive limits, and no custom functions. Require exact identity,
+   schema fingerprint, full integrity, empty foreign-key check, and the retained
+   semantic digest.
+7. Hash the closed bytes. Write one strict manifest and one database member to a
+   new archive; stream and verify the complete archive before same-directory
+   replacement. The manifest hash detects accidental mismatch, not malicious
+   replacement of both manifest and database.
+
+The manifest includes format version, database member, closed byte size/hash,
+application ID, user version, migration-registry digest, schema fingerprint,
+source store generation, authority revision, semantic digest, producing
+DJ Support/APSW/SQLite versions, and UTC creation time. It contains no path,
+credential, account, source, playlist, track, fingerprint, row, SQL, or error
+text.
+
+### Restore Preview and apply
+
+Restore streams exactly the allowlisted manifest and database members after
+rejecting duplicate names, directories, links/special files, encryption,
+absolute/drive/UNC/backslash/parent paths, unknown fields, unsupported
+compression, CRC/hash/length mismatch, resource limits, wrong identities,
+corruption, and foreign-key violations. It never calls `extractall()`.
+
+The restored database is never installed over an active file. Apply acquires
+the exclusive maintenance lease, backs up and verifies the current authority,
+revalidates the Preview token and current revision, copies the restored logical
+state into a **new physical generation with a new store-generation ID**, verifies
+it, and activates it through the selector protocol below. The backup manifest
+retains the source generation ID; two independently restored physical files do
+not masquerade as the same generation.
+
+An Online Backup copy may contain deleted bytes in free pages. Backups, retained
+generations, and rollback JSON are therefore private historical artifacts and
+may retain facts absent from current logical authority. Restore/cleanup Preview
+must say so without exposing those facts. Deleting a current row never claims to
+erase an existing backup.
+
+## #146 selector, cutover, and startup contract
+
+### Strict selector states
+
+Use one bounded, duplicate-key-rejecting JSON selector at a fixed private path.
+It is a tagged union, not an arbitrary configuration file:
+
+| State | Authority and permitted behavior |
+| --- | --- |
+| absent | Ordinary 0.7 clients return `store_initialization_required` or `migration_required`; they do not infer an empty store or open JSON. Only explicit initialize/migrate tooling may proceed after inspecting the private root. |
+| `json` | Legacy JSON is authority during the #146 transition. It is accepted only by migration/rollback tooling after #147. |
+| `transition` | JSON remains the recoverable authority, but ordinary work is stopped. The selector binds one transition ID, source digests, retained JSON generation, and intended SQLite generation so recovery can restore JSON paths or complete the same transition without guessing. |
+| `sqlite` | The named SQLite generation and embedded store-generation ID are sole authority. |
+| `legacy_rollback` | Byte-verified JSON has been explicitly rehydrated for an old binary. The 0.7 runtime refuses ordinary work until a fresh migration/cutover is completed. |
+
+The steady `sqlite` variant contains only selector version, safe generation
+basename, embedded generation ID, and monotonic activation sequence. It never
+contains an external/absolute path, content hash, mutable authority revision,
+or private domain value. Generation names match one fixed ASCII pattern and are
+resolved beneath one fixed directory.
+
+Selector reads reject a symlink/special file, non-UTF-8, oversize content,
+duplicate/unknown/missing fields, unknown state/version, unsafe basename, and
+generation mismatch. Writes create an exclusive same-directory temporary,
+flush and sync it, replace the selector once, sync directory metadata where the
+platform supports it, and read it back. A torn or missing selector after restart
+fails closed; readback is not a claim of power-loss certification.
+
+### Recoverable cutover sequence
+
+1. Create/validate the `json` selector through explicit migration tooling and
+   acquire the exclusive maintenance lease without changing selector state.
+2. While `json` remains selected authority, create and verify a complete current
+   JSON backup and the #144 exact Preview. Revalidate source bytes and the
+   accepted staging candidate.
+3. Only after backup, Preview, and candidate verification succeed, replace the
+   selector with `transition`. Then move the byte-identical original JSON
+   authorities and ancillary migration
+   records, on the same filesystem, into the transition's private retained-JSON
+   generation. Do not merge, rewrite, or delete them. This removes them from all
+   canonical 0.6 production paths and prevents a later old binary from silently
+   writing a second authority.
+4. If any pre-activation step crashes, `transition` causes recovery-only
+   startup. The recovery command uses the recorded digests to restore the whole
+   JSON path family or resumes the same transition. It never selects the staged
+   SQLite database implicitly.
+5. Re-run semantic, identity, schema, integrity, and foreign-key checks; close
+   and sync the new generation. The only activation point is one selector
+   replacement from `transition` to `sqlite`.
+6. Reopen through Runtime Assembly, require the same generation identity, and
+   run the fail-closed startup sequence before releasing the lease. A
+   post-activation reopen failure remains SQLite recovery; it does not restore
+   JSON automatically.
+
+The transition cannot technically stop a deliberately launched unmodified 0.6
+binary from ignoring the new lease while maintenance is in progress. The
+command and user documentation must require all old processes stopped. After
+activation, removing the retained bytes from the legacy default paths prevents
+accidental old-binary writes during ordinary operation.
+
+### Fail-closed post-#147 startup
+
+For CLI, web, and Agent Clients, the startup order is fixed:
+
+1. qualify the exact APSW/runtime/artifact/native cell without resolving an
+   owner-data path;
+2. acquire the shared operation lease;
+3. read and validate the selector; ordinary production accepts only `sqlite`;
+4. resolve the safe basename inside the generation root and open APSW with
+   `READWRITE`, private cache, extended codes, and `NOFOLLOW`, but without
+   `CREATE`, URI interpretation, or a non-default VFS;
+5. require `readonly("main") is False`, the selected generation ID, application
+   ID, supported user version, exact migration registry/digests, schema
+   fingerprint, WAL mode, foreign keys, trusted-schema/defensive settings, and
+   the #139 integrity policy before the first write;
+6. hold the lease for the complete high-level operation and close all APSW
+   objects deterministically.
+
+Missing selector/generation, wrong identity, unsupported schema, malformed
+registry, read-only fallback, sidecar/recovery failure, corruption, failed
+qualification, busy deadline, or unknown exception returns one redacted typed
+failure. None may create a file, scan for another generation, choose the newest
+timestamp, restore a backup, open JSON, or downgrade a binding automatically.
+Fresh installation is an explicit initialization operation; ordinary open never
+turns apparent data loss into a new empty authority.
+
+## Exact 0.7 rollback window
+
+The support window begins when the first `sqlite` selector is activated and
+continues through the **entire 0.7.x release line**, including release
+candidates. A later release may end support only through explicit upgrade and
+recovery documentation plus its own review. There is no wall-clock deletion and
+no automatic cleanup at the boundary.
+
+Two rollback operations are distinct:
+
+- **SQLite-generation rollback:** first back up the current generation, restore
+  the chosen snapshot into a fresh generation, show redacted authority-revision
+  and category-count differences, require explicit apply/data-loss acceptance,
+  then use one `sqlite` selector replacement. The displaced generation and its
+  verified backup remain retained.
+- **0.6 binary rollback:** first back up current SQLite, show that the retained
+  byte-identical JSON baseline cannot include post-cutover SQLite changes, and
+  require explicit data-loss acceptance. Rehydrate the exact JSON family into
+  legacy canonical paths and set `legacy_rollback`; 0.7 ordinary startup then
+  refuses work. Returning to 0.7 requires a new #144 Preview, import into a new
+  generation, and a new cutover. It must never reselect the stale pre-rollback
+  SQLite generation.
+
+The rollback catalog records only private generation/backup identities,
+activation sequence, revisions, compatibility, hashes, and retention status.
+It never authorizes deletion. After the support window, a separate cleanup
+Preview enumerates artifact categories and dependencies, proves each candidate
+is not selected, pending, or the only verified rollback, and requires explicit
+confirmation. Code retirement in #147 is not that cleanup operation.
+
+## Deletion and retention semantics
+
+| Fact or artifact | Required 0.7 behavior |
+| --- | --- |
+| Matching proposal/failure/Approval/Correction/conflict | Import current typed facts exactly. A legacy revoked entry is absent; do not invent its history. Future explicit revocation may retain a non-authoritative event, but no cascade may delete related publication/Approval evidence. |
+| Publication Manifest and Approval outcome | Retain as historical authority/evidence. Active replacement must not cascade-delete the prior Approval facts required by current behavior or recovery. |
+| Active Mirror relationship | Import only the active relationship JSON retained. Explicit keep/delete/relink may end or replace the active row, while Publication/Approval/Effect Journal evidence remains. No pre-cutover removal tombstone is invented. |
+| Transfer and Batch | Retain terminal and incomplete state needed for explanation, retry, and exact migration. Cleanup is not part of #144–#147. |
+| Qualification Draft | Discard and supersession are status/link transitions, not row deletion. Both predecessor and successor remain exact and revisioned. |
+| Effect Journal | Never delete an incomplete or uncertain effect as cleanup. Intent/attempt/observation facts remain until a separately specified reconciliation/retention policy can prove safe removal. |
+| Operational Event | Non-authoritative and rebuildable. Explicit analytics-history deletion cannot cascade to or change authority. Migration fabricates no historical events. |
+| Failed staging file | May be removed only after proving it was created by the current process, was never selected, and is not named by a transition/rollback record. Crash-orphaned stages are quarantined until proven. |
+| Original JSON and migration records | Relocate byte-identically into a private retained generation at cutover. Keep for all 0.7.x rollback support; never rewrite or silently delete. |
+| Active/superseded SQLite generation | Active is mutable authority. Superseded generations are immutable retained artifacts; restore always creates a fresh generation ID. Cleanup is explicit and cannot select by age alone. |
+| Backup/archive | Immutable private historical artifact. It may retain logically deleted bytes. Current-state deletion never reaches backward into backups. |
+| JSON writer code/locks/temp-name conventions | Remove from production interfaces in #147. Removing code does not remove user files or automatically unlink legacy lock/temp artifacts. |
+
+Foreign keys must default to `RESTRICT`/explicit service operations for
+authority-bearing relationships. Broad `ON DELETE CASCADE` from a convenience
+parent to Approval, Effect Journal, Qualification, or migration evidence would
+make deletion semantics implicit and fails the contract.
+
+## Native crash and recovery matrix
+
+Tests use only synthetic app-data roots and public/domain readers after restart.
+Each named point is exercised both as an injected exception and as a child
+process `os._exit()`/forced termination. A test-only APSW VFS derives from the
+platform default and injects `FullError`/`IOError` at selected `xWrite`, `xSync`,
+`xTruncate`, and `xDelete` calls; production connections continue to reject a
+non-default VFS. SQLite itself uses modified VFS implementations for its crash
+testing, and APSW exposes VFS and VFSFile overrides for this purpose
+([SQLite atomic-commit crash testing](https://www.sqlite.org/atomiccommit.html#testing_atomic_commit_behavior),
+[APSW VFS](https://rogerbinns.github.io/apsw/vfs.html)).
+
+| Flow | Mandatory crash/fault points | Evidence after restart |
+| --- | --- | --- |
+| #144 JSON Preview | lease acquisition; every source read/hash; strict decode; each category import; before/after transaction commit; semantic/identity/integrity checks; source revalidation; token emission; staging cleanup | Every original input byte and presence state is unchanged; selector unchanged; no stage is selectable; result is exact success or a redacted failure. |
+| #145 online backup | destination exclusive create/open; each `Backup.step`; busy/locked deadline; `finish`; DELETE-mode conversion; close; integrity/FK/semantic verification; hash; each archive member; archive sync and replace | Active generation remains usable; incomplete destination is rolled back/rejected; final archive name is absent, the prior complete archive, or one complete verified new archive. |
+| #145 restore | archive directory/member validation; bounded stream; every identity/security/integrity check; new generation-ID transaction; current backup; before/after selector replacement; reopen | Archive and old generation unchanged; selector names one complete old or new generation; wrong/corrupt input never becomes selected. |
+| #146 cutover | `json`→`transition`; current backup; each JSON relocation; staging revalidation; generation sync; temporary selector write/sync; immediately before/after `transition`→`sqlite`; Runtime Assembly reopen | Before final replacement, JSON is the recoverable authority and recovery can restore the whole path family. After it, only the complete SQLite generation is authority. No canonical JSON writer remains reachable. |
+| #147 startup | absent/malformed/torn/symlink selector; unsafe basename; missing/symlink/read-only/wrong generation; unsupported migration; corrupt main/WAL; qualification revocation; busy and I/O faults | Stable redacted unavailable/recovery result; no file creation, fallback, generation scan, JSON read/write, or partial client graph. |
+| Rollback | current backup; redacted diff; JSON rehydrate; every selector state replacement; forward re-migration | Exactly one explicit mode is selected. Post-cutover state is backed up, retained baseline unchanged, and returning to SQLite uses a new verified generation. |
+
+Run the focused interface, backup, selector, and hard-exit suite on every native
+OS/architecture shape claimed by #167: Ubuntu 24.04 x64/ARM64, macOS 15
+Intel/Apple silicon, and Windows Server 2025 x64. Run Python 3.10 and 3.14 edge
+jobs at minimum on Linux and run the focused Operational Store suite on all 25
+qualified Python/OS/architecture cells before #149 freezes 0.7.0rc1. Native
+tests must include Windows open-handle/replacement behavior, POSIX stale-open
+handle behavior, same-filesystem selector replacement, concurrent WAL readers,
+backup source writers, full disk, permission/read-only fallback, and paths with
+spaces/non-ASCII characters.
+
+Ordinary CI cannot certify arbitrary power loss or faulty storage hardware. It
+can prove the application state machine under hard process exit, VFS I/O faults,
+and native filesystem behavior. Reports record only platform/runtime identity,
+fault-point name, reason code, and pass/fail—not private paths, SQL, rows, or
+generated databases.
+
+## Ready-to-paste issue amendments
+
+These additions preserve the existing issue boundaries and dependency order.
+
+### Amend #144
+
+Add to acceptance criteria:
+
+- [ ] The exact input catalog is frozen: canonical matching versions 1–3,
+  publication versions 1–7, Transfer versions 1–6, and version-1 legacy and
+  foundation migration facts. Configuration, credentials, reports, source
+  files, and archive-only aliases are excluded; an ambiguous canonical/alias
+  family fails closed.
+- [ ] One exclusive maintenance lease is honored by every current JSON writer;
+  Preview records and revalidates each source's presence, identity, bytes, size,
+  and SHA-256 before releasing it.
+- [ ] JSON parsing rejects duplicate keys, non-finite numbers, unsupported or
+  unknown shapes, symlinks, special files, and bounded-resource violations; it
+  does not use the permissive initial `MatchCache.load()` path.
+- [ ] A versioned typed semantic projection compares all fields, explicit
+  absence/null, logical relationships, revisions, ordered duplicates, and every
+  incomplete-effect mapping; migration fabricates no authority, Effect Journal
+  completion, or Operational Event history.
+- [ ] The staging database uses only the qualified APSW runtime, is outside the
+  selectable generation root, and cannot be activated by #144. The redacted,
+  expiring Preview token binds all source, projection, and target-schema facts.
+
+### Amend #145
+
+Add to acceptance criteria:
+
+- [ ] Backup uses APSW 3.53.4.0's destination-owned Online Backup API with
+  distinct qualified connections, bounded step/deadline handling, mandatory
+  `finish()`, and destination-derived revision/semantic facts.
+- [ ] The archived database is closed, verified, `journal_mode=DELETE`, and has
+  no WAL/SHM/hot journal. Restore opens it with no URI/create/symlink following,
+  trusted schema off, defensive limits, full integrity, and foreign-key checks.
+- [ ] Restore apply never overwrites the active file; it backs up current
+  authority, creates a verified new physical generation with a new generation
+  ID, and activates only through the shared selector protocol.
+- [ ] The manifest/archive has an exact allowlist and resource limits. Reports
+  are privacy-redacted, hashes are not described as authenticity, and users are
+  told backups may retain logically deleted bytes.
+- [ ] SQLite-generation and 0.6 rollback remain supported through all 0.7.x;
+  expiry never deletes an artifact. Native hard-exit, APSW VFS-fault, hostile
+  archive, and selector tests pass on every claimed platform shape.
+- [ ] Update canonical `docs/storage.md` in the same change to replace its
+  standard-library `Connection.backup()` example with the destination-owned APSW
+  Online Backup mechanism. Research prose does not override canonical storage
+  guidance.
+
+### Amend #146
+
+Add to acceptance criteria:
+
+- [ ] The authority selector has explicit `json`, `transition`, `sqlite`, and
+  `legacy_rollback` states. Missing/unknown/torn state never means JSON or a new
+  empty database; ordinary startup and initialization are separate.
+- [ ] Every high-level client operation shares the Runtime Assembly operation
+  lease. Apply obtains its exclusive form, drains all clients, and closes all
+  APSW objects before changing a selector.
+- [ ] Before final activation, byte-identical JSON is moved into a verified
+  retained generation outside every legacy runtime default path. A crash in the
+  transition state restores the complete JSON family or resumes the exact bound
+  transition; it never selects staging.
+- [ ] The sole activation point is one same-directory selector replacement from
+  `transition` to the complete verified `sqlite` generation. Before it JSON is
+  recoverable authority; after it SQLite is sole authority. Reopen failure is
+  SQLite recovery, never fallback.
+- [ ] Runtime qualification precedes path resolution. Selected opens use APSW
+  with no create/URI/non-default VFS, verify writable mode and every identity,
+  and fail closed without scanning another generation.
+- [ ] Old-version rollback requires a current SQLite backup and explicit
+  post-cutover data-loss acknowledgement, selects `legacy_rollback`, and a
+  return to 0.7 requires a fresh Preview and new generation.
+
+### Amend #147
+
+Add to acceptance criteria:
+
+- [ ] Ordinary CLI, web, and Agent startup accepts only a valid `sqlite`
+  selector and exact qualified generation. Missing/malformed/wrong/read-only/
+  corrupt state returns a redacted recovery result and creates or selects
+  nothing.
+- [ ] Production exports no JSON writer, default JSON authority path, generic
+  JSON adapter, hidden fallback, or client-specific selector. Strict versioned
+  legacy codecs remain reachable only from explicit migrate/rollback tooling
+  for the full 0.7.x support window.
+- [ ] Removing writer/lock/temp-path code does not delete user files. Retained
+  JSON remains byte-identical outside old runtime paths; legacy lock/temp
+  artifacts are private and cleaned only through a separately Previewed action.
+- [ ] Interface tests preserve the exact deletion/retention matrix: discarded
+  and superseded drafts, Approval/publication history, incomplete Effect
+  Journal facts, and rollback artifacts are retained; authority-bearing foreign
+  keys do not disappear through broad cascades; Operational Event deletion
+  cannot change authority.
+- [ ] Native startup/crash tests prove no partial graph, old-generation writer,
+  old-binary default-path authority, auto-created empty database, or JSON
+  fallback after selector loss.
+
+## Completion evidence required across #144–#147
+
+Each PR must provide its own release-note record but no tag, release, package,
+live provider, or owner-data action. Before merge, review the fixed-base diff for
+exact scope and prove:
+
+- the upstream ticket commits it depends on are accepted and idle;
+- focused interface/conformance tests and the complete offline suite pass;
+- APSW is imported only inside the private Operational Store adapter and Python
+  `sqlite3` never opens a store;
+- native runtime qualification remains fail closed before private-path access;
+- repository privacy and built wheel/sdist inspection exclude database families,
+  selectors, transition/rollback catalogs, JSON generations, snapshots,
+  backups, staging, diagnostics, query exports, reports, and test output;
+- every crash point yields one complete recognized authority or an explicit
+  recovery state; and
+- the issue body and user documentation state the exact 0.7.x retention and
+  rollback behavior before code claims completion.
+
+## Primary sources
+
+- DJ Support:
+  [ADR-0005](https://github.com/spontain112/djsupport/blob/3e6ae7f6157364eeedaa2667d2a1deabed9efcee/docs/adr/0005-use-one-local-transactional-operational-store.md),
+  [storage model](https://github.com/spontain112/djsupport/blob/3e6ae7f6157364eeedaa2667d2a1deabed9efcee/docs/storage.md),
+  [Runtime Assembly](https://github.com/spontain112/djsupport/blob/3e6ae7f6157364eeedaa2667d2a1deabed9efcee/djsupport/runtime.py),
+  [current JSON adapters](https://github.com/spontain112/djsupport/blob/3e6ae7f6157364eeedaa2667d2a1deabed9efcee/djsupport/transfer.py),
+  [runtime delivery](https://github.com/spontain112/djsupport/blob/3e6ae7f6157364eeedaa2667d2a1deabed9efcee/docs/sqlite-runtime-delivery.md),
+  [#144](https://github.com/spontain112/djsupport/issues/144),
+  [#145](https://github.com/spontain112/djsupport/issues/145),
+  [#146](https://github.com/spontain112/djsupport/issues/146), and
+  [#147](https://github.com/spontain112/djsupport/issues/147).
+- APSW 3.53.4.0:
+  [Backup](https://rogerbinns.github.io/apsw/backup.html),
+  [Connection](https://rogerbinns.github.io/apsw/connection.html),
+  [exceptions](https://rogerbinns.github.io/apsw/exceptions.html), and
+  [VFS](https://rogerbinns.github.io/apsw/vfs.html).
+- SQLite:
+  [Online Backup API](https://www.sqlite.org/backup.html),
+  [WAL](https://www.sqlite.org/wal.html),
+  [WAL file lifecycle](https://www.sqlite.org/walformat.html),
+  [open flags](https://www.sqlite.org/c3ref/open.html),
+  [untrusted database guidance](https://www.sqlite.org/security.html),
+  [integrity and secure-delete pragmas](https://www.sqlite.org/pragma.html),
+  [`VACUUM INTO`](https://www.sqlite.org/lang_vacuum.html),
+  [corruption hazards](https://www.sqlite.org/howtocorrupt.html), and
+  [atomic-commit crash testing](https://www.sqlite.org/atomiccommit.html).
+- Python:
+  [`json`](https://docs.python.org/3.14/library/json.html),
+  [`zipfile`](https://docs.python.org/3.14/library/zipfile.html),
+  [`os`](https://docs.python.org/3.14/library/os.html), and
+  [`hashlib`](https://docs.python.org/3.14/library/hashlib.html).

--- a/docs/research/2026-08-16-operational-store-diagnostics-deepening-contract.md
+++ b/docs/research/2026-08-16-operational-store-diagnostics-deepening-contract.md
@@ -1,0 +1,614 @@
+# Operational Store diagnostics and Qualification deepening contract
+
+**Date:** 2026-08-16
+
+**Status:** implementation-readiness research; both delivery tickets remain
+blocked by #147
+
+**Baseline:** [`origin/main` at `3e6ae7f`](https://github.com/spontain112/djsupport/commit/3e6ae7f6157364eeedaa2667d2a1deabed9efcee)
+
+**Source policy:** repository truth plus first-party SQLite and APSW 3.53.4.0
+documentation only
+
+**Contract precedence:** The ready-to-paste issue amendments are the proposed
+normative execution delta; the preceding sections explain and source that delta.
+Once an amendment is accepted into an issue, the issue body is authoritative.
+Do not combine conflicting versions—reconcile the amendment first.
+
+## Decision
+
+[#130](https://github.com/spontain112/djsupport/issues/130) and
+[#132](https://github.com/spontain112/djsupport/issues/132) can be made
+implementation-ready now, but neither can start before
+[#147](https://github.com/spontain112/djsupport/issues/147) is complete on an
+accepted commit.
+
+- #130 remains a conditional deletion test, not a mandatory extraction. The
+  current evidence shows a coherent, substantial Qualification cluster inside
+  `Transfer`, but the test must be rerun against the post-#147 interface. If a
+  private module does not hide the complete invariant set without becoming a
+  second policy interface, close #130 with evidence.
+- #132 needs one correction to its execution lane. Reading diagnostics is
+  query-only, but installing versioned SQL views and explicitly deleting event
+  history are writes. Permit exactly one diagnostics-owned schema migration and
+  one expected-epoch/count maintenance operation. Do not expose a generic SQL,
+  event-write, or Operational Store mutation interface.
+- “Spotify request cost” means locally retained **claimed request-attempt
+  units** and requested-item units, with uncertainty kept explicit. A durable
+  claim is committed immediately before one bounded adapter call; a crash can
+  occur after that commit but before the network call, so the unit is a
+  conservative upper bound and not proof that Spotify received a request. It
+  does not mean money, Spotify billing, rate-limit quota units, or an estimate
+  of provider cost.
+- Analytics deletion has two truthful layers. The required result is atomic
+  logical deletion of the previewed Operational Events without changing any
+  authority or Effect Journal row. SQLite-level overwrite/checkpoint facts are
+  reported separately and never imply erasure from backups, snapshots, retained
+  generations, or physical media.
+
+This packet does not change production authority, define a public Agent Client
+contract, authorize telemetry, or authorize live/owner-data verification.
+
+## Current-state evidence
+
+### Dependency and implementation state
+
+Both issue bodies still declare #147 as their blocker. ADR-0005 makes compact
+Operational Events private and non-authoritative, allows explicit analytics
+history deletion, and keeps Transfer as policy authority
+([ADR-0005](https://github.com/spontain112/djsupport/blob/3e6ae7f6157364eeedaa2667d2a1deabed9efcee/docs/adr/0005-use-one-local-transactional-operational-store.md#L3-L30)).
+The storage guide likewise says views are rebuildable projections and deletion
+must not alter Transfers, Approval, Matching Knowledge, publication state, or
+Effect Journal recovery facts
+([storage contract](https://github.com/spontain112/djsupport/blob/3e6ae7f6157364eeedaa2667d2a1deabed9efcee/docs/storage.md#L198-L209)).
+
+Current `origin/main` contains runtime qualification and artifact delivery under
+`djsupport/operational_store/`, but no production Operational Event table,
+diagnostics view, diagnostics document, or analytics-deletion implementation.
+In particular,
+[`djsupport/operational_store/qualification.py`](https://github.com/spontain112/djsupport/blob/3e6ae7f6157364eeedaa2667d2a1deabed9efcee/djsupport/operational_store/qualification.py)
+already means **SQLite runtime qualification**. #130 must not reuse
+`qualification.py` or create an import name that makes runtime qualification and
+Transfer Qualification ambiguous.
+
+Privacy scaffolding is ahead of the implementation: current ignore rules and
+repository tests already cover `djsupport-operational-events*`,
+`djsupport-analytics*`, `djsupport-diagnostics*`, and query exports
+([`.gitignore`](https://github.com/spontain112/djsupport/blob/3e6ae7f6157364eeedaa2667d2a1deabed9efcee/.gitignore#L30-L51),
+[`tests/test_repository_privacy.py`](https://github.com/spontain112/djsupport/blob/3e6ae7f6157364eeedaa2667d2a1deabed9efcee/tests/test_repository_privacy.py#L10-L86)).
+Those are necessary delivery guards, not evidence that a diagnostics projection
+is private by construction.
+
+### Exact current deletion-test inventory for #130
+
+At the pinned baseline:
+
+| Evidence | Exact current fact | Why it matters after #147 |
+| --- | --- | --- |
+| Domain values | Eight Qualification-specific value types live in `transfer.py`: decision, status, request, durable draft state, item, view, apply outcome, and Approval outcome ([types](https://github.com/spontain112/djsupport/blob/3e6ae7f6157364eeedaa2667d2a1deabed9efcee/djsupport/transfer.py#L351-L543), [Approval outcome](https://github.com/spontain112/djsupport/blob/3e6ae7f6157364eeedaa2667d2a1deabed9efcee/djsupport/transfer.py#L858-L869)). | The public types must continue to be obtained from `djsupport.transfer`; an internal module must not become a second caller-facing seam. |
+| Transfer lifecycle | `Transfer` presents nine Qualification operations: obtain, view, link, record, audition, discard, supersede, apply, and approve. | These nine existing operations remain the only public policy interface. Do not disguise their real lifecycle complexity behind an untyped `execute(command)` method. |
+| Hidden implementation | The same class contains twelve Qualification-specific helpers: Transfer selection, three evidence digests, item construction, audition preflight, view construction, Approval serialization/deserialization/summary, application projection, and chunk application ([workflow span](https://github.com/spontain112/djsupport/blob/3e6ae7f6157364eeedaa2667d2a1deabed9efcee/djsupport/transfer.py#L2693-L4555)). | These helpers are the candidate implementation to concentrate, provided the post-#147 Effect Journal and store operations can stay internal. |
+| Old persistence interface | `TransferStorage` has four Qualification-specific methods: load, save, atomically save successor, and list by playlist ([protocol](https://github.com/spontain112/djsupport/blob/3e6ae7f6157364eeedaa2667d2a1deabed9efcee/djsupport/transfer.py#L1143-L1169)). | Re-inventory the accepted Operational Store after #147. A deepening must consume it; it must not wrap it in a second public repository interface. |
+| Behavioral tests | `tests/test_qualification.py` contains exactly 23 public-behavior tests spanning attention selection, decisions, application, Approval, duplicate occurrences, drift/conflict stops, restart, idempotency, linking, concurrency, migration, discard/supersession, redaction, and audition retirement ([test module](https://github.com/spontain112/djsupport/blob/3e6ae7f6157364eeedaa2667d2a1deabed9efcee/tests/test_qualification.py)). | These tests stay at the Transfer seam. They are not replaced by tests of a new internal class. |
+| Thin clients | Agent rendering has eight Qualification operations and web has ten Qualification routes, all intended to render Transfer behavior ([Agent adapter](https://github.com/spontain112/djsupport/blob/3e6ae7f6157364eeedaa2667d2a1deabed9efcee/djsupport/agent.py#L639-L916), [web adapter](https://github.com/spontain112/djsupport/blob/3e6ae7f6157364eeedaa2667d2a1deabed9efcee/djsupport/web.py#L670-L969)). | No client may import the internal module or learn store ordering, revision, digest, or Effect Journal rules. |
+| Leaked coordination | CLI currently performs one direct Qualification load and web performs two direct Qualification loads to recover context ([CLI](https://github.com/spontain112/djsupport/blob/3e6ae7f6157364eeedaa2667d2a1deabed9efcee/djsupport/cli.py#L794-L808), [web](https://github.com/spontain112/djsupport/blob/3e6ae7f6157364eeedaa2667d2a1deabed9efcee/djsupport/web.py#L580-L661)). | Recheck these after #147. #130 passes only if context recovery is Transfer-owned or a non-policy Runtime Assembly lookup; clients must not reconstruct lifecycle policy. |
+
+Line count is not the depth test. The evidence is the set of invariants and
+ordering knowledge that would have to reappear outside the candidate module if
+it were deleted. A passing design must increase **Depth** by hiding that
+complexity behind a smaller internal Interface, increase **Leverage** because
+the same hidden rules serve multiple Transfer operations, and improve
+**Locality** by keeping each invariant in one place. Moving names or lines
+without those three effects fails the test.
+
+## #130 contract: rerun the deletion test after #147
+
+### Invariant families that must move together
+
+The post-#147 inventory must account for all of these families before any
+refactor begins:
+
+1. Rekordbox-only eligibility, completed Mirror eligibility, bounded Transfer
+   and Source Selection ownership, and unchanged browser-origin behavior.
+2. Draft identity and lineage: Transfer, Batch when present, account, playlist,
+   playlist head, Publication Manifest, selected Source Occurrences, supersedes,
+   successor, and optimistic revision.
+3. Selection, manifest, and audition-evidence digests; exact order and duplicate
+   Source Occurrences; evidence-changed stop conditions.
+4. Attention selection and the non-authoritative keep, Correction, deferred,
+   exclusion, and rejection state machine. Pending/deferred work still blocks
+   apply and Approval.
+5. Explicit private-source authorization, bounded audition identity, unavailable
+   media outcomes, and process-local handle invalidation without persistence;
+   no path, filename, audio, fingerprint, account/playlist/track identifier, or
+   private source fact may cross a privacy-redacted client interface.
+6. Explicit Spotify-write authorization, stable playlist-head validation, one
+   Effect Journal entry per bounded Spotify call, pause/resume/reconciliation,
+   and idempotent completion without guessing.
+7. Separate playlist-scoped Approval, stable manifest/head validation,
+   collision/conflict handling, authority-only commit, and replay of an already
+   completed outcome.
+
+The current code repeats account, manifest, selection, playlist-head, status,
+and review-required checks across obtain, link, record, apply, and approve. #147
+will change their persistence mechanics, so the merged #147 commit—not this
+baseline—decides whether those repetitions remain and whether deepening is
+earned.
+
+### Accepted module shape if the test passes
+
+- Keep `Transfer` as the external seam and preserve its nine Qualification
+  operations and public result types.
+- Use one private Transfer-owned implementation module, recommended name
+  `djsupport/_qualification_workflow.py`. Do not use
+  `djsupport/operational_store/qualification.py`, which already owns SQLite
+  runtime qualification.
+- Only `Transfer` may construct/call the private module. CLI, web, Agent Client,
+  Runtime Assembly, and Operational Store adapters must not import it.
+- Inject the accepted Operational Store, Spotify and local-audition Interfaces,
+  clock, retry/pause controls, and Effect Journal capability. Do not construct
+  production Adapters inside the module.
+- Keep matching/publication/Approval policy in this Transfer-owned
+  implementation. The Operational Store retains facts and performs atomic units
+  of work; it does not decide lifecycle transitions.
+- Do not create a generic command bus or a second public “Qualification
+  interface.” Collapsing nine typed operations into one untyped method is not
+  depth; it merely moves the interface knowledge into command values and
+  ordering rules.
+
+### Exact deletion-test procedure
+
+Run this only on the accepted #147 commit:
+
+1. Record the fixed commit and inventory every Qualification production symbol,
+   every non-test caller, every Operational Store operation it uses, and every
+   existing Transfer-level behavior test. Include the command output in the
+   issue/PR evidence.
+2. Write the first failing Transfer tests for any invariant not already covered;
+   parameterize only the internal recovery mechanics over in-memory and SQLite
+   adapters.
+3. Prepare the candidate private module without changing client-visible
+   behavior. Preserve the complete Transfer, Agent, web, CLI, privacy, backup,
+   migration, and package suites.
+4. In a throwaway deletion diff, remove the candidate module. Fill this evidence
+   table for each of the seven invariant families: `lost behavior`, `where the
+   rule must be reimplemented`, `affected Transfer operation`, and `public test
+   that proves it`. The module passes only when deletion forces substantial
+   policy/recovery knowledge back into `Transfer` or duplicates it across
+   callers/adapters.
+5. Fail the deletion test if removing the module eliminates complexity, leaves
+   only delegation glue, requires callers to learn the private module, or moves
+   policy into the Operational Store. Close #130 with that evidence and no
+   forced refactor.
+6. If it passes, delete superseded shallow tests. Keep public behavior at the
+   Transfer seam; retain narrower direct tests only for crash/recovery mechanics
+   that cannot be observed more precisely through Transfer.
+
+A release-note record is needed only if distributable behavior or packaging
+changes. A behavior-preserving internal move alone does not earn a user-facing
+release claim.
+
+## #132 contract: allowed diagnostics and deletion seam
+
+### Resolve the issue's read-only-lane contradiction
+
+The existing issue asks for SQL views and deletion while saying the lane only
+consumes a read-only query interface. Those requirements cannot all be true
+without a narrow write seam. Permit exactly:
+
+1. one versioned, diagnostics-owned Operational Store migration that installs
+   or replaces named ordinary views; and
+2. `delete_analytics_history(expected_epoch, expected_event_count)`, a typed
+   maintenance operation implemented by the Operational Store.
+
+All document rendering uses a read-only diagnostics query interface. There is
+no generic `execute_sql`, view builder, event writer, table delete, predicate,
+or user-supplied query. Transfer remains the only ordinary event producer and
+the only policy authority.
+
+SQLite ordinary views are read-only unless writable behavior is deliberately
+added with `INSTEAD OF` triggers. Define every view with an explicit column-name
+list and add no such triggers
+([SQLite `CREATE VIEW`](https://sqlite.org/lang_createview.html)). The view
+definitions live in the application migration registry, not in diagnostics
+requests.
+
+### Compact Operational Event allowlist
+
+Implement one `STRICT` event table so SQLite enforces declared storage types and
+integrity checks cover type violations
+([SQLite STRICT tables](https://sqlite.org/stricttables.html)). The physical
+schema may use the post-#147 table names, but its logical fields are frozen here:
+
+| Field | Allowed meaning |
+| --- | --- |
+| `commit_sequence` | Non-negative Operational Store commit sequence inherited from the foundation schema. It is never emitted and is not reset or reused when analytics history is deleted. |
+| `event_ordinal` | Non-negative event position within one commit sequence. Together with `commit_sequence`, it remains the frozen primary key `(commit_sequence, event_ordinal)`. |
+| `analytics_epoch` | Non-authoritative integer generation copied from diagnostics metadata when the event is appended. |
+| `recorded_at_utc` | Canonical internal UTC fact instant. It is never used to choose a latest state, emitted, or grouped in 0.7. |
+| `category` | One of the six categories below; enforced by a constraint/registry. |
+| `source_kind` | Exactly `rekordbox`, `beatport_chart`, `beatport_label`, or `not_applicable`; never null. No display label or source reference. |
+| `phase` | `intake`, `matching`, `publication`, `qualification`, `qualification_apply`, `approval`, `mirror_maintenance`, or `recovery`. |
+| `outcome` | A category-scoped code from the table below. Never provider/user text. |
+| `reason_code` | A category-scoped stable code from the table below. Never a raw exception, report message, or source fact. |
+| `attempt_units` | Non-negative integer. Exactly `1` on a `spotify_request` claim and `0` on its observation; zero for non-request events. A claim is committed immediately before the bounded adapter call, but a crash can intervene, so this is a conservative claimed-attempt unit rather than proof that a network request started. |
+| `item_units` | Non-negative integer. For `spotify_request`, it is set only on the claim and is the number of query/item inputs presented to that bounded attempt, not unique recordings; observations use zero. It is exactly `1` for proposal/match subjects and `0` for Transfer/resume/effect subjects. Unknown request size is `0`, never null. |
+| `subject_kind` | Closed private enum identifying the event subject family: `transfer`, `spotify_request`, `qualification_proposal`, `resume`, `effect`, or `match_fact`, matching the six categories one-to-one. It is never emitted. |
+| `subject_id` | Required opaque, store-owned identity for one subject within its family. It may be a random token or keyed digest, but never a raw Transfer, Batch, Effect, account, source, playlist, track, provider, or filesystem identifier. It is copied into the event as a scalar, is never emitted, and is not a foreign key. |
+| `subject_revision` | Non-negative integer that increases monotonically for each `(category, subject_kind, subject_id)`. A request claim and its observation have separate revisions; proposal/effect latest-state projections select the greatest revision. |
+
+Enforce
+`UNIQUE(category, subject_kind, subject_id, subject_revision)`. Recording is
+insert-or-verify: retrying the same key succeeds only when every logical field
+is identical; a mismatched duplicate is an integrity failure and rolls back the
+associated local authority transaction. The event table has **no foreign keys
+to authority or across subject families**. Authority deletion therefore cannot
+rewrite an event, and ordinary history remains append-only until the explicit
+whole-history deletion operation runs.
+
+No event may contain an arbitrary JSON payload, free-form detail/message,
+provider response, exception text, SQL, path, filename, source metadata,
+Spotify URI, playlist/account identifier, fingerprint, credential, report, or
+diagnostics document.
+
+The category registry is:
+
+| Category | Exact v1 outcomes | Exact v1 reason vocabulary |
+| --- | --- | --- |
+| `transfer_transition` | `completed`, `paused`, `partial_success`, `failed`, `abandoned`, `review_required` | `none`, `user_pause`, `store_busy`, `stale_revision`, `source_unavailable`, `account_changed`, `playlist_changed`, `manifest_changed`, `selection_changed`, `review_conflict`, `provider_failure`, `integrity_failure` |
+| `spotify_request` | `claimed`, `observed_success`, `observed_failure`, `observed_rate_limited`, `uncertain` | `none`, `retryable_provider_failure`, `quota_or_rate_limit`, `non_retryable_provider_failure`, `response_unknown`, `observation_missing`, `reconciliation_required` |
+| `proposal_transition` | `proposed`, `kept`, `corrected`, `rejected`, `deferred`, `excluded`, `approved`, `unresolved`, `collision`, `conflict` | `none`, `user_decision`, `explicit_correction`, `explicit_exclusion`, `explicit_rejection`, `playlist_review`, `approval_conflict`, `match_collision`, `no_acceptable_candidate` |
+| `resume_transition` | `resumed`, `already_complete`, `paused`, `completed`, `review_required`, `failed` | `none`, `checkpoint`, `prepared_effect`, `in_flight_effect`, `observation_pending`, `reconciliation_required`, `stale_revision` |
+| `effect_transition` | `prepared`, `in_flight`, `observed_complete`, `observed_not_applied`, `uncertain`, `reconciled_complete`, `reconciled_not_applied`, `review_required` | `none`, `not_attempted`, `call_claimed`, `remote_completion_proven`, `remote_not_applied_proven`, `remote_state_ambiguous`, `provider_failure` |
+| `match_outcome` | `proposed`, `approved`, `rejected`, `corrected`, `unresolved`, `reused`, `collision`, `conflict` | `exact`, `shorter_version`, `fallback_version`, `approved_reuse`, `approved_local_audio_reuse`, `correction`, `no_acceptable_candidate`, `unavailable`, `match_collision`, `approval_conflict` |
+
+Adding a source, phase, outcome, or reason is a reviewed registry/schema change.
+An unknown value rolls back the associated local transaction, leaving every
+authority row at its previous revision. The event may be committed in the same
+local transaction as the domain change, but no domain operation may later read
+an event to make an authority or recovery decision.
+
+### Required read-only views
+
+Install ordinary, explicitly named views with only aggregate columns:
+
+1. `diagnostic_transfer_outcomes(source_kind, phase, outcome, reason_code,
+   event_count)`;
+2. `diagnostic_spotify_request_cost(source_kind, phase, request_state,
+   reason_code, claimed_attempt_units, requested_item_units,
+   uncertain_attempt_units)`;
+3. `diagnostic_proposal_progression(source_kind, phase, outcome, reason_code,
+   item_units, event_count)`;
+4. `diagnostic_resume_outcomes(source_kind, phase, outcome, reason_code,
+   event_count)`;
+5. `diagnostic_effect_transitions(phase, outcome, reason_code, event_count)`;
+6. `diagnostic_match_outcomes(source_kind, phase, outcome, reason_code,
+   item_units, event_count)`; and
+7. `diagnostic_incomplete_effects(phase, latest_outcome, reason_code,
+   effect_count)`.
+
+All seven derive only from Operational Events. Proposal progression selects the
+greatest `subject_revision` per proposal before grouping, so one proposal is not
+counted once per transition. The incomplete-effect view likewise selects the
+greatest revision per effect and includes only `prepared`, `in_flight`,
+`uncertain`, and `review_required`. It never reads the Effect Journal. After
+analytics-history deletion this view truthfully becomes empty while Transfer
+continues to recover from the untouched authoritative Effect Journal.
+
+Every view groups inside SQL, exposes no private subject key, and has no
+per-event row. For one `spotify_request` subject, revision zero is the durable
+claim and a later revision is its conclusive observation or explicit uncertain
+observation. The cost view joins each claim to its greatest revision and counts
+the claim exactly once. A claim with no later observation—such as after a crash
+between claim commit and adapter result—is projected as `request_state =
+uncertain`, `reason_code = observation_missing`; an explicit uncertain
+observation is also uncertain. Claimed-attempt and requested-item units are
+therefore retained, conservative local evidence, never money, provider quota,
+billing, exact network-start counts, or Spotify internal accounting.
+
+### Consistent and private projection
+
+- Query all seven views and analytics metadata in one explicit read transaction,
+  exhaust/close every cursor, then render the document. SQLite guarantees that
+  an active read transaction continues to see one historic snapshot while
+  another connection writes
+  ([SQLite transactions](https://sqlite.org/lang_transaction.html#read_transactions_versus_write_transactions)).
+- Obtain the connection only through the accepted Operational Store query
+  interface. If #132 opens a dedicated connection, open it with APSW
+  `SQLITE_OPEN_READONLY` and require `Connection.readonly("main") is True`
+  ([APSW read-only open](https://rogerbinns.github.io/apsw/example.html#opening-the-database),
+  [`Connection.readonly`](https://rogerbinns.github.io/apsw/connection.html#apsw.Connection.readonly)).
+  `PRAGMA query_only` alone is insufficient because SQLite documents that it can
+  still checkpoint or commit
+  ([SQLite `query_only`](https://sqlite.org/pragma.html#pragma_query_only)).
+- Verify the connection returns to no transaction with APSW `txn_state()` after
+  all rows are consumed
+  ([APSW `txn_state`](https://rogerbinns.github.io/apsw/connection.html#apsw.Connection.txn_state)).
+- Build the JSON from literal keys and typed aggregate values. Do not serialize
+  arbitrary rows, expose a database connection, accept filters by private ID, or
+  echo exception text.
+
+The exact experimental document is:
+
+```json
+{
+  "contract": "djsupport.local-diagnostics",
+  "version": "0.7-experimental-1",
+  "stability": "experimental",
+  "analytics_epoch": 0,
+  "event_count": 0,
+  "transfer_outcomes": [],
+  "spotify_request_cost": [],
+  "proposal_progression": [],
+  "resume_outcomes": [],
+  "effect_transitions": [],
+  "incomplete_effects": [],
+  "match_outcomes": []
+}
+```
+
+Rows contain only the view columns above and are explicitly ordered by their
+category columns. The document excludes event/time IDs; Transfer, Batch, Draft,
+Effect, account, source, playlist, and track identifiers; paths and source
+metadata; Spotify URIs; fingerprints; credentials; SQL/schema/query plans; raw
+exceptions; and per-event details. Stable redacted reason codes are permitted.
+The document is private local user data, is ignored and package-rejected, and
+is not accepted by `AgentTransferContract` or any stable Agent Client renderer.
+
+### Explicit analytics-history deletion
+
+Use a two-step, typed maintenance flow:
+
+1. `preview_analytics_history_deletion()` reads one snapshot and returns only
+   `analytics_epoch`, `event_count`, and category counts.
+2. `delete_analytics_history(expected_epoch, expected_event_count)` begins one
+   bounded `BEGIN IMMEDIATE` transaction, rechecks both values, and fails with a
+   redacted `analytics_history_changed` outcome if either differs. It then
+   deletes every Operational Event, obtains the directly deleted row count from
+   APSW `Connection.changes()`, increments the analytics epoch, and commits
+   ([APSW `changes`](https://rogerbinns.github.io/apsw/connection.html#apsw.Connection.changes),
+   [SQLite `DELETE`](https://sqlite.org/lang_delete.html)).
+
+The operation has no predicate, date range, category selector, cascade into
+authority, or caller-supplied SQL. On success:
+
+- all seven event-derived views are empty;
+- Transfer, Batch, Qualification, Publication, Approval, Matching Knowledge,
+  Mirror, Effect Journal, migration, backup, and authority-pointer rows and
+  revisions have a canonical authority projection that is exactly unchanged;
+- later ordinary recording uses the incremented epoch; and
+- the result reports `deleted_events`, new `analytics_epoch`, and only redacted
+  maintenance status.
+
+Logical deletion is not automatically a forensic-erasure claim. SQLite says a
+plain delete normally leaves content in reusable space, while enabling
+`secure_delete` before deletion overwrites deleted content with zeros
+([SQLite `secure_delete`](https://sqlite.org/pragma.html#pragma_secure_delete),
+[SQLite `VACUUM`](https://sqlite.org/lang_vacuum.html)). Therefore the
+maintenance connection must enable and verify `secure_delete=ON` before the
+delete. After commit it may request one bounded `TRUNCATE` checkpoint through
+the canonical Operational Store checkpoint coordinator. A successful TRUNCATE
+checkpoint reduces the WAL to zero bytes; an active reader can block completion
+([SQLite WAL checkpoints](https://sqlite.org/pragma.html#pragma_wal_checkpoint),
+[WAL reader behavior](https://sqlite.org/wal.html#concurrency)).
+
+Report these facts separately as `secure_delete_verified` and
+`wal_cleanup: complete|pending`. If the checkpoint is busy, logical deletion
+stays committed and the result truthfully reports pending WAL cleanup; it does
+not delete sidecars, bypass the maintained checkpoint policy, or restore event
+rows. Do not run `VACUUM` implicitly: SQLite documents that it rewrites the
+database, may require up to twice the database size, and fails with an open
+transaction. Existing backups, snapshots, rollback generations, and physical
+storage may retain older bytes and require their own explicit retention action.
+
+## The 1,000,000-event correctness proof
+
+This is a correctness and privacy test, not a latency contest.
+
+1. Generate exactly 10,000 invented Transfers with 100 events each in bounded
+   production-shaped commits. Each Transfer contributes 1
+   `transfer_transition`, 20 `spotify_request`, 20 `proposal_transition`, 5
+   `resume_transition`, 4 `effect_transition`, and 50 `match_outcome` rows.
+   The exact category totals are therefore 10,000; 200,000; 200,000; 50,000;
+   40,000; and 500,000—exactly 1,000,000.
+2. Cycle source, phase, outcome, and reason codes arithmetically over the closed
+   registries. Of each Transfer's 20 `spotify_request` events, create eleven
+   durable claims and nine later observations: seven successful, one failed,
+   and one explicitly uncertain. Leave two claims without an observation to
+   model a crash before conclusive recording. Claims use `attempt_units=1` and
+   `item_units=(request_index mod 20)+1`; observations use zero for both. Across
+   the fixture this gives 110,000 claimed-attempt units, 70,000 observed-success
+   units, 10,000 observed-failure units, and 30,000 uncertain units (10,000
+   explicit plus 20,000 missing observations). Compute every expected aggregate
+   with an independent formula, not by calling the production projection code.
+3. Put distinctive invented private markers only in the referenced synthetic
+   authority rows. Assert no marker, identifier, forbidden key, path-shaped
+   value, URI, fingerprint, credential-shaped value, SQL, or exception text
+   appears in the document. Assert output row cardinality is bounded by the
+   category vocabularies rather than event count.
+4. Query all views twice in one read snapshot, close/reopen the store, query from
+   a second read-only connection, reinstall the versioned views in a fresh
+   synthetic store, and compare the same explicitly ordered typed tuples and
+   canonical digest each time. Repeat the projection with SQLite
+   `reverse_unordered_selects` first off and then on; both results must be
+   identical because every consumer-visible query has an explicit complete
+   ordering
+   ([SQLite `reverse_unordered_selects`](https://sqlite.org/pragma.html#pragma_reverse_unordered_selects)).
+5. Run full integrity and foreign-key checks. Take and restore the accepted
+   Online Backup snapshot, then compare the same event count and diagnostic
+   projection. Do not compare SQLite bytes, rowids, query plans, or WAL layout.
+6. Preserve at least one incomplete Effect Journal row and its corresponding
+   event revisions. Capture the canonical authority projection, preview
+   deletion, delete with the exact epoch/count, and assert APSW reports
+   1,000,000 directly deleted events. Prove the canonical authority projection
+   is exactly unchanged while all seven event-derived views—including
+   incomplete effects—become empty. Then exercise Transfer recovery for that
+   Effect Journal entry to prove authority remains available without reading an
+   event or diagnostic view.
+7. Append one new event in the next epoch and prove recording/projection still
+   works. Exercise stale epoch, stale count, busy, interrupted delete, commit
+   fault, and blocked checkpoint outcomes without partial history deletion or
+   authority change.
+8. Record elapsed time, database/WAL size, and aggregate query plans only as
+   non-gating diagnostic evidence. Do not assert wall-clock thresholds, compare
+   machines, publish a benchmark, or weaken any exact-count/digest/privacy
+   assertion to make the run faster.
+
+Run the million-event proof in one dedicated fully offline synthetic CI job.
+Run smaller view, read-only, deletion, redaction, and authority-independence
+conformance on every supported native persistence cell. No generated database,
+diagnostics JSON, query export, or timing evidence may be tracked or packaged.
+
+## Ready-to-paste amendment for #130
+
+```markdown
+## Post-#147 execution amendment
+
+This issue remains blocked until #147 is merged. Rerun the deletion test on the
+exact accepted #147 commit; do not infer the result from the pre-cutover JSON
+implementation.
+
+Before editing, inventory every Qualification production symbol, non-test
+caller, Operational Store operation, and Transfer-level behavior test. The
+current pre-#147 baseline has nine public Transfer operations, twelve private
+Qualification helpers, four old storage operations, and 23 tests in
+`tests/test_qualification.py`; report the post-#147 equivalents exactly.
+
+The deletion test covers seven invariant families as one cluster: Rekordbox-only
+eligibility; bounded draft identity/lineage/revision; manifest/selection/head and
+audition evidence; ordered duplicate Source Occurrences and the non-authoritative
+decision state machine; private-source audition; explicit Spotify-write plus
+Effect Journal recovery; and separate stable-head playlist Approval with
+collision/conflict handling.
+
+If earned, keep `Transfer` and its existing typed lifecycle as the sole public
+policy interface and move the implementation behind one private Transfer-owned
+module, recommended `djsupport/_qualification_workflow.py`. Do not reuse
+`djsupport/operational_store/qualification.py`; that name already owns SQLite
+runtime qualification. Only Transfer may call the private module. CLI, web,
+Agent Clients, Runtime Assembly, and store adapters must not import it or learn
+revision/digest/effect ordering.
+
+Prove depth with a throwaway deletion diff: for each invariant family record the
+lost behavior, where it would have to be reimplemented, the affected Transfer
+operation, and the public test that proves it. Pass only if deleting the module
+forces substantial policy/recovery knowledge back into Transfer or duplicates
+it across callers/adapters. Fail if it removes complexity, leaves delegation
+glue, creates a generic command bus, or moves policy into the Operational Store;
+in that case close this issue with the evidence and no forced refactor.
+
+Keep user behavior tested through Transfer. Direct internal tests may cover only
+crash/recovery mechanics. Browser-origin review must remain unchanged. Add a
+release-note record only if distributable behavior or packaging changes.
+```
+
+## Ready-to-paste amendment for #132
+
+```markdown
+## Post-#147 execution amendment
+
+This issue remains blocked until #147 is merged. Its diagnostics reads stay
+read-only, with exactly two narrow writes permitted: one versioned
+diagnostics-owned migration installing named ordinary SQL views, and one
+Operational Store maintenance operation
+`delete_analytics_history(expected_epoch, expected_event_count)`. No generic SQL,
+event-write, predicate-delete, or Transfer-persistence interface is exposed.
+
+Freeze one STRICT compact Operational Event schema with primary key
+`(commit_sequence, event_ordinal)` and six categories:
+`transfer_transition`, `spotify_request`, `proposal_transition`,
+`resume_transition`, `effect_transition`, and `match_outcome`. Fields are limited
+to the internal commit sequence/event ordinal, epoch, and time values; registered
+source kind, phase, outcome, and
+reason codes; non-negative claimed-attempt/item units; and required private
+`subject_kind`, opaque `subject_id`, and monotonic `subject_revision`. Enforce
+`UNIQUE(category, subject_kind, subject_id, subject_revision)` with
+insert-or-verify idempotency: an identical retry succeeds and a mismatched retry
+rolls back the associated authority transaction. Events have no foreign keys to
+authority or across subject families, and no subject identity crosses the query
+interface. Arbitrary JSON, free-form messages, raw exceptions, SQL, paths,
+source metadata, Spotify/account/playlist/track identifiers, fingerprints,
+credentials, and reports are forbidden.
+
+Expose aggregate ordinary views for Transfer outcomes and stop reasons, Spotify
+claimed-attempt units by source/phase, proposal-to-Approved progression, resume
+outcomes, historical Effect transitions, match outcomes by reason, and latest
+incomplete Effect event states. Proposal and incomplete-effect views select the
+greatest subject revision before grouping. Effect outcomes are exactly
+`prepared`, `in_flight`, `observed_complete`, `observed_not_applied`,
+`uncertain`, `reconciled_complete`, `reconciled_not_applied`, and
+`review_required`; incomplete means `prepared`, `in_flight`, `uncertain`, or
+`review_required`. Every view derives only from Operational Events. Views have
+explicit column lists, no identity columns, and no INSTEAD OF triggers.
+
+“Spotify request cost” means locally retained claimed-attempt and requested-item
+units. Commit one `claimed` revision immediately before each bounded adapter
+call, then a later observed-success, observed-failure, observed-rate-limited, or
+explicit-uncertain revision. A claim without a later observation is uncertain:
+a crash can happen before the network call, so claimed units are a conservative
+upper bound, not proof a request started. They are not money, billing, provider
+quota, or an estimate of Spotify's internal accounting.
+
+Render all views from one read snapshot into
+`djsupport.local-diagnostics` version `0.7-experimental-1`. Output only enum codes
+and integer counts. It is private local data, not a stable Agent Client contract,
+and excludes all event/time/private identities, metadata, SQL, and exceptions.
+
+Deletion is Preview-first. Apply requires the exact previewed analytics epoch and
+event count, revalidates both inside one bounded BEGIN IMMEDIATE transaction,
+deletes all Operational Events, increments the epoch, and reports the directly
+deleted count. Stale preview, busy, interruption, or commit failure is typed and
+redacted. All seven event-derived views become empty, including incomplete
+effects; the canonical authority projection, including the Effect Journal, is
+exactly unchanged, and Transfer recovery remains available. Enable and verify SQLite
+secure_delete before deletion and report bounded WAL TRUNCATE checkpoint success
+or pending cleanup separately. Never claim that this deletes backups, snapshots,
+retained generations, or physical-media traces, and never delete sidecars or run
+VACUUM implicitly.
+
+The scale proof creates exactly 1,000,000 deterministic synthetic events with
+known category totals, independently checks claim/observation uncertainty,
+compares aggregates across repeat query/reopen/second connection/fresh view
+install/backup restore with `reverse_unordered_selects` both off and on, runs
+integrity and foreign-key checks, proves private sentinels cannot enter JSON,
+and then deletes exactly 1,000,000 events. All event views must empty while the
+canonical authority projection stays exactly unchanged and Transfer recovery
+still uses the retained Effect Journal. Timings and file sizes are recorded only
+as non-gating diagnostics; there is no wall-clock benchmark assertion.
+
+Keep all work fully offline and synthetic. Include the required release-note
+record. Do not add telemetry, engagement/productivity/music-quality scores, raw
+event export, live providers, owner data, tags, Releases, or package publication.
+```
+
+## Primary sources
+
+Repository sources are pinned to the baseline commit above:
+
+- [Issue #130](https://github.com/spontain112/djsupport/issues/130),
+  [issue #132](https://github.com/spontain112/djsupport/issues/132), and
+  [issue #147](https://github.com/spontain112/djsupport/issues/147)
+- [ADR-0005](https://github.com/spontain112/djsupport/blob/3e6ae7f6157364eeedaa2667d2a1deabed9efcee/docs/adr/0005-use-one-local-transactional-operational-store.md)
+- [Operational Store issue frontier](https://github.com/spontain112/djsupport/blob/3e6ae7f6157364eeedaa2667d2a1deabed9efcee/docs/research/2026-08-16-operational-store-issue-frontier.md)
+- [SQLite concurrency and durability contract](https://github.com/spontain112/djsupport/blob/3e6ae7f6157364eeedaa2667d2a1deabed9efcee/docs/research/2026-08-16-sqlite-concurrency-durability-contract.md)
+- [Transfer Qualification implementation](https://github.com/spontain112/djsupport/blob/3e6ae7f6157364eeedaa2667d2a1deabed9efcee/djsupport/transfer.py) and
+  [Qualification behavior tests](https://github.com/spontain112/djsupport/blob/3e6ae7f6157364eeedaa2667d2a1deabed9efcee/tests/test_qualification.py)
+- [Agent privacy decision](https://github.com/spontain112/djsupport/blob/3e6ae7f6157364eeedaa2667d2a1deabed9efcee/docs/adr/0002-make-transfer-agent-native.md)
+
+External claims use only first-party documentation:
+
+- SQLite: [`CREATE VIEW`](https://sqlite.org/lang_createview.html),
+  [transactions](https://sqlite.org/lang_transaction.html),
+  [`DELETE`](https://sqlite.org/lang_delete.html),
+  [STRICT tables](https://sqlite.org/stricttables.html),
+  [`secure_delete`](https://sqlite.org/pragma.html#pragma_secure_delete),
+  [`query_only`](https://sqlite.org/pragma.html#pragma_query_only),
+  [`reverse_unordered_selects`](https://sqlite.org/pragma.html#pragma_reverse_unordered_selects),
+  [WAL checkpoint modes](https://sqlite.org/pragma.html#pragma_wal_checkpoint),
+  [WAL concurrency](https://sqlite.org/wal.html), and
+  [`VACUUM`](https://sqlite.org/lang_vacuum.html)
+- APSW 3.53.4.0: [connection interface](https://rogerbinns.github.io/apsw/connection.html),
+  [read-only open](https://rogerbinns.github.io/apsw/example.html#opening-the-database),
+  [`Connection.readonly`](https://rogerbinns.github.io/apsw/connection.html#apsw.Connection.readonly),
+  [`Connection.changes`](https://rogerbinns.github.io/apsw/connection.html#apsw.Connection.changes), and
+  [`Connection.txn_state`](https://rogerbinns.github.io/apsw/connection.html#apsw.Connection.txn_state)

--- a/docs/research/2026-08-16-operational-store-docs-release-frontload-contract.md
+++ b/docs/research/2026-08-16-operational-store-docs-release-frontload-contract.md
@@ -1,0 +1,633 @@
+# Operational Store documentation and release front-load contract
+
+**Date:** 2026-08-16
+
+**Product baseline:** `origin/main` at
+[`3e6ae7f6157364eeedaa2667d2a1deabed9efcee`](https://github.com/spontain112/djsupport/commit/3e6ae7f6157364eeedaa2667d2a1deabed9efcee)
+
+**Documentation baseline:** `djsupport-docs/main` at
+[`70bfbab06e5d4a34d659bbc73e2145e8cc3f6898`](https://github.com/spontain112/djsupport-docs/commit/70bfbab06e5d4a34d659bbc73e2145e8cc3f6898),
+with the unmerged production foundation at
+[`58fd4013c43cf2da426c761e0f0e21e64a60e777`](https://github.com/spontain112/djsupport-docs/commit/58fd4013c43cf2da426c761e0f0e21e64a60e777)
+
+**Scope:** Implementation research for
+[#148](https://github.com/spontain112/djsupport/issues/148) and
+[#149](https://github.com/spontain112/djsupport/issues/149), plus a downstream
+authority audit of human-gated
+[#150](https://github.com/spontain112/djsupport/issues/150) and
+[#151](https://github.com/spontain112/djsupport/issues/151). No tag, GitHub
+Release, package-index publication, workflow artifact upload, advisory
+publication, live provider call, or owner-data access is authorized or
+performed by this contract.
+
+**Contract precedence:** The exact issue amendments are the proposed normative
+execution delta; the preceding sections explain and source that delta. Once an
+amendment is accepted into an issue, the issue body is authoritative. Do not
+combine conflicting versions—reconcile the amendment first.
+
+## Decision
+
+The two independently safe front-load streams now stand at different stages:
+
+1. establish a stable review route for the documentation foundation in
+   [#116](https://github.com/spontain112/djsupport/issues/116), then prepare
+   #148 as a **draft, unmerged** documentation change with the final
+   information architecture, privacy inventory, contract tests, and visibly
+   unresolved product-command slots; and
+2. treat the reusable, publication-free candidate qualification harness as
+   completed infrastructure: [#181](https://github.com/spontain112/djsupport/issues/181)
+   was merged by [PR #182](https://github.com/spontain112/djsupport/pull/182) at
+   this note's product baseline, without adding a version override, consuming
+   release records, or uploading built archives.
+
+Do not finalize #148 until #147 has frozen the public migration, recovery,
+restore, and rollback behavior. Do not prepare or merge the exact version PR
+for #149 until #136, #130, #132, #147, and #148 are complete. The existing
+automated [PR #159](https://github.com/spontain112/djsupport/pull/159) currently
+prepares final `0.7.0`, not `0.7.0rc1`; its current head is not a release
+candidate and must not merge.
+
+The remaining safe front-load work is therefore the draft documentation route.
+The merged harness is a stable prerequisite, but its current evidence is
+deliberately `synthetic_non_release`; it is not evidence that a 0.7 candidate
+exists. This split advances reusable mechanics without turning planned behavior
+into public instructions or confusing a mutable version branch with a frozen
+candidate.
+
+## Current-state evidence
+
+### The repository boundary is decided but not integrated
+
+The accepted #116 decision assigns behavior, domain language, commands,
+release state, schemas, and architecture to `djsupport`; `djsupport-docs` owns
+audience-focused explanation, navigation, and presentation. The proposed
+product ADR records the same boundary
+([ADR branch](https://github.com/spontain112/djsupport/blob/dcd0f163956f1ad27ee16a3d11ebac5132ec34f7/docs/adr/0004-separate-public-documentation-from-product-authority.md)).
+The docs foundation implements it through a machine-readable product contract
+and a read-only cross-repository check
+([contract](https://github.com/spontain112/djsupport-docs/blob/58fd4013c43cf2da426c761e0f0e21e64a60e777/product-contract.json),
+[checker](https://github.com/spontain112/djsupport-docs/blob/58fd4013c43cf2da426c761e0f0e21e64a60e777/scripts/check_product_contract.py)).
+
+That foundation is not yet on `djsupport-docs/main`, and there is currently no
+pull request or validation run for it. The default branch is still the
+Mintlify starter. Consequently, #148 has two real prerequisites:
+
+- #116 must first provide the production information architecture, ownership
+  rules, and CI review route; and
+- #147 must freeze the actual 0.7 command and recovery behavior that the guide
+  will explain.
+
+The product repository must not absorb the #148 prose as a workaround. Its
+role is to expose canonical facts and verify documentation impact; the public
+guide itself remains a `djsupport-docs` change.
+
+### The release lane is not yet on a development version
+
+Current product metadata still says `0.6.0`
+([`pyproject.toml`](https://github.com/spontain112/djsupport/blob/3e6ae7f6157364eeedaa2667d2a1deabed9efcee/pyproject.toml)).
+Issue [#136](https://github.com/spontain112/djsupport/issues/136) explicitly
+requires a replacement 0.6 freeze plus separately authorized tag and final
+GitHub Release before its draft development-version PR may merge. Under the
+present publication exclusions, that human gate remains open.
+
+The version workflow rebuilds the mutable `release/version` branch from each
+push to `main`, consumes all pending release records, force-with-lease updates
+that branch, and edits or opens its PR
+([workflow](https://github.com/spontain112/djsupport/blob/3e6ae7f6157364eeedaa2667d2a1deabed9efcee/.github/workflows/version-pr.yml),
+[preparer](https://github.com/spontain112/djsupport/blob/3e6ae7f6157364eeedaa2667d2a1deabed9efcee/scripts/release_records.py)).
+Ten records are currently pending. Without a one-use
+`.release-notes/next-version` override, automation has prepared `0.7.0` in PR
+#159. That PR is an evolving projection of pending records, not a frozen
+candidate.
+
+The accepted release process already separates version preparation,
+validation, tag creation, GitHub Release creation, and package publication
+([release checklist](https://github.com/spontain112/djsupport/blob/3e6ae7f6157364eeedaa2667d2a1deabed9efcee/docs/releasing.md)).
+PEP 440 orders `.devN` before `rcN` and `rcN` before the corresponding final
+release, so `0.7.0.dev0` -> `0.7.0rc1` -> `0.7.0` is the correct version
+sequence
+([PyPA version specification](https://packaging.python.org/en/latest/specifications/version-specifiers/#summary-of-permitted-suffixes-and-relative-ordering)).
+
+### The merged harness is reusable infrastructure, not candidate evidence
+
+Current CI runs the complete offline suite and compilation on Ubuntu with
+Python 3.10 and 3.14, then builds and inspects one source archive and one wheel
+and performs a clean wheel smoke install
+([CI](https://github.com/spontain112/djsupport/blob/3e6ae7f6157364eeedaa2667d2a1deabed9efcee/.github/workflows/ci.yml)).
+The SQLite delivery workflow separately verifies 25 exact APSW native cells
+across Linux, macOS, and Windows, with read-only permissions and no artifact
+upload
+([native workflow](https://github.com/spontain112/djsupport/blob/3e6ae7f6157364eeedaa2667d2a1deabed9efcee/.github/workflows/sqlite-runtime.yml),
+[delivery policy](https://github.com/spontain112/djsupport/blob/3e6ae7f6157364eeedaa2667d2a1deabed9efcee/docs/sqlite-runtime-delivery.md)).
+
+PR #182 added a read-only Candidate qualification workflow and versioned input
+and evidence contracts. A full manual run binds every observed job to the exact
+workflow/product commit, requires the exact current `djsupport-docs/main`
+commit, pins build and documentation tools, rebuilds one reproducible DJ Support
+wheel digest across all 25 qualified APSW cells, runs the documentation contract
+and site checks, and emits one path-free evidence document. Dispatch inputs are
+equality facts and never select executable checkout refs. Pull requests run only
+the harness's synthetic contract tests
+([candidate workflow](https://github.com/spontain112/djsupport/blob/3e6ae7f6157364eeedaa2667d2a1deabed9efcee/.github/workflows/candidate-qualification.yml),
+[release guidance](https://github.com/spontain112/djsupport/blob/3e6ae7f6157364eeedaa2667d2a1deabed9efcee/docs/releasing.md#publication-free-candidate-qualification)).
+
+The merged finalizer intentionally accepts only `synthetic_non_release` with
+`synthetic_contract` scenario evidence. It therefore does **not** yet prove all
+of #149 on one exact merged candidate:
+
+- the Operational Store Preview, cutover, interrupted resume, restore, rollback,
+  and diagnostics behavior does not exist until #138–#147 and #132 merge;
+- the synthetic scenario seam does not substitute for installed execution of
+  those final product behaviors;
+- the exact merged #148 documentation commit does not yet exist; and
+- no merged `0.7.0rc1` product commit exists to qualify.
+
+#149 must extend or feed the same versioned harness with observed installed
+scenario results and admit `release_candidate` evidence only after those facts
+exist. It must not weaken or replace the already merged identity, native-cell,
+documentation, privacy, and no-publication gates.
+
+PyPA distinguishes building distributions from uploading them: `python -m
+build` produces an sdist and wheel, while upload is a separate step
+([packaging flow](https://packaging.python.org/en/latest/flow/)). That supports
+local and CI validation without package publication. GitHub Actions artifacts,
+however, persist files for later download and are available to signed-in
+readers of a public repository, ordinarily for up to 90 days
+([workflow artifacts](https://docs.github.com/en/actions/concepts/workflows-and-actions/workflow-artifacts),
+[download and retention](https://docs.github.com/en/actions/how-tos/manage-workflow-runs/download-workflow-artifacts)).
+Under the current exclusions, candidate archives should therefore be built,
+verified, hashed, and deleted in-job rather than uploaded.
+
+## Safe front-load stream A: documentation contract
+
+### Work that is stable now
+
+A draft #148 change may safely establish all of the following before #147:
+
+- a versioned **Upgrade to 0.7** route in **Use DJ Support**;
+- sections for release preflight, verified backup, migration Preview,
+  explicit apply, interruption recovery, restore, and rollback;
+- a privacy inventory covering the database, WAL and SHM sidecars, snapshots,
+  backups, restore staging, diagnostics, query exports, retained legacy JSON,
+  and reports;
+- the statement that `.gitignore` is a repository guardrail, never permission
+  to commit private data;
+- the prohibition on credentials, local paths, playlists, library data,
+  matching knowledge, and user-derived evidence entering Git;
+- the separation of `config.json` and Spotipy-managed credentials from the
+  Operational Store; and
+- contract tests that require every section, classification metadata, and
+  canonical source link.
+
+The draft should update, at minimum:
+
+- `use/upgrade-0-7.mdx` (new versioned guide);
+- `use/upgrade.mdx` and `use/backup-and-restore.mdx` (navigation only until
+  behavior freezes);
+- `docs.json` (navigation);
+- `product-contract.json` (versioned migration-contract facts);
+- `scripts/check_product_contract.py` and its tests; and
+- `.github/workflows/validate.yml` only where the stronger contract requires
+  it.
+
+The existing foundation already pins the Mintlify CLI and runs contract tests,
+`mint validate`, `mint broken-links`, and `mint a11y`
+([docs validation workflow](https://github.com/spontain112/djsupport-docs/blob/58fd4013c43cf2da426c761e0f0e21e64a60e777/.github/workflows/validate.yml)).
+Mintlify documents `mint validate` as strict build validation,
+`mint broken-links` as internal-link validation, and `mint a11y` as contrast
+and alternative-text validation
+([Mintlify CLI reference](https://www.mintlify.com/docs/cli/commands)). For
+#148, also enable anchor and redirect checks, while validating canonical
+product links against the checked-out product repository rather than relying
+on a flaky general external-link crawl.
+
+### Facts that must remain unresolved until #147
+
+The draft must not invent or infer:
+
+- command names, flags, prompts, exit codes, or example output;
+- Operational Store filenames or application-data paths;
+- the supported rollback duration or its start/end event;
+- what an interrupted phase reports or which exact resume command follows;
+- whether 0.7 is currently a candidate or a final stable release; or
+- any screenshot based on owner data.
+
+Use machine-detectable placeholders in the draft branch and make the contract
+checker reject a `publishable` status while any placeholder remains. Keep the
+PR draft and unmerged. Once #147 lands, fill the slots from executable `--help`,
+public behavior tests, canonical product docs, and synthetic outputs on the
+exact product commit. Do not copy internal schema or transaction explanations
+into the public guide.
+
+### Exact #148 amendment
+
+Append this to #148:
+
+```markdown
+## Documentation foundation and two-phase delivery
+
+The production docs foundation in #116 is an additional prerequisite. The
+default branch of `spontain112/djsupport-docs` must first contain the accepted
+Use/Build information architecture, canonical product-contract check, and
+Mintlify validation workflow.
+
+Phase A may begin after #116 has a stable review route: prepare a draft 0.7
+guide, navigation, private-artifact inventory, and contract tests. Do not infer
+commands, outputs, paths, recovery choices, or rollback duration, and do not
+merge or publish placeholder guidance.
+
+Phase B begins only after #147 freezes production behavior. Replace every
+placeholder from executable CLI help, public behavior tests, and canonical
+product sources; validate against that exact product commit; then run product
+contract tests, `mint validate`, `mint broken-links --check-anchors
+--check-redirects`, and `mint a11y`.
+
+The final PR must record the exact product commit validated, contain no owner
+data or owner-derived screenshot, and link back to this issue. Product behavior,
+terms, commands, release state, schemas, and architecture remain canonical in
+`djsupport`; `djsupport-docs` owns explanation and presentation.
+
+## Blocked by
+
+- #116
+- #147
+```
+
+## Completed front-load stream B: candidate qualification harness
+
+Issue [#181](https://github.com/spontain112/djsupport/issues/181), **Build the
+publication-free 0.7 candidate qualification harness**, is complete through
+[PR #182](https://github.com/spontain112/djsupport/pull/182). The following
+ledger separates the reusable mechanism already merged from product behavior
+that cannot exist until the Operational Store and documentation land:
+
+1. **Merged—read-only authority.** Pull requests run only the synthetic contract
+   tests. Full qualification is a manual `workflow_dispatch`; workflow
+   permissions are `contents: read`, actions are full-SHA pinned, checkout
+   credentials are not persisted, and secrets, write permissions,
+   `continue-on-error`, publishing commands, and artifact upload are absent.
+2. **Merged—exact source.** Executable product checkout is fixed to the workflow
+   commit and compared with the expected full SHA. Canonical docs checkout is
+   fixed to `djsupport-docs/main` and compared with the expected full SHA. Every
+   observed job is bound to that product SHA and the exact workflow identity.
+3. **Merged—exact build input.** Release-build tools are pinned, build isolation
+   is disabled after explicit installation, and `SOURCE_DATE_EPOCH` derives from
+   source history
+   ([build documentation](https://build.pypa.io/en/latest/how-to/basic-usage.html#building-without-isolation),
+   [SOURCE_DATE_EPOCH specification](https://reproducible-builds.org/specs/source-date-epoch/)).
+4. **Merged—one package identity.** The harness verifies archive identity and
+   rebuilds the pure-Python DJ Support wheel in every claimed native cell,
+   requiring the canonical SHA-256 in all 25 observations.
+5. **Merged—native runtime identity.** Every cell reuses #167's exact APSW
+   artifact/runtime policy and rejects source-built fallback.
+6. **Deferred to #149—installed product behavior.** The current scenario seam is
+   explicitly `synthetic_contract`. After #138–#147 and #132, it must consume
+   observed installed Preview, cutover, interruption, resume, backup, restore,
+   rollback, and diagnostics results from invented data; static scenario facts
+   cannot qualify a release candidate.
+7. **Partly merged—cross-platform scope.** The full 25-cell matrix and installed
+   wheel/runtime smoke are present. Actual installed Operational Store scenarios
+   on native Linux, macOS, and Windows remain part of the #149 extension.
+8. **Mechanism merged; exact input blocked—documentation identity.** The workflow
+   can check one exact canonical docs commit and run its contract/site checks,
+   but the final #148 commit does not exist yet.
+9. **Merged foundation; final product inventory deferred.** The repository
+   privacy and archive inspectors are required. #149 must extend their denylist
+   for the final database, sidecars, snapshots, backups, restore staging,
+   diagnostics, exports, and retained legacy state introduced downstream.
+10. **Merged—ephemeral archives.** Evidence contains only bounded path-free facts;
+    the workflow does not upload the source archive, wheel, database, logs, or
+    other generated artifacts.
+
+The merged harness fails closed on identity, version, changelog, tool, native
+cell, wheel digest, docs commit, job/step, privacy, source-build, or publication
+contract disagreement. It was verified with invented non-release facts and does
+not claim that a 0.7 candidate exists.
+
+## Exact #149 amendment
+
+Replace #149's dependency and freeze language with the following:
+
+```markdown
+## Exact freeze definition
+
+The candidate is the full merged `main` commit that contains package version
+`0.7.0rc1` and the generated matching changelog entry. A `release/version` PR
+head, passing run on another SHA, branch name, local checkout, or rebuilt
+archive alone is not the candidate.
+
+Before preparing version metadata:
+
+- close #136 and confirm `main` is explicitly `0.7.0.dev0`;
+- close #130, #132, #147, and #148; #131, #167, and #181 are satisfied
+  infrastructure prerequisites;
+- merge every intended 0.7 release record and audit its consumer-visible
+  summary;
+- record the exact merged `djsupport-docs` commit from #148; and
+- extend the publication-free candidate qualification harness with the adapters
+  that will consume observed installed results for the final Operational Store
+  scenarios, and require its `synthetic_non_release` contract tests to be green.
+  Do not require or emit `release_candidate` evidence before the rc metadata
+  exists.
+
+Only then add one-line `.release-notes/next-version` value `0.7.0rc1` through a
+reviewed PR. Let automation regenerate the existing open `release/version` PR
+from current `main`; verify it consumes exactly the intended records, changes
+the project version to exactly `0.7.0rc1`, and creates exactly one matching
+changelog section. The current `0.7.0` state of PR #159 is not acceptable and
+must not merge.
+
+After the version PR merges, run the finalizer in `release_candidate` mode and
+rerun every required gate on the exact merge commit. Require the same DJ Support
+wheel SHA-256 on all claimed native cells,
+the exact qualified APSW artifact/runtime per cell, installed synthetic
+Preview/cutover/resume/restore/rollback/diagnostics coverage, the exact #148
+docs commit check, the full offline/privacy/package suites, compilation,
+CodeQL, archive inspection, and clean installation. No skip, warning-only
+result, `continue-on-error`, different SHA, or source-built fallback passes.
+
+Record the evidence using the issue template below. Built archives are
+validation-only: do not upload them to Actions, a GitHub Release, or a package
+index. No tag, GitHub Release, package publication, advisory publication, live
+provider call, or owner-data operation occurs.
+
+## Blocked by
+
+- #136
+- #130
+- #132
+- #147
+- #148
+```
+
+The explicit #136 dependency matters even though #138 already names it: #149
+must prove that the release train began at `0.7.0.dev0`, not merely infer that
+from downstream issue closure. Listing #147 explicitly makes the exact
+behavior-freeze gate auditable rather than relying only on transitive blockers.
+
+## Candidate evidence record
+
+Post exactly one completion comment on #149 after the merged candidate has
+passed. Use this schema and do not include local paths or raw logs:
+
+```markdown
+## Frozen DJ Support 0.7.0rc1 candidate
+
+- Product commit: `<40-character merged main SHA>`
+- Documentation commit: `<40-character merged djsupport-docs SHA>`
+- Package metadata: `0.7.0rc1`
+- Changelog: `[0.7.0rc1] - YYYY-MM-DD`
+- Pending release records: `<none; README only>`
+- Version PR: `<URL and head SHA>`
+- Exact-merge CI: `<run URL and conclusions>`
+- Exact-merge CodeQL: `<run URL and conclusions>`
+- Candidate qualification: `<run URL; all native cells passed>`
+- Documentation validation: `<run URL or exact in-run check>`
+- Offline suite: `<test count, Python endpoints, passed>`
+- Installed synthetic scenarios: `Preview, apply/cutover, resume, backup,
+  restore, rollback, diagnostics — passed on Linux/macOS/Windows`
+- DJ Support sdist: `<filename>`, `<size>`, SHA-256 `<digest>`
+- DJ Support wheel: `<filename>`, `<size>`, SHA-256 `<one digest for every
+  native cell>`
+- APSW evidence: `<catalog version; 25/25 exact cells; no source build>`
+- Archive/privacy inspection: `<member counts and passed categories>`
+- Remote verification: `origin/main == <candidate SHA>` after validation
+- Publication state: `no tag; no GitHub Release; no package upload; no Actions
+  artifact upload; no advisory publication`
+- Data/provider state: `synthetic only; no owner data; no live provider call`
+- Handoff authority: `evidence only; no #150 tag, pre-release, asset, or package
+  publication authorization is granted or implied`
+```
+
+The prior #134 completion comment is the project-owned precedent for recording
+an exact commit, workflow URLs, suite results, archive member counts and
+digests, and the fact that validation-only artifacts were not uploaded
+([#134 evidence](https://github.com/spontain112/djsupport/issues/134#issuecomment-5304217325)).
+For an eventual separately authorized release, GitHub's immutable-release
+model can bind a tag, commit, and assets and prevent later asset/tag mutation
+([GitHub immutable releases](https://docs.github.com/en/code-security/concepts/supply-chain-security/immutable-releases));
+that future publication operation is deliberately outside #149.
+
+## Downstream human gates: #150 and #151
+
+The #149 completion comment is a **sealed evidence handoff**, not a release
+instruction and not approval to exercise any publication capability. Issue
+#150 is `ready-for-human` and owns the candidate tag and pre-release decisions;
+#151 is `ready-for-human` and separately owns final promotion and return to
+development. The agent-ready #149 lane must end before either begins.
+
+GitHub Releases are based on Git tags and make software available to a wider
+audience
+([GitHub release model](https://docs.github.com/en/repositories/releasing-projects-on-github/about-releases)).
+The GitHub CLI will create a missing tag automatically unless the caller uses
+an existing tag with `--verify-tag`; it also exposes independent
+`--prerelease` and `--latest=false` controls
+([`gh release create`](https://cli.github.com/manual/gh_release_create)). These
+facts make three authorities materially separate: tag creation, GitHub Release
+publication, and package-index publication.
+
+### Exact #149 -> #150 handoff
+
+Before #150 requests any human authorization, its owner must re-read #149 and
+prove all of the following without changing remote state:
+
+- the full product and docs SHAs still equal the frozen evidence;
+- every cited workflow is green for that exact product SHA and has no skipped
+  or allowed-to-fail required cell;
+- candidate version, changelog, release-record consumption, sdist/wheel
+  filenames, sizes, digests, and 25-cell runtime facts exactly match #149;
+- `v0.7.0rc1` and a corresponding GitHub Release are absent;
+- the current Latest final release is unchanged;
+- no candidate archive has been uploaded to Actions, a Release, or a package
+  index; and
+- no new commit, vulnerability/revocation fact, docs drift, or blocking issue
+  has invalidated the freeze.
+
+Only after that read-only preflight may #150 request three independently
+scoped approvals, in order:
+
+1. create and push one annotated `v0.7.0rc1` tag at the exact #149 SHA;
+2. after verifying the remote tag target, create one GitHub Release for that
+   existing tag with **Pre-release = true** and **Latest = false**; and
+3. publish to a package index only if separately requested and approved.
+
+The Release operation must verify the existing tag rather than allow GitHub or
+the CLI to create one implicitly. Any rebuilt sdist or wheel must reproduce the
+#149 digest before it can be considered the same candidate. A mismatch creates
+a blocking defect and a new candidate; it never authorizes replacing, moving,
+or silently rebuilding the frozen identity.
+
+After authorized publication, #150 downloads the published candidate artifacts
+into disposable environments, verifies their digests against #149, and repeats
+the synthetic migration/recovery/rollback/diagnostics exercise. This is
+artifact-consumer validation, not permission for live Spotify/Beatport calls
+or owner data. The Release must remain a pre-release and must not displace the
+Latest final channel. GitHub documents both the Pre-release and Latest choices
+as explicit release properties
+([managing releases](https://docs.github.com/en/repositories/releasing-projects-on-github/managing-releases-in-a-repository)).
+
+Append this to #150:
+
+```markdown
+## Authority and evidence handoff from #149
+
+#149 supplies evidence only. It does not authorize a tag, GitHub Release,
+release asset, package upload, live-provider call, or owner-data operation.
+
+Before requesting authorization, revalidate the exact #149 product/docs SHAs,
+workflow conclusions, version/changelog state, archive identities and digests,
+25-cell runtime evidence, absence of `v0.7.0rc1`, absence of its Release, and
+unchanged Latest final release.
+
+Request separate explicit approval for: (1) the annotated `v0.7.0rc1` tag at
+the exact #149 SHA; (2) after remote tag-target verification, the GitHub
+Release for that existing tag with Pre-release true and Latest false; and (3)
+any package-index publication. The Release operation must verify the existing
+tag and must not auto-create or retarget it.
+
+Any rebuilt or downloaded candidate archive must match the #149 filename,
+size, and SHA-256 before use. Exercise only disposable synthetic environments.
+Any mismatch, failed gate, revocation, docs drift, or behavioral defect blocks
+promotion and requires a new candidate; never mutate the frozen candidate.
+```
+
+### Exact #150 -> #151 handoff
+
+Issue #151 cannot promote the rc1 tag or merely relabel the candidate Release
+as final. It first consumes #150's evidence and defect list, resolves every
+blocking issue through normal reviewed development, and prepares a distinct
+final `0.7.0` version commit. If #150 found no defects, the final version-only
+commit is still a new identity and must receive the complete final-release
+validation on its own SHA.
+
+The final lane must:
+
+- record the exact proven rc1 tag, Release URL, artifact digests, installed
+  synthetic results, and all issues opened by #150;
+- prove each such issue closed or explicitly still blocking;
+- prepare `0.7.0` and its changelog through a separately reviewed version PR,
+  with the linked #148 docs commit and required notices unchanged or updated
+  deliberately;
+- repeat every #149 gate on the exact final merge commit, including package
+  reproducibility, native APSW identity, installed synthetic behavior, docs
+  validation, privacy, CodeQL, and archive inspection;
+- obtain separate human authorization for the annotated final tag, then the
+  Latest GitHub Release, then any package-index publication;
+- verify published tag target, Release `isPrerelease=false`, Latest identity,
+  asset digests, and clean installation; and
+- only after publication verification merge a separately reviewed change to
+  the next explicit `.dev0` version.
+
+Append this to #151:
+
+```markdown
+## Final-promotion authority
+
+#150 supplies a proven pre-release and a defect/evidence handoff; it does not
+authorize final promotion. Do not relabel `v0.7.0rc1`, move its tag, or reuse
+its commit as `0.7.0` without separately reviewed final version metadata and a
+complete exact-final-SHA validation.
+
+Record every #150 issue and require it to be resolved or explicitly blocking.
+Prepare one exact `0.7.0` final commit with complete changelog, linked #148
+documentation commit, and required notices. Repeat the full candidate-quality
+gate on that exact final commit.
+
+Request separate explicit approval for: (1) the annotated final tag at the
+exact validated final SHA; (2) after remote tag-target verification, the final
+GitHub Release with Pre-release false and Latest true; and (3) any package-index
+publication. Verify tag, Release, asset digests, Latest state, and clean
+installation before returning `main` to the next reviewed `.dev0` version.
+```
+
+Neither downstream amendment authorizes action now. They define the evidence
+and approval boundaries that a future human-gated session must enforce.
+
+## Dependency and concurrency map
+
+```text
+#116 docs foundation ───────────────┐
+                                    ├─> #148 final docs ──┐
+#136 0.6 publish + 0.7.dev0 ─> #138 ... #147 ───────────┤
+                                                          ├─> #149 exact freeze
+#130 Qualification deletion test <─ #147 ────────────────┤
+#132 private diagnostics <────────── #147 ────────────────┘
+
+#181 candidate harness (merged, synthetic_non_release) ──> #149 exact freeze
+             #149 adds observed installed release-candidate scenario evidence
+
+#149 evidence-only freeze -> #150 human tag + pre-release gate -> #151 human final + Latest gate
+```
+
+The #148 draft and completed #181 harness did not overlap: one changes only
+`djsupport-docs`; the other changed release tooling/tests in `djsupport`. Final
+#148 content waits on #147. #149 reuses the merged harness but must add observed
+installed scenario evidence before it can admit `release_candidate`; actual
+version preparation waits on every listed gate.
+
+## Stop conditions
+
+Stop and return to the owning issue rather than weakening a gate if any of the
+following appears:
+
+- #116 still lacks an integrated docs foundation or stable review route;
+- any #148 placeholder remains, commands differ from the exact product build,
+  or docs validation targets mutable product facts instead of the chosen
+  commit;
+- main is not `0.7.0.dev0` before the one-use candidate override;
+- PR #159 still says `0.7.0`, consumes an unexpected record, lacks required
+  checks, or is not fresh against `main`;
+- a test is skipped, allowed to fail, or runs on a different SHA;
+- any native cell produces another DJ Support wheel digest or an unqualified
+  binding/runtime;
+- package inspection finds a private/generated artifact or required public
+  policy/notice is absent;
+- evidence would require an artifact upload, tag, Release, package upload,
+  advisory publication, owner data, or live provider call; or
+- a #149 completion statement is treated as tag, GitHub Release, release-asset,
+  or package-index authority rather than as evidence-only handoff;
+- #150 attempts implicit tag creation, Latest candidate status, artifact
+  replacement, or a digest mismatch; or
+- #151 attempts to relabel rc1 as final, skips exact-final-SHA validation, or
+  reopens development before final publication is verified; or
+- a concurrent branch changes version automation, release records, docs
+  ownership, #147 public behavior, or the candidate commit.
+
+These are blockers to resolve, not reasons to narrow the candidate definition.
+
+## Primary sources
+
+### DJ Support and documentation sources
+
+- [Issue #116 — documentation-site decision](https://github.com/spontain112/djsupport/issues/116)
+- [Issue #136 — 0.6 publication/development gate](https://github.com/spontain112/djsupport/issues/136)
+- [Issue #147 — retire JSON production writers](https://github.com/spontain112/djsupport/issues/147)
+- [Issue #148 — migration/recovery guidance](https://github.com/spontain112/djsupport/issues/148)
+- [Issue #149 — exact 0.7.0rc1 freeze](https://github.com/spontain112/djsupport/issues/149)
+- [Issue #150 — human-gated candidate publication and exercise](https://github.com/spontain112/djsupport/issues/150)
+- [Issue #151 — human-gated final promotion](https://github.com/spontain112/djsupport/issues/151)
+- [Issue #181 — publication-free candidate qualification harness](https://github.com/spontain112/djsupport/issues/181)
+- [PR #182 — merged candidate qualification implementation](https://github.com/spontain112/djsupport/pull/182)
+- [Product release checklist at the inspected commit](https://github.com/spontain112/djsupport/blob/3e6ae7f6157364eeedaa2667d2a1deabed9efcee/docs/releasing.md)
+- [Candidate qualification workflow at the inspected commit](https://github.com/spontain112/djsupport/blob/3e6ae7f6157364eeedaa2667d2a1deabed9efcee/.github/workflows/candidate-qualification.yml)
+- [Release-record preparer at the inspected commit](https://github.com/spontain112/djsupport/blob/3e6ae7f6157364eeedaa2667d2a1deabed9efcee/scripts/release_records.py)
+- [Version workflow at the inspected commit](https://github.com/spontain112/djsupport/blob/3e6ae7f6157364eeedaa2667d2a1deabed9efcee/.github/workflows/version-pr.yml)
+- [CI at the inspected commit](https://github.com/spontain112/djsupport/blob/3e6ae7f6157364eeedaa2667d2a1deabed9efcee/.github/workflows/ci.yml)
+- [SQLite native-delivery workflow at the inspected commit](https://github.com/spontain112/djsupport/blob/3e6ae7f6157364eeedaa2667d2a1deabed9efcee/.github/workflows/sqlite-runtime.yml)
+- [Unmerged docs ownership ADR](https://github.com/spontain112/djsupport/blob/dcd0f163956f1ad27ee16a3d11ebac5132ec34f7/docs/adr/0004-separate-public-documentation-from-product-authority.md)
+- [Unmerged docs validation workflow](https://github.com/spontain112/djsupport-docs/blob/58fd4013c43cf2da426c761e0f0e21e64a60e777/.github/workflows/validate.yml)
+- [Unmerged docs product-contract checker](https://github.com/spontain112/djsupport-docs/blob/58fd4013c43cf2da426c761e0f0e21e64a60e777/scripts/check_product_contract.py)
+
+### External specifications and first-party documentation
+
+- [PyPA version specifiers](https://packaging.python.org/en/latest/specifications/version-specifiers/)
+- [PyPA packaging flow](https://packaging.python.org/en/latest/flow/)
+- [PyPA build basic usage](https://build.pypa.io/en/latest/how-to/basic-usage.html)
+- [`SOURCE_DATE_EPOCH` specification](https://reproducible-builds.org/specs/source-date-epoch/)
+- [GitHub workflow artifacts](https://docs.github.com/en/actions/concepts/workflows-and-actions/workflow-artifacts)
+- [GitHub artifact access and retention](https://docs.github.com/en/actions/how-tos/manage-workflow-runs/download-workflow-artifacts)
+- [GitHub immutable releases](https://docs.github.com/en/code-security/concepts/supply-chain-security/immutable-releases)
+- [GitHub release model](https://docs.github.com/en/repositories/releasing-projects-on-github/about-releases)
+- [GitHub release management](https://docs.github.com/en/repositories/releasing-projects-on-github/managing-releases-in-a-repository)
+- [GitHub CLI release creation](https://cli.github.com/manual/gh_release_create)
+- [Mintlify CLI commands](https://www.mintlify.com/docs/cli/commands)

--- a/docs/research/2026-08-16-operational-store-effect-journal-contract.md
+++ b/docs/research/2026-08-16-operational-store-effect-journal-contract.md
@@ -1,0 +1,718 @@
+# Operational Store Effect Journal implementation contract
+
+**Date:** 2026-08-16
+
+**Current implementation baseline:** `origin/main` at
+`3e6ae7f6157364eeedaa2667d2a1deabed9efcee`
+
+**Scope:** implementation-readiness research for
+[#140](https://github.com/spontain112/djsupport/issues/140),
+[#141](https://github.com/spontain112/djsupport/issues/141),
+[#142](https://github.com/spontain112/djsupport/issues/142), and
+[#143](https://github.com/spontain112/djsupport/issues/143)
+
+**Status:** contract research only. It does not switch production authority,
+call a live provider, read owner data, publish a package, or authorize work past
+the issues' dependency gates.
+
+**Contract precedence:** The actionable issue amendments are the proposed
+normative execution delta; the preceding sections explain and source that delta.
+Once an amendment is accepted into an issue, the issue body is authoritative.
+Do not combine conflicting versions—reconcile the amendment first.
+
+## Decision
+
+Issues #140–#143 should share one explicit effect protocol and extend the one
+Operational Store Interface with domain-cohesive publication, Approval,
+Qualification, and Mirror operations. A logical provider effect has a
+stable identity and a durable desired state. Each actual provider call has three
+local boundaries:
+
+1. commit the desired state and a `prepared` effect;
+2. commit an attempt claim, leaving the effect `in_flight`;
+3. with **no database transaction open**, make exactly one bounded provider
+   call, then commit the observed result and all local state made valid by that
+   result.
+
+`prepared` proves the call has not been claimed and is safe to claim.
+`in_flight` means the call may have happened; after interruption it is
+`uncertain` and must be reconciled. A durable observation is replayable without
+calling the provider. This extra claim boundary is necessary because a single
+`intent -> call -> observation` sequence cannot distinguish a crash before
+dispatch from a lost response after dispatch.
+
+SQLite can make each local transition atomic, but it cannot include Spotify in
+the database commit. SQLite permits only one writer at a time, and
+`BEGIN IMMEDIATE` acquires the write transaction before a read-then-write unit
+does its validation. APSW's connection context manager commits on clean exit,
+rolls back on exception, and uses its `transaction_mode` for the outer
+transaction. Every writer unit should therefore use an outer
+`transaction_mode="IMMEDIATE"` context and finish before the provider adapter is
+entered
+([SQLite transactions](https://sqlite.org/lang_transaction.html),
+[APSW connection transactions](https://rogerbinns.github.io/apsw/connection.html)).
+
+This contract deepens the accepted
+[ADR-0005](../adr/0005-use-one-local-transactional-operational-store.md),
+[APSW integration contract](2026-08-16-apsw-operational-store-integration-contract.md),
+and
+[concurrency contract](2026-08-16-sqlite-concurrency-durability-contract.md).
+It does not replace their qualified-runtime, connection, backup, migration, or
+cutover rules.
+
+## What the current implementation proves—and what it does not
+
+The current domain policy is already substantial:
+
+- `Transfer` owns publication, Qualification, Approval, Drift, orphaning, and
+  explicit Mirror disposition; clients remain renderers
+  ([architecture](../architecture.md), [domain model](../domain-model.md)).
+- Publication recovery uses a stable marker and chunk checkpoints; Approval
+  double-reads the playlist head around ordered playlist items; Qualification
+  retains manifest, selection, account, and playlist-head evidence; file-backed
+  drafts already reject stale revisions and persist both sides of supersession
+  together
+  ([Transfer implementation](../../djsupport/transfer.py),
+  [Transfer tests](../../tests/test_transfer.py),
+  [Qualification tests](../../tests/test_qualification.py)).
+- The merged runtime work pins APSW 3.53.4.0, qualifies exact native artifacts,
+  and keeps APSW private to the Operational Store adapter
+  ([ADR-0005](../adr/0005-use-one-local-transactional-operational-store.md),
+  [runtime qualification tests](../../tests/test_sqlite_runtime_qualification.py),
+  [delivery tests](../../tests/test_sqlite_runtime_delivery.py)).
+
+Those behaviors are regression inputs, not proof that the four issues are
+already implementable without choices. The current JSON model still has these
+material gaps:
+
+1. `PublicationManifest` requires a Spotify playlist ID and has no independent
+   immutable publication identity or manifest revision. The store must be able
+   to commit the manifest **before** playlist creation returns an ID.
+2. `_publish_checkpointed` and Qualification chunking retain remote results
+   after calls, but there is no pre-call Effect Journal claim that separates
+   definitely unattempted work from uncertain work.
+3. Approval writes matching knowledge, publication state, and Qualification
+   state through separate files. A failure can split one logical Approval.
+4. Correction repair can mutate a Spotify playlist from inside the current
+   Approval path. That remote mutation must become a separately authorized,
+   journaled application effect; local Approval itself remains authority-only.
+5. `MirrorRelationship` has no optimistic revision or lifecycle state beyond an
+   `orphaned_at` timestamp, and `remove_mirror` deletes the active relationship
+   rather than retaining a terminal history fact.
+6. Draft IDs are initially derived from Transfer and source reference while the
+   remaining binding facts are validated as mutable fields. #142 needs one exact
+   identity contract for account, Transfer, manifest, playlist head, and selected
+   occurrences.
+
+## Common transaction and Effect Journal protocol
+
+### Connection and unit-of-work rules
+
+Every Operational Store call in this document inherits the accepted connection
+contract: runtime qualification occurs before path resolution, each unit opens a
+fresh APSW connection, the five-second busy timeout and connection PRAGMAs are
+set and read back, WAL and `synchronous=FULL` are required, and connections,
+cursors, and result iterators stay inside the adapter. WAL lets readers proceed
+with a writer, but still allows only one writer; all clients must be on the same
+host
+([SQLite WAL concurrency](https://sqlite.org/wal.html#concurrency),
+[APSW busy timeout](https://rogerbinns.github.io/apsw/connection.html#apsw.Connection.set_busy_timeout)).
+
+For each write unit:
+
+```text
+open qualified connection
+set transaction_mode = IMMEDIATE
+BEGIN IMMEDIATE
+  reload every aggregate and expected revision
+  validate closed-state and identity constraints
+  perform all local writes for this transition
+  append the compact Operational Event in the same transaction
+COMMIT, or roll back the whole unit
+assert txn_state(main) == NONE
+close connection
+```
+
+APSW exposes `txn_state()` specifically to distinguish no transaction, read
+transaction, and write transaction. Tests must assert `NONE` immediately before
+every synthetic provider call and after every public store operation
+([APSW transaction state](https://rogerbinns.github.io/apsw/connection.html#apsw.Connection.txn_state)).
+Nested helpers may use savepoints, but an inner `RELEASE` is not durable if the
+outer transaction later rolls back
+([SQLite savepoints](https://sqlite.org/lang_savepoint.html)).
+
+Use `UPDATE ... WHERE id = ? AND revision = ? RETURNING revision` for mutable
+aggregates. Consume exactly one returned row; zero means a typed stale revision,
+and more than one is an invariant failure. SQLite's `RETURNING` output appears
+only after the statement's database modifications, but the enclosing transaction
+still owns the commit
+([SQLite `RETURNING`](https://sqlite.org/lang_returning.html),
+[APSW connection API](https://rogerbinns.github.io/apsw/connection.html)).
+
+### Durable effect states
+
+```text
+prepared --claim attempt--> in_flight --observed response--> observed_complete
+                                    |                    \-> observed_not_applied
+                                    |
+                                    +--process loss / ambiguous response--> uncertain
+
+uncertain --reconcile--> reconciled_complete
+                       \-> reconciled_not_applied
+                       \-> review_required
+
+observed_not_applied / reconciled_not_applied --permitted retry--> prepared
+```
+
+- `prepared` contains the exact aggregate revision, operation kind, ordered
+  effect ordinal, canonical request digest, and the durable desired facts needed
+  to invoke or reconcile. It is inserted in the same transaction as those
+  desired facts.
+- Claiming an attempt is a separate revision-qualified local transaction.
+  A crash during this commit leaves either `prepared` or `in_flight`.
+- Once `in_flight` commits, no automatic resume may assume the call did not
+  happen—even if the process died before the adapter was entered. This may
+  conservatively require reconciliation for a call that never reached the
+  provider, but it never guesses that an applied call was absent.
+- `observed_not_applied` is allowed only for a response that conclusively says the
+  requested mutation did not apply. A timeout, disconnect, process loss, or
+  ambiguous provider error is `uncertain`.
+- Reconciliation itself consists of provider reads outside a database
+  transaction followed by one local transaction that binds the exact observation
+  to the still-current effect and aggregate revisions.
+- An uncertain effect may be retried only after reconciliation proves it was not
+  applied, or when the provider operation has a separately documented
+  idempotency guarantee. A stable DJ Support key is evidence for reconciliation,
+  not proof of provider idempotency.
+- A conclusive not-applied result returns the same logical effect to `prepared`
+  only when the request and aggregate revisions are still exact and Transfer's
+  bounded retry policy permits another attempt. The next claim creates a new
+  attempt ordinal; it never overwrites attempt history.
+- Each provider call is one effect. Playlist creation, description update,
+  replacement, each append chunk, relink mutation, restore, and deletion do not
+  share an opaque “publication happened” journal row.
+- Effects in one operation have an ordinal and predecessor. Effect `n+1` cannot
+  be claimed until effect `n` is durably complete.
+- Preview creates neither an effect nor an attempt. A Preview checkpoint and its
+  compact event remain explicitly non-authoritative.
+
+### Live claimant boundary
+
+Durable `in_flight` state alone does not prove whether another process is still
+inside the bounded provider call. Before claiming `prepared`, a worker acquires a
+non-blocking, process-scoped exclusive OS lock for that effect, using a fixed
+private lock directory and a one-way safe filename derived from the effect ID.
+It keeps the lock handle open across the claim transaction, provider call, and
+observation/uncertain transaction, then releases it. Lock files use the
+foundation's owner-only permission contract and are never deleted while another
+process may contend for them.
+
+A concurrent resume that cannot acquire the lock returns the stable
+`effect_attempt_active` outcome and performs no provider read, write, or state
+transition. If it acquires the lock and then observes `in_flight`, the previous
+claimant is no longer live; it atomically marks the attempt `uncertain` before
+reconciliation. Wall-clock expiry, process IDs, and heartbeats are not accepted
+as proof that a provider call ended. Process death releases the OS lock while the
+durable claim remains for conservative recovery.
+
+### Minimum binding-neutral schema facts
+
+The final table names belong to #138's schema registry. The following facts and
+constraints are normative for #140–#143, regardless of names:
+
+| Record | Required durable facts and constraints |
+| --- | --- |
+| Publication | Local `publication_id` independent of a remote playlist ID; Transfer, account, mode, source identity, lifecycle state, current manifest revision, and optimistic revision. One Snapshot publication per exact Transfer; a later Transfer of the same source remains a distinct Snapshot. |
+| Publication Manifest | Immutable `manifest_id`, publication ID, manifest revision, canonical digest, source facts, and creation fact. It does not require a remote playlist ID; that nullable binding belongs to the Publication aggregate. `UNIQUE(publication_id, manifest_revision)`; later Mirror or Qualification applications create a new revision rather than overwriting history. |
+| Publication Item | Manifest ID, explicit ordinal, exact Source Occurrence ID and proposal/unresolved facts. `UNIQUE(manifest_id, ordinal)` and explicit `ORDER BY ordinal`; track facts and Spotify URIs are deliberately **not** unique because duplicate occurrences are valid. Review items and managed items need two ordered relations or an equally lossless role/ordinal representation. |
+| Logical effect | Stable effect ID, owning operation/aggregate, effect ordinal and predecessor, effect kind, expected aggregate revision, canonical request digest, lifecycle state, optimistic revision, and timestamps. `UNIQUE(operation_id, effect_ordinal)` and `UNIQUE(effect_id)`. |
+| Effect attempt/observation | Effect ID, attempt ordinal, opaque claim token, claim/observation state, stable safe reason code, provider object identity/head when observed, and result digest. Raw provider responses and exceptions are not required; if retained privately they never enter diagnostics. `UNIQUE(effect_id, attempt_ordinal)`. |
+| Approval | Stable approval request ID, account, publication/manifest revision and digest, exact reviewed playlist head plus ordered-item digest, correction-input digest, outcome, and terminal revision. An exact attempt replay returns the retained result without a second event or authority write. At most one terminal `approved` or `abandoned` Approval exists per publication revision; retained `needs_review` attempts may be followed only after an explicit supported repair produces new evidence. |
+| Approval item | Approval ID, manifest item/occurrence identity, classification (`approved`, `rejected`, `collision`, `correction`, or `conflict`) and ordinal. Ambiguous items never acquire successful representation implicitly. |
+| Qualification Draft | Exact draft identity tuple, status, account, Transfer, manifest revision/digest, playlist ID/head, selection and selected-occurrence digests, revision, predecessor/successor, intended applied manifest revision, and application operation ID. |
+| Qualification decision | Draft ID, selected occurrence ID, decision kind, explicit exclusion flag where allowed, correction facts or private reason, and decision revision/fact time. One current decision per selected occurrence; history may be an event but is never matching authority. |
+| Mirror | Stable Mirror ID, account, source type, Source Selection reference, remote playlist ID, lifecycle state, current Mirror revision, current manifest revision, and last conclusively observed playlist head. Active source and playlist bindings are unique within an account. |
+| Mirror revision | Immutable Mirror ID/revision, source binding, manifest, ordered managed items, expected/observed remote head, maintenance operation ID, and outcome. `UNIQUE(mirror_id, revision)`. |
+| Operational Event | Stable event ID, category, aggregate type and opaque local identity, outcome/reason category, counts, and fact time. No authority code reads it; rebuilding or deleting analytics history cannot change any row above. |
+
+All text identities are `NOT NULL`; revisions and ordinals have non-negative
+`CHECK` constraints; closed state vocabularies are checked. Parent ownership uses
+foreign keys with `RESTRICT`/`NO ACTION`, not cascades that could turn deletion
+into authority. SQLite foreign-key enforcement is disabled by default and must
+be enabled and verified on every connection. Full integrity verification also
+requires both `PRAGMA integrity_check` and `PRAGMA foreign_key_check`, because
+the former does not check foreign keys
+([SQLite foreign keys](https://sqlite.org/foreignkeys.html),
+[SQLite integrity checks](https://sqlite.org/pragma.html#pragma_integrity_check)).
+
+## #140 — publish one Snapshot through the Effect Journal
+
+### Exact operation boundary
+
+1. **Prepare outside a transaction.** Transfer finishes matching, constructs one
+   immutable local publication/manifest identity, canonical ordered Publication
+   Items, desired playlist name/description/items, and request digest. This pure
+   work does not call Spotify.
+2. **Transaction P — prepare publication.** `BEGIN IMMEDIATE`; reload the
+   Transfer and expected revision; require the same account, mode, selection, and
+   incomplete publication state; insert the publication, immutable manifest and
+   ordered items; insert effect 0 (`playlist_create`) as `prepared`; move the
+   Transfer to retaining-publication; append the compact prepared event; commit.
+   The remote playlist ID is still null.
+3. **Transaction C — claim effect.** Compare-and-swap `prepared -> in_flight`,
+   create attempt 1, and commit.
+4. **Provider boundary.** Assert the APSW connection has no transaction. Invoke
+   exactly one synthetic/production Spotify adapter method. For create, pass the
+   stable publication recovery marker already modeled by the current adapter.
+5. **Transaction O — observe.** Reload effect, attempt, Transfer, and publication
+   revisions. Atomically retain the exact observed playlist ID/head or conclusive
+   failure, bind the Publication aggregate to the remote playlist, advance the Transfer and
+   effect, and append the outcome event. A commit failure leaves `in_flight`, not
+   a partial manifest.
+6. **Continue one effect at a time.** Description, initial replacement, and each
+   append chunk repeat C/provider/O with their own stable effect IDs. Only after
+   all required effects are observed complete does one final local transaction
+   mark the publication and Transfer complete.
+
+An interrupted create is reconciled by the stable publication marker and exact
+desired facts. Exactly one matching remote playlist can prove completion; more
+than one is review-required. No match is not automatically proof of absence
+after an ambiguous dispatch. The current recovery-marker search remains useful,
+but #140 must not describe it as an at-most-once guarantee unless the adapter can
+prove the remote result
+([current publication and recovery tests](../../tests/test_transfer.py)).
+
+The new ordering removes the current need to delete a newly created playlist
+when local manifest retention fails. Such a compensating delete would itself be
+an external effect, require separate authorization and journaling, and could
+turn a recoverable local failure into an untracked destructive action.
+
+### Required first tests
+
+- Through `Transfer`, parameterize in-memory and APSW-backed store adapters over
+  duplicate Source Occurrences and exact manifest order.
+- Add named failpoints after Transaction P commit, during Transaction C commit,
+  after C before adapter entry, after the adapter has applied the mutation, and
+  at each statement/commit point in Transaction O. Reopen in a fresh process.
+- Assert the durable classification is respectively unattempted (`prepared`),
+  previous-or-uncertain, uncertain, uncertain, and uncertain-or-complete.
+- Make reconciliation return zero, one, and two marker matches; only the single
+  exact match advances automatically.
+- Repeat the completed Transfer and assert no provider write, authority write,
+  duplicate event, or second playlist.
+- Exercise create, description, replace, and a two-chunk (>100 item) publication;
+  crash every call boundary. A later chunk never causes an earlier chunk to
+  repeat without proof.
+- Run the same Preview and assert zero Effect Journal and effect-attempt rows.
+
+## #141 — approve one Provisional Playlist atomically
+
+### Remote evidence phase
+
+Approval cannot lock Spotify and SQLite atomically. It must instead bind one
+stable remote observation to one local transaction:
+
+1. outside any database transaction, obtain the account identity;
+2. read playlist head `H1`, then exact ordered items, then head `H2`;
+3. require `H1 == H2`, reject unsupported/local/relinked/unavailable items, and
+   compute the ordered-item digest;
+4. resolve Correction track metadata outside a database transaction, without
+   creating matching authority;
+5. only then enter the local Approval transaction.
+
+A remote change after `H2` is a later fact; the Approval row records the exact
+head and ordered-item digest it approved. There is no honest claim of distributed
+atomicity.
+
+Current CSV Correction repair can replace playlist items during Approval. #141
+must either route that mutation through a separately authorized Effect Journal
+operation before the evidence phase or reject it with a next action. The final
+Approval transaction itself performs zero Spotify writes, matching
+[ADR-0002](../adr/0002-make-transfer-agent-native.md) and the existing Agent
+Client Approval test
+([Agent contract tests](../../tests/test_agent_contract.py)).
+
+### One local authority transaction
+
+Under `BEGIN IMMEDIATE`, the store must:
+
+1. load the publication, immutable manifest revision, optional applied
+   Qualification Draft, and every affected matching-knowledge identity;
+2. compare account, publication state, manifest revision/digest, expected local
+   revisions, reviewed `H2`, ordered-item digest, Correction digest, and any
+   Qualification evidence;
+3. insert or replay the stable Approval request ID;
+4. classify every manifest occurrence as surviving, removed, corrected,
+   colliding, or conflicting;
+5. create Approved Matches, Rejected Matches, Corrections, Local Audio Identity
+   associations, conflicts, Mirror establishment (for an approved Mirror), the
+   Publication outcome, Qualification aggregate outcome, and compact event;
+6. commit all changes once, or roll them all back.
+
+Atomic storage failure and domain partial success are different. To preserve
+current Transfer policy, a `needs_review` outcome may commit unambiguous
+approved/rejected items and explicit conflict/collision facts together, while
+ambiguous identities acquire no successful representation. The issue should say
+this explicitly; if product intent is instead “any ambiguity rolls back all item
+authority,” that is a policy change requiring a separate decision.
+
+An exact repeated Approval request returns the retained outcome. It does not
+re-read and reapply matching authority, increment revisions, or append another
+event. A retained `needs_review` attempt may be followed after an explicit
+supported repair with a new request identity and evidence. A different head,
+manifest revision, Correction digest, or draft revision after terminal
+`approved` or `abandoned` fails closed as an incompatible second Approval; it
+does not become latest-write-wins.
+
+### Required first tests
+
+- Inject a failure after every local mutation category—Approval row,
+  classifications, Approved Match, Rejected Match, Correction, Local Audio
+  association, conflict, Mirror, Publication state, Qualification outcome, and
+  event—and assert a canonical whole-store digest is unchanged.
+- Run the existing surviving/removed/Correction/collision/conflict cases through
+  both store adapters and compare exact domain outcomes, not SQL rows.
+- Race two independent connections approving the same request. Exactly one
+  commit occurs; the loser reloads and receives the identical terminal outcome.
+- Race the same publication with different manifest/head/Correction evidence.
+  One may commit; the incompatible request fails stale and creates no authority.
+- Assert the provider adapter records zero writes during local Approval.
+- Crash during COMMIT in a subprocess; reopen to the complete prior or complete
+  next state, then run integrity and foreign-key checks.
+
+## #142 — resume and apply one Qualification Draft
+
+### Draft identity and local transitions
+
+The durable draft identity must bind this exact tuple, either directly in the
+stable ID digest or through an immutable identity row protected by a unique
+constraint:
+
+```text
+schema version
+Transfer ID
+Spotify Account
+Publication ID + manifest revision + digest
+Spotify playlist ID + reviewed head
+Source Selection digest
+ordered selected Source Occurrence IDs + selection mode
+```
+
+The initial ID must not be only `Transfer + source reference`. A changed
+manifest, account, playlist head, selected occurrence set, or selection digest is
+new bounded evidence and cannot silently resume the old draft.
+
+Every create, decision, revision, discard, or status transition is one short
+optimistic transaction. Discard plus successor creation is one transaction that
+marks the old draft terminal, inserts the new identity/items, and links both
+sides. A unique successor constraint makes an exact repeated request return the
+existing successor. No caller may coordinate two repository writes.
+
+Keep, Correction, deferred, rejection, and exclusion remain non-authoritative.
+The issue must define exclusion as either its own decision or the existing
+explicit modifier of `deferred`; the database must not accept both meanings.
+Corrections retain reviewed track facts but become matching authority only in the
+later playlist-scoped Approval transaction.
+
+Local Audio Identity handling needs the same precision. A draft may reference an
+opaque evidence digest and an already existing account-scoped association, but it
+must not create a new association. Fingerprints remain private, and source paths,
+filenames, file URLs, and process-local audition handles never enter the store.
+
+### Effect-journaled application
+
+Application first computes the intended immutable next manifest and exact
+ordered desired playlist representation. Transaction P binds that intended
+manifest, current draft revision, current publication/manifest revision, current
+playlist head, and one effect per provider call. The intended manifest is staged,
+not active.
+
+Each replacement/append call then follows claim/provider/observation. The effect
+records the expected pre-call head and the observed post-call head. Resume accepts
+the latest head only when it is the postcondition of this draft's immediately
+preceding observed effect; any other head is review-required. Unmanaged playlist
+items are preserved from one exact ordered observation included in the request
+digest, not through set-based reconstruction that loses duplicates or order.
+
+After every required effect is durably complete, one final transaction activates
+the staged manifest revision, marks the draft `applied`, records the final head,
+updates the Transfer projection, and emits the outcome event. Application still
+creates no Approved Match, Correction authority, rejection authority, or Mirror
+Approval. `approve_qualification` remains a later #141 transaction.
+
+### Required first tests
+
+- Parameterize the complete existing Qualification lifecycle suite over the
+  in-memory and SQLite adapters, including duplicate occurrences, Preview-link,
+  stale revision, changed evidence, discard/successor, and idempotent terminal
+  replay.
+- Race two decision writes at the same draft revision; one succeeds and one
+  returns reload-before-retry with no merged guess.
+- Fail every statement in discard/successor and prove neither half commits.
+- For one- and multi-chunk apply, crash at every prepare/claim/provider/observe
+  boundary. Reconcile exact pre-head, exact observed post-head, external edit,
+  missing playlist, and ambiguous ordered state.
+- Assert an interrupted application never activates the intended manifest early
+  and never creates matching authority.
+- Generate exactly 1,000 deterministic drafts spanning all lifecycle states,
+  close/reopen, compare canonical ordered digests, run integrity and foreign-key
+  checks, and prove the database contains none of the path/filename/handle denylist.
+
+## #143 — create and maintain one Mirror
+
+### Revision and lifecycle model
+
+An Approved Mirror has one stable identity and immutable revisions. The active
+binding is unique by `(account, source type, Source Selection reference)` and by
+`(account, Spotify playlist)`. A revision links the exact ordered managed items,
+manifest revision, expected/observed playlist head, and maintenance operation.
+Source facts or remote facts never select a row by “latest timestamp.”
+
+The minimum explicit lifecycle is:
+
+```text
+active -> maintenance_pending -> active
+active -> drift_review_required -> active
+active -> orphaned -> active (relink)
+active -> orphaned -> released (keep as ordinary playlist)
+active -> orphaned -> deletion_pending -> deleted
+```
+
+Terminal `released` and `deleted` records remain as history; “remove Mirror” must
+not physically erase the only evidence of an explicit decision. A source-not-found
+result may create `orphaned` in one local revision transaction. Source parse,
+permission, validation, or transient I/O failures merely pause/fail the Transfer
+and never infer orphaning.
+
+### Operation-specific boundaries
+
+| Explicit operation | Local preparation | Provider effects | Atomic local finalization |
+| --- | --- | --- | --- |
+| Ordinary source maintenance | Bind current Mirror/manifest revision, exact source selection, desired next manifest, and expected playlist head. | Replace, each append chunk, and description are separate effects. | Activate one new Mirror and manifest revision only after every effect is observed complete. |
+| Drift restore | Bind the exact drift observation and explicit `restore` choice. | Journal replacement/chunks against the observed head. | New revision records restored head; matching authority is unchanged. |
+| Drift revoke | Bind exact drift and explicit `revoke` choice. | None. | In one transaction revoke only the affected Approved Matches/Local Audio associations, create the next manifest/Mirror revision, and append the event. |
+| Orphan keep | Bind current orphan revision and explicit `keep`. | None. | Mark `released`; retain playlist and Mirror history. |
+| Orphan relink | Bind current orphan revision, explicitly selected new source, intended manifest, and current playlist head. | Journal replacement/chunks and description. | Activate the new source binding and next revision only after conclusive effects. |
+| Orphan delete | Bind current orphan revision and explicit `delete` plus Spotify-write authorization. | One journaled playlist-delete effect. | Mark `deleted` only after observed/reconciled deletion; uncertainty stays pending/review-required. |
+
+All desired managed items preserve Source Occurrence identity and order.
+`dict.fromkeys`, URI sets, or track-ID sets cannot define the provider request,
+because repeated occurrences are valid domain facts
+([domain identity layers](../domain-model.md#identity-layers)).
+
+One maintenance operation may contain several remote calls, so `maintenance_pending`
+belongs to the operation while the previously completed Mirror revision remains
+the last authoritative complete revision. Resume does not publish a partially
+mutated remote playlist as a completed next Mirror revision. The new revision is
+activated only after reconciliation proves every required effect.
+
+### Required first tests
+
+- Reuse the complete current Mirror/Drift/orphan suite through both store
+  adapters, then assert immutable revision history and exact ordered duplicate
+  occurrences.
+- Crash create, replace, append, description, relink, restore, and delete at each
+  effect boundary; reopen and reconcile without an inferred destructive choice.
+- Race two maintenance requests at one Mirror revision. One can commit its plan;
+  the other fails stale before a provider call.
+- Inject source-not-found separately from malformed, permission, and transient
+  source failures; only the exact not-found case becomes orphaned.
+- Repeat keep, relink, delete, restore, and revoke. Exact repeats replay; changed
+  intent or revision fails closed.
+- Assert deletion uncertainty retains the Mirror, manifest, journal, and explicit
+  choice; no cleanup code deletes the remote playlist or local history by inference.
+
+## TDD seams and implementation order
+
+The Operational Store should remain deep. `Transfer` asks for domain-named
+operations on the same Interface established by #138; it does not receive an
+APSW connection, SQL transaction, table repository, exported unit-of-work plan,
+or generic `commit(change)` method. Private transaction composition stays inside
+the Module.
+
+| Seam | First red test | Production responsibility |
+| --- | --- | --- |
+| Store conformance factory | Run the same aggregate scenarios against in-memory and temporary APSW stores. | One binding-neutral interface and equivalent domain results. |
+| Effect coordinator | Table-drive prepared, claim, observe, uncertain, reconcile, and terminal replay. | Stable effect/attempt identity and legal transitions; no provider policy. |
+| Recording provider adapter | Assert `txn_state == NONE` at every read/write and coordinate barriers around dispatch/application/return. | Existing Spotipy adapter behind the same semantic effect calls. |
+| Deterministic identity/codec | Golden digests for manifests, ordered items, draft identity, approval request, and effect requests. | Versioned canonical encoding; no wall clock, Python hash, rowid, or insertion-order identity. |
+| Transaction failpoint | Raise after each repository mutation and during commit. | Test-only instrumentation below the deep interface; no production user toggle. |
+| Reconciler | Zero/one/multiple remote candidates, exact/mismatched head, missing target, and unsupported item. | Pure classification plus bounded provider observations; never guessed replay. |
+| Privacy projection | Deny raw identifiers/paths/SQL/exceptions while preserving category, count, lifecycle, and next action. | Existing CLI/web/Agent renderers consume domain outcomes, never journal rows. |
+
+Implementation order follows the issue dependencies: #140 establishes the
+effect protocol; #141 makes the first whole-authority local transaction; #142
+reuses both for draft application; #143 reuses both for multi-revision Mirror
+maintenance. #142 and #143 are separate Operational-authority lanes and must not
+change the interface concurrently even though both depend on #141
+([issue frontier](2026-08-16-operational-store-issue-frontier.md)).
+
+## Cross-platform failure and durability matrix
+
+The exact supported cells are the reviewed native artifact catalog introduced by
+#167; at this baseline it contains 25 conventional-GIL CPython 3.10–3.14 cells
+across Linux x64/arm64, macOS Intel/arm64, and Windows x64. A wheel's existence is
+not persistence evidence
+([artifact catalog](../../djsupport/contracts/apsw-runtime-artifacts.v1.json),
+[APSW integration contract](2026-08-16-apsw-operational-store-integration-contract.md)).
+
+1. Run the focused store/effect/Approval/Qualification/Mirror conformance tests on
+   every admitted native cell. Fail rather than skip when the runtime qualifier
+   or artifact admission rejects the cell.
+2. Run the subprocess crash/commit suite natively on every OS/architecture
+   family, plus Linux Python 3.10 and 3.14 edges. A child process opens its own
+   connection; no connection crosses `fork`. Windows uses a spawned subprocess,
+   not a POSIX-only signal assumption.
+3. Coordinate contention and crash locations with pipes/events and durable test
+   barriers, not sleeps. Hold `BEGIN IMMEDIATE` on one independent connection to
+   prove bounded busy translation on another.
+4. For local transaction crashes, accept only the complete prior or complete
+   next canonical domain digest. For external effects, accept only the durable
+   journal classifications specified above; “test did not see a duplicate” is
+   not recovery proof.
+5. After every process-kill case, reopen from a fresh process and require full
+   `integrity_check`, empty `foreign_key_check`, supported migration registry,
+   exact ordered domain digest, and no open transaction.
+6. Inject typed APSW/SQLite busy, snapshot-stale, constraint, full-disk, I/O,
+   read-only, corruption, and unknown failures at adapter boundaries. Translate
+   by APSW `result` and `extendedresult`, retain the private chained cause, and
+   expose only stable path-free store errors
+   ([APSW exceptions](https://rogerbinns.github.io/apsw/exceptions.html)).
+7. Scale tests use deterministic synthetic facts and correctness assertions, not
+   wall-clock pass thresholds. Keep the million-event/large-store run in its
+   owning schema/diagnostics lane; #142 still owns its exact 1,000-draft reopen
+   proof.
+
+WAL commits append a commit record, and `synchronous=FULL` syncs each WAL commit;
+checkpointing is a later operation. Tests must not delete or detach `-wal` or
+`-shm`, and must not treat a filesystem copy of the main database as a valid
+snapshot
+([SQLite WAL operation](https://sqlite.org/wal.html#how_wal_works),
+[SQLite WAL file lifecycle](https://sqlite.org/wal.html#the_wal_file)).
+
+## Privacy and publication constraints
+
+- The Operational Store, WAL/SHM sidecars, snapshots, backups, restore staging,
+  diagnostics, query exports, legacy JSON, reports, and every generated failure
+  artifact are private user data. They never enter Git or package archives
+  ([ADR-0001](../adr/0001-keep-user-data-out-of-the-repository.md),
+  [private storage](../storage.md)).
+- Account, source, playlist, track, manifest, Correction, fingerprint, and
+  Effect Journal facts may be necessary inside the private store. Public and
+  Agent-facing output exposes only approved aggregate counts, opaque bounded
+  work IDs, lifecycle states, stable reason codes, and permitted next actions.
+- Configuration and Spotipy-managed credentials remain outside the Operational
+  Store. Effect requests and observations never retain tokens, request headers,
+  raw HTTP bodies, raw exceptions, SQL text/bindings, or native/database paths.
+- Qualification retains no source path, filename, `file://` URL, audio bytes,
+  local audition handle, or unapproved fingerprint association. All repository
+  fixtures are invented; no owner-derived database or regression evidence is
+  admissible.
+- Operational Events are rebuildable analytics input, not authority. Authority
+  logic may not query them, and deleting analytics history cannot cascade into
+  Transfers, publications, matching knowledge, drafts, effects, Approvals, or
+  Mirrors.
+- None of #140–#143 authorizes a live Spotify/Beatport call, owner Rekordbox/audio
+  read, playlist mutation, tag, GitHub Release, package publication, advisory,
+  or public security-fix merge. Synthetic provider adapters remain the default
+  evidence surface.
+
+## Actionable issue amendments
+
+### Amend #140
+
+1. Name `prepared`, `in_flight`, observed, uncertain, reconciled, and
+   review-required states; add crash hooks after prepare, after claim, after
+   provider application, and during observation commit.
+2. Require a local publication identity and immutable manifest revision that
+   exist before the remote playlist ID.
+3. State whether the issue journals all Snapshot writes—create, description,
+   replace, and append chunks. “Publish one Snapshot” should not leave the calls
+   after creation on the old checkpoint model.
+4. Define zero/one/multiple reconciliation outcomes and prohibit automatic replay
+   of an uncertain create without proof.
+5. Remove compensating remote deletion from local retention failure unless it is
+   a separately authorized and journaled explicit effect.
+6. Require the per-effect OS claimant lock across claim, provider call, and
+   observation. A busy lock returns `effect_attempt_active`; a resume may mark
+   `in_flight` uncertain only after acquiring the lock and re-reading the exact
+   durable attempt.
+
+### Amend #141
+
+1. Define the stable Approval request identity and exact terminal replay result.
+2. Require `head -> ordered items -> head` remote evidence and bind its ordered
+   digest to the local transaction.
+3. Move Correction playlist mutation out of authority-only Approval into a
+   separately authorized, Effect Journal-backed application step.
+4. Decide explicitly whether unambiguous items may commit in a `needs_review`
+   outcome. The current policy supports that while ambiguous items remain
+   non-authoritative.
+5. Name every expected revision checked inside the transaction, including
+   publication/manifest, applicable draft, and affected matching identities.
+
+### Amend #142
+
+1. Define the complete immutable draft identity tuple and selected-occurrence
+   digest; do not leave identity as Transfer/source reference alone.
+2. Decide whether exclusion is a first-class decision or only an explicit
+   deferred-item modifier.
+3. Require one journal effect per replacement/append call with expected and
+   observed heads, plus staged-versus-active manifest semantics.
+4. Clarify that Local Audio Identity references round-trip but drafts never create
+   account-scoped authority; only Approval can do so.
+5. Define the 1,000-draft proof as deterministic populate, close/reopen, canonical
+   digest, integrity/foreign-key checks, and privacy denylist—not only row count.
+
+### Amend #143
+
+1. Define Mirror lifecycle states and require retained terminal history for keep
+   and delete instead of physical relationship removal.
+2. Define when a multi-effect maintenance operation increments the authoritative
+   Mirror revision: only after all effects are conclusively complete.
+3. Enumerate journaled create/replace/append/description/relink/restore/delete
+   calls and their reconciliation evidence.
+4. Separate local-only revocation/keep/orphan transitions from provider effects,
+   and require compare-and-swap revisions for both.
+5. Distinguish exact source-not-found from validation, permission, parse, and
+   transient failures; only the former may produce orphaning.
+6. Require ordered duplicate Source Occurrences throughout Mirror replacement;
+   URI or track-ID deduplication is not an implementation shortcut.
+
+With these amendments, the four labels can mean “ready for an implementation
+agent after declared dependencies,” rather than “policy-complete but still
+requiring transactional design choices during coding.”
+
+## Primary sources
+
+- DJ Support:
+  [program #125](https://github.com/spontain112/djsupport/issues/125),
+  [implementation parent #128](https://github.com/spontain112/djsupport/issues/128),
+  [#138](https://github.com/spontain112/djsupport/issues/138),
+  [#139](https://github.com/spontain112/djsupport/issues/139),
+  [#140](https://github.com/spontain112/djsupport/issues/140),
+  [#141](https://github.com/spontain112/djsupport/issues/141),
+  [#142](https://github.com/spontain112/djsupport/issues/142), and
+  [#143](https://github.com/spontain112/djsupport/issues/143).
+- Repository truth:
+  [ADR-0001](../adr/0001-keep-user-data-out-of-the-repository.md),
+  [ADR-0002](../adr/0002-make-transfer-agent-native.md),
+  [ADR-0005](../adr/0005-use-one-local-transactional-operational-store.md),
+  [domain model](../domain-model.md), [lifecycles](../lifecycles.md),
+  [storage](../storage.md),
+  [Transfer](../../djsupport/transfer.py),
+  [Transfer tests](../../tests/test_transfer.py), and
+  [Qualification tests](../../tests/test_qualification.py).
+- SQLite:
+  [transactions](https://sqlite.org/lang_transaction.html),
+  [isolation](https://sqlite.org/isolation.html),
+  [WAL](https://sqlite.org/wal.html),
+  [savepoints](https://sqlite.org/lang_savepoint.html),
+  [`RETURNING`](https://sqlite.org/lang_returning.html),
+  [foreign keys](https://sqlite.org/foreignkeys.html), and
+  [integrity PRAGMAs](https://sqlite.org/pragma.html#pragma_integrity_check).
+- APSW 3.53.4.0:
+  [connection and transaction API](https://rogerbinns.github.io/apsw/connection.html),
+  [execution model](https://rogerbinns.github.io/apsw/execution.html),
+  [SQLite/DB-API differences](https://rogerbinns.github.io/apsw/pysqlite.html),
+  and [exceptions](https://rogerbinns.github.io/apsw/exceptions.html).

--- a/docs/research/2026-08-16-operational-store-foundation-implementation-contract.md
+++ b/docs/research/2026-08-16-operational-store-foundation-implementation-contract.md
@@ -1,0 +1,920 @@
+# Operational Store foundation implementation contract
+
+**Date:** 2026-08-16
+
+**Code baseline:** `origin/main` at
+`3e6ae7f6157364eeedaa2667d2a1deabed9efcee`
+
+**Status:** Implementation-ready research for
+[#138](https://github.com/spontain112/djsupport/issues/138) and
+[#139](https://github.com/spontain112/djsupport/issues/139). It does not
+authorize owner-data access, a production authority switch, a live Spotify call,
+or a release. #138 remains blocked by its human gate in #136, and #139 remains
+blocked by #138.
+
+**Authority and method:** The merged
+[ADR-0005](../adr/0005-use-one-local-transactional-operational-store.md),
+the current issues and repository code, and primary APSW, SQLite, and Python
+documentation. Statements phrased as “must” are the DJ Support implementation
+contract inferred from those sources; they are not descriptions of library
+defaults.
+
+**Contract precedence:** The ready-to-paste issue amendments are the proposed
+normative execution delta; the preceding sections explain and source that delta.
+Once an amendment is accepted into an issue, the issue body is authoritative.
+Do not combine conflicting versions—reconcile the amendment first.
+
+## Outcome
+
+Implement #138 and #139 as one deep Operational Store Module with one small
+Interface and exactly two conforming Implementations: a strict pure-Python
+in-memory Adapter and the private APSW 3.53.4.0 Adapter. Transfer continues to
+own policy. Runtime Assembly selects and qualifies an Adapter; callers never
+coordinate matching, Transfer, Batch, checkpoint, and event stores themselves.
+The Interface contains no SQL, cursor, connection, transaction, path, PRAGMA,
+APSW object, or APSW exception.
+
+The first SQLite schema is normalized around selected occurrences and mutable
+aggregates. Source order is an explicit zero-based position, duplicate source
+tracks are separate occurrence rows, and no provider item, source entity, or
+Spotify URI is incorrectly made unique. Every mutable Transfer, Batch, and
+matching-knowledge aggregate uses compare-and-swap revisions. A successful
+change commits its aggregate rows, compact Operational Events, and one store
+commit sequence atomically.
+
+Before any owner-data path is resolved, created, statted, locked, opened, or
+logged, the already-merged #166/#167 runtime gate must accept the exact APSW
+artifact and embedded SQLite runtime. Every qualified APSW connection uses WAL,
+short transactions, a five-second busy timeout, foreign keys, full synchronous
+durability, and read-back verification. Unsupported runtime, schema, migration,
+integrity, contention, stale revision, I/O, or corruption conditions fail closed
+through stable binding-neutral store errors.
+
+Production JSON remains the sole authority throughout #138 and #139. These
+issues create no production selector, no dual write, no JSON fallback, and no
+cutover. The SQLite path is a non-authoritative Preview implementation until the
+later migration and cutover issues explicitly verify and activate it
+([#138](https://github.com/spontain112/djsupport/issues/138),
+[ADR-0005](../adr/0005-use-one-local-transactional-operational-store.md)).
+
+## Explicit supersession
+
+This note supersedes every standard-library-shaped implementation mechanism in
+the earlier
+[concurrency and durability research](2026-08-16-sqlite-concurrency-durability-contract.md),
+including its connection example, transaction-control calls, cursor row-count
+mechanism, backup call direction, exception hierarchy, runtime-version probe,
+and illustrative aggregate `state_json` update. Preserve that note's behavioral
+outcomes—WAL, bounded contention, optimistic concurrency, integrity, crash
+atomicity, migration discipline, and scale—but implement them only through APSW
+3.53.4.0 and the normalized schema below.
+
+This note also supersedes the conditional language in the
+[APSW integration research](2026-08-16-apsw-operational-store-integration-contract.md):
+APSW 3.53.4.0 is now accepted, pinned, delivered, and qualified by the merged
+#165–#167 work and
+[package metadata](../../pyproject.toml). Python's standard `sqlite3` must not
+open, inspect, migrate, back up, restore, test, or otherwise touch an Operational
+Store. It is not a fallback or a second test oracle. APSW documents that it is
+not DB-API compatible and that using different SQLite libraries against the same
+database in one process can be unsafe
+([APSW comparison](https://rogerbinns.github.io/apsw/pysqlite.html)).
+
+## 1. Current repository gap
+
+The merged Operational Store package currently owns runtime probing,
+qualification, and delivery only. Runtime Assembly still constructs three file
+Implementations: `MatchCache`, `FileTransferStorage`, and
+`FilePublicationStorage`. `FileTransferStorage` mutates caller revisions and
+rewrites one JSON document under a platform lock; `MatchCache` has no aggregate
+revision; publication state has no general optimistic revision
+([Runtime Assembly](../../djsupport/runtime.py),
+[Transfer storage](../../djsupport/transfer.py),
+[matching cache](../../djsupport/cache.py)).
+
+The domain already carries the right occurrence primitive:
+`SourceOccurrence(occurrence_id, position, facts)`. `SourceTrackFacts` includes
+ordered artists and remixers, nullable nested facts, tri-state availability,
+and explicitly opaque evidence. `TransferState` and `BatchState` already carry
+integer revisions, but their JSON-shaped collections are not a normalized
+transactional model
+([source facts](../../djsupport/source_facts.py),
+[Transfer model](../../djsupport/transfer.py)).
+
+#138 must therefore add the storage Module and one non-authoritative end-to-end
+Preview path; it must not merely wrap the existing three file Implementations or
+put their whole documents into SQLite blobs. #139 then proves the same Module's
+multi-connection, optimistic-write, integrity, and crash behavior.
+
+## 2. One deep Module and one Interface
+
+### Vocabulary and ownership
+
+“Operational Store” is one Module. `OperationalStore` is its Interface. The
+pure-Python in-memory store and APSW store are Implementations and Adapters.
+Runtime qualification, the connection factory, schema registry, codecs,
+integrity verifier, and lifecycle lease are private Seams inside the Module.
+This gives the Module Depth: a small set of domain-named operations hides schema,
+migrations, connection setup, transactions, locks, result codes, and recovery.
+Transfer policy stays local to Transfer; persistence mechanics stay local to the
+Operational Store.
+
+### Normative Interface
+
+The #138 Interface begins with two domain-named operations (names may change
+during implementation, semantics may not):
+
+```python
+class OperationalStore(Protocol):
+    def persist_transfer_preview(
+        self, intent: PersistTransferPreview
+    ) -> PersistTransferPreviewReceipt: ...
+
+    def resume_transfer_preview(
+        self, request: ResumeTransferPreview
+    ) -> TransferPreviewSnapshot: ...
+```
+
+The associated immutable values are a closed, typed vocabulary:
+
+- `PersistTransferPreview` carries one complete, validated Preview intent,
+  expected aggregate revisions, an idempotency identity where the domain
+  supplies one, and zero or more compact event facts. It describes domain intent,
+  not tables, rows, or transaction steps.
+- `PersistTransferPreviewReceipt` returns the durable store commit sequence and
+  resulting aggregate revisions. It is created inside the private unit of work
+  but returned only after the outer transaction has committed successfully.
+- `ResumeTransferPreview` names one exact Transfer identity; it cannot contain
+  arbitrary SQL, table names, paths, predicates, or callbacks.
+- `TransferPreviewSnapshot` returns immutable domain facts plus the revision of
+  each mutable aggregate read and the observed store commit sequence.
+
+The persist operation may update a Transfer, its Batch, matching knowledge,
+checkpoints, and compact events together. This is the Leverage the current
+separate storage Interfaces cannot provide. A private typed unit-of-work plan may
+compose those mutations inside the Module, but it is never exported as a generic
+`commit(change)` command interpreter. Later issues extend the same Interface with
+reviewed domain-named operations for Snapshot publication, Approval,
+Qualification application, and Mirror maintenance.
+
+The Interface deliberately has no `begin`, `execute`, `cursor`, `flush`,
+`checkpoint_wal`, `migrate`, `path`, or `connection` member. No caller controls a
+transaction. No persistence Adapter is passed separately to Transfer. Runtime
+Assembly may expose a context-managed runtime session, but the selected store is
+the one persistence Interface in that session.
+
+### Error Interface
+
+Both Implementations return the same stable, path-free errors:
+
+| Error | Meaning | Caller outcome |
+| --- | --- | --- |
+| `StoreRuntimeUnavailable` | Exact runtime or artifact is not qualified | Stop before path access; no fallback |
+| `StoreSchemaUnsupported` | Application ID, migration registry, schema fingerprint, or version is unknown/newer/drifted | Stop and direct repair/upgrade |
+| `StoreIntegrityError` | SQLite, foreign-key, or domain integrity failed | Stop and direct restore/repair |
+| `StoreLeaseBusy` | A shared operation or exclusive maintenance lease was not acquired in its bounded window | End this attempt; retry only as a new operation |
+| `StoreBusy` | SQLite could not acquire its lock within 5,000 ms | End this attempt; retry only with a fresh connection and fresh facts |
+| `StaleRevision` | An expected aggregate revision no longer matches | Reload before deciding whether to retry |
+| `EntityMissing` | A required aggregate is absent | Do not reinterpret it as stale or create implicitly |
+| `StoreInvariantError` | Typed input or persisted relational invariant is invalid | Fail closed; this is not contention |
+| `StoreUnavailable` | Read-only, full disk, I/O, permission, open, or other storage failure | Fail closed; retain the private chained cause |
+
+Messages and diagnostics include only stable reason codes and public runtime or
+schema versions. They exclude paths, database names, SQL bindings, source facts,
+account identifiers, playlist identifiers, credentials, and raw APSW error text.
+The Adapter may chain the private APSW cause for local debugging.
+
+### Binding containment and file layout
+
+Only `djsupport/operational_store/apsw.py` may import or dynamically load APSW.
+Extend the existing architecture test so every other production module remains
+binding-neutral. A reasonable Locality-preserving layout is:
+
+```text
+djsupport/operational_store/
+  __init__.py        binding-neutral exports only
+  interface.py       OperationalStore and immutable request/result/error values
+  model.py           closed snapshot and mutation vocabulary
+  memory.py          pure-Python conforming Implementation
+  schema.py          immutable migration registry and schema fingerprints
+  lease.py           cross-platform shared/exclusive lifecycle lease
+  apsw.py            sole APSW import, runtime probe, connection factory, Adapter
+```
+
+Do not create an ORM, a repository per table, or Adapter-specific abstractions
+for callers. The table layout is private to the APSW Implementation.
+
+### Private-path permission contract
+
+After runtime qualification and before opening the store, verify that the
+application-data directory and every existing database, WAL, SHM, lease, backup,
+and staging member are regular, non-symlink objects owned by and accessible only
+to the current OS account. New POSIX directories use mode `0700` and files use
+mode `0600`; creation must not depend on a permissive process umask. On Windows,
+use the platform ACL surface to require an equivalent current-user-only boundary
+and reject broadly readable or writable inheritance. A platform on which that
+boundary cannot be established fails closed with a path-free `StoreUnavailable`.
+
+Permission and hostile-path tests run on native Linux, macOS, and Windows. They
+cover permissive parent defaults, pre-existing symlinks/special files, foreign
+ownership where the platform permits creating it, and an ACL/mode that grants
+another principal access. Public diagnostics report only a stable reason code.
+
+## 3. Two-Implementation conformance Seam
+
+### Pure-Python in-memory Implementation
+
+The in-memory Adapter is a strict behavioral peer, not a permissive fake and not
+an APSW `:memory:` database. It must:
+
+1. keep a normalized internal state with the same identities, positions,
+   revision rules, constraints, and typed errors;
+2. provide two independent handles over one shared backend for concurrency tests;
+3. serialize each write operation with a private lock, validate every expected revision,
+   apply mutations to a private copy, and publish the copy only after all
+   validations succeed;
+4. leave the prior state and every caller input unchanged on injected failure;
+5. increment the store commit sequence exactly once per successful domain write
+   operation, not once per row; and
+6. return new immutable snapshots and receipts rather than shared mutable values.
+
+The in-memory Adapter has no filesystem, WAL, migration, or APSW behavior. Those
+are Adapter lifecycle tests, not Interface conformance. It still exposes the
+current logical schema version in snapshots so semantic fixtures compare cleanly.
+
+### Shared conformance suite
+
+Run every fixture once against `MemoryOperationalStore` and once against a fresh
+qualified `ApswOperationalStore`. Compare canonical domain snapshots and typed
+outcomes, never private row layouts. The suite must cover:
+
+- empty/missing entities and one complete Preview;
+- exact zero-based Source Occurrence order;
+- adjacent and non-adjacent duplicates with identical provider and Spotify facts;
+- `facts=None`, nullable nested facts, tri-state booleans, empty repeated facts,
+  Unicode, and canonical opaque evidence;
+- matched proposals, failures, Batch/Transfer progress, checkpoints, and compact
+  events;
+- new revision `0` becoming durable revision `1`, then every successful update
+  advancing exactly once;
+- atomic multi-aggregate success and rollback on any stale member;
+- two handles reading revision *n*, one winning, and the other receiving
+  `StaleRevision` without hidden retry;
+- fault injection before validation, between every mutation family, and before
+  publication of a receipt; and
+- immutable inputs and deterministic snapshots after success or failure.
+
+Adapter-specific tests then add runtime-before-path, schema, WAL, busy,
+multi-process, integrity, reopen, and crash cases.
+
+## 4. Runtime-before-path gate and lifecycle lease
+
+### Required startup order
+
+The merged `SQLiteRuntimeQualification.run_qualified()` is the only entry to the
+APSW-backed store. The order is normative:
+
+1. Load the packaged runtime and delivery contracts and probe APSW's public
+   runtime facts. Do not evaluate a default application-data path first.
+2. Classify the exact binding, extension digest, embedded SQLite identity,
+   Python ABI, OS, and architecture.
+3. On any non-qualified result, raise `StoreRuntimeUnavailable` with a stable
+   path-free reason and stop.
+4. Inside the qualified callback only, resolve the private application-data
+   directory, derive the candidate database/lease names, and acquire the lease.
+5. Only then may code stat, create, open, configure, migrate, or check the
+   database family.
+
+The path resolver must be a thunk evaluated inside the qualified callback. A
+precomputed `Path`, `RuntimePaths.defaults()` call that performs I/O, directory
+creation, existence probe, log statement, or lease-file open before
+qualification violates the gate. A spy test must make every path primitive fail
+if invoked before the classifier returns qualified
+([runtime qualification](../../djsupport/operational_store/qualification.py),
+[#166](https://github.com/spontain112/djsupport/issues/166)).
+
+### One lifecycle lease
+
+Add one private, cross-platform `OperationalStoreLease` beside the database
+family after qualification. It has two modes:
+
+- a shared operation lease covers one complete CLI, web, or Agent Client command;
+  multiple clients may hold it, including while bounded external work occurs;
+- an exclusive maintenance lease covers first bootstrap, migrations, full
+  integrity/repair, backup/restore, and later cutover operations; it starts only
+  after existing shared operations drain.
+
+The lease is not a database transaction. Every store operation still opens and
+closes a short SQLite unit of work, including when the shared lease is held
+across a Spotify call. SQLite revisions arbitrate same-aggregate writes;
+the lease only prevents lifecycle replacement or migration underneath active
+operations. Account publishing guards remain separate domain guards and do not
+replace this store lease.
+
+Acquisition is bounded and returns `StoreLeaseBusy`; it never waits forever.
+Process death releases the OS lock. POSIX and Windows Implementations must share
+one test contract, use a fixed lock byte/range, and never delete or replace a
+lock file while contenders may exist. The lease path, as well as the database,
+WAL, and SHM, is private user data and must be ignored, excluded from packages,
+and absent from diagnostics. #138 introduces the Seam; later migration/cutover
+issues reuse it rather than inventing another quiescence mechanism.
+
+#138/#139 must not create or replace the future production generation selector.
+The non-authoritative Preview database records a stable `generation_id` in its
+metadata, but JSON remains selected production authority.
+
+## 5. Normalized schema v1
+
+### Global rules
+
+All application tables are `STRICT`; use `WITHOUT ROWID` for composite-key tables
+where it improves explicit identity. SQLite STRICT tables enforce declared types
+and make integrity checks validate stored types
+([SQLite STRICT tables](https://sqlite.org/stricttables.html)). Every identifier,
+ordinal, status, and revision is `NOT NULL`; use `CHECK` constraints for
+non-negative ordinals, revision bounds, boolean values, and closed status codes.
+Foreign keys are explicit and default to `ON DELETE RESTRICT`. Deletion is a
+typed domain mutation, never an incidental cascade from a parent row.
+
+No authority-bearing aggregate is stored as `state_json`, pickled Python, a
+generic key/value table, or a document blob. Repeated and ordered domain values
+are child rows with explicit ordinals. A canonical JSON codec is allowed only
+for fields the domain explicitly defines as opaque non-authoritative evidence
+(`raw_evidence`, artwork, opaque price evidence, and bounded event facts). That
+codec is versioned, UTF-8, key-sorted, compact, rejects NaN/infinity and
+non-JSON values, and is exercised identically on Python 3.10–3.14.
+
+### Required table families
+
+| Table family | Required identity and facts | Required constraints |
+| --- | --- | --- |
+| `store_metadata` | Singleton row, generation ID, logical schema version, store commit sequence, created-at fact | Singleton key; non-negative sequence; generation immutable |
+| `schema_migrations` | Version, stable name, SHA-256 of canonical migration bytes | Version primary key, name unique, contiguous immutable prefix |
+| `source_selections` | Selection ID, source kind, source reference/digest, display facts, creation fact | Stable selection ID; no uniqueness rule that collapses occurrence content |
+| `source_occurrences` | Selection ID, occurrence ID, zero-based position, nullable-facts marker | Primary key `(selection_id, occurrence_id)` and unique `(selection_id, position)`; contiguous positions verified by domain integrity |
+| `source_occurrence_facts` | One-to-zero/one typed fact row for an occurrence: provider/item identity, title/URL, durations, dates, availability, commerce, preview, musical and release facts | Same occurrence key; nullable fields preserve absence; tri-state booleans are NULL/0/1 |
+| `source_occurrence_entities` | Occurrence, role (`artist`, `remixer`, `genre`, `subgenre`, `release`, `label`), role ordinal, provider entity facts | Composite key including role/ordinal; ordered artists/remixers; singleton roles limited to ordinal 0 |
+| `source_occurrence_evidence` | Occurrence, evidence kind, codec version, canonical opaque bytes/digest | Only explicitly opaque, non-authoritative facts; bounded size; no path-bearing evidence |
+| `transfers` | Transfer ID, source/account/request scalar facts, status, timestamps, progress scalar facts, selection ID, revision | Revision at least 1 when durable; status/check constraints; selection FK |
+| `transfer_proposals` | Transfer, occurrence, proposal ordinal, candidate/public review facts and score reasons | Occurrence FK; explicit proposal order; proposal remains non-authoritative |
+| `transfer_failures` | Transfer, occurrence, failure kind and privacy-safe code | Occurrence FK; no raw exception text |
+| `transfer_checkpoints` | Transfer, checkpoint kind, ordinal, typed progress facts and digest | Unique per transfer/kind/ordinal; no generic mutable checkpoint document |
+| `batches` | Batch ID, scalar request/progress facts, status, revision | Revision at least 1; status/check constraints |
+| `batch_transfers` | Batch ID, transfer ID, zero-based position and phase/outcome facts | Unique batch position and transfer membership; order explicit |
+| `matching_entities` | Stable normalized lookup identity, current result facts, revision | Lookup identity unique only at the matching-entity level; revision at least 1 |
+| `matching_observations` | Matching entity, observation identity/order, proposal/failure/availability facts | Append facts without overwriting an unrelated entity; no URI-wide uniqueness |
+| `operational_events` | Store commit sequence, event ordinal, category/code, optional aggregate identity and bounded redacted facts | Primary key `(commit_sequence, event_ordinal)`; append-only in ordinary operation; no authority row cascades from event deletion |
+
+The exact DDL is part of #138's review, but it must implement these identities and
+constraints. If a current JSON field has no stable typed representation, #138
+must narrow its Preview vocabulary or add a reviewed typed table; it must not
+hide the field inside a generic aggregate blob.
+
+### Source order and duplicates
+
+`position` is zero based and, for a selection of length *n*, the set must be
+exactly `0..n-1`. Reads always use an explicit `ORDER BY position`; insertion or
+`RETURNING` order is never treated as domain order. SQLite documents that rows
+from `RETURNING` have arbitrary order
+([SQLite RETURNING](https://sqlite.org/lang_returning.html)).
+
+Two occurrences with identical provider item ID, source entity ID, source URL,
+title, artists, matching key, or Spotify proposal remain two rows with distinct
+occurrence IDs and positions. None of those content columns is unique. Facts are
+stored per occurrence rather than content-deduplicated in v1, avoiding accidental
+identity collapse. Exact round-trip tests include duplicates at positions 0/1,
+0/last, and three repeated occurrences separated by other tracks.
+
+## 6. Immutable migration registry
+
+The registry is a tuple of code-owned values:
+
+```python
+@dataclass(frozen=True)
+class Migration:
+    version: int
+    name: str
+    sha256: str
+    statements: tuple[str, ...]
+    schema_fingerprint: str
+```
+
+Canonical migration bytes are the UTF-8 encoding of every exact statement in
+order, with LF line endings and one trailing LF per statement. The committed
+digest and expected post-migration fingerprint are literals reviewed with the
+DDL. Never calculate the expected digest from mutable database content at
+runtime.
+
+Bootstrap/migration runs only after runtime qualification and under the exclusive
+maintenance lease. The Adapter must:
+
+1. require an outermost transaction state, set
+   `connection.transaction_mode = "IMMEDIATE"`, and enter one APSW connection
+   context;
+2. re-read `application_id`, `user_version`, `schema_migrations`, and the schema
+   fingerprint after acquiring the writer transaction;
+3. reject a foreign application ID, a newer version, a gap, duplicate, name or
+   digest mismatch, changed historical migration, unexpected schema object, or
+   `user_version`/registry disagreement;
+4. execute each migration statement separately with bindings where applicable
+   and fully consume its cursor; multiple statements in one APSW execute string
+   are prohibited even though APSW supports them;
+5. insert the migration registry row and update `user_version` in the same
+   transaction after that migration's DDL/data steps;
+6. verify the resulting schema fingerprint and contiguous registry before the
+   transaction exits; and
+7. return only after the APSW context has committed.
+
+Schema v1 uses application ID `0x444A5350` (`1145721680`, ASCII `DJSP`). It is a
+signed 32-bit value absent from SQLite's current assigned-ID list. Keep it
+immutable and test it on every open. SQLite reserves the application header field
+for exactly this file-identity purpose; `user_version` is application-owned
+([SQLite application and user version](https://sqlite.org/pragma.html#pragma_application_id),
+[SQLite assigned application IDs](https://sqlite.org/src/doc/trunk/magic.txt)).
+
+APSW's connection context starts a transaction, commits on clean exit, rolls back
+on exception, and uses savepoints for nested contexts. The factory must ensure
+migration owns the outermost context and set its transaction mode explicitly
+([APSW connection context](https://rogerbinns.github.io/apsw/connection.html#apsw.Connection.__enter__),
+[APSW `transaction_mode`](https://rogerbinns.github.io/apsw/connection.html#apsw.Connection.transaction_mode)).
+
+#138 must prove fresh bootstrap, idempotent reopen, every supported registry
+prefix, concurrent bootstrap, statement-by-statement injected failure, digest
+drift, version gap, newer schema, foreign application ID, and schema tampering.
+A crash or exception exposes either the complete prior prefix or complete next
+prefix. Migration of a non-empty production authority and its backup remain in
+the later migration/backup issues; #138 tests only synthetic Preview databases.
+
+## 7. APSW connection and transaction contract
+
+### Open modes
+
+Use one short-lived connection per unit of work. Never share a connection or
+cursor simultaneously across threads, processes, or a fork. APSW permits
+multiple connections across processes, while its cursors on one connection are
+not isolated from one another; the stricter project rule produces one portable
+execution model
+([APSW connections](https://rogerbinns.github.io/apsw/connection.html),
+[APSW cursors](https://rogerbinns.github.io/apsw/cursor.html)).
+
+After qualification and exclusive lease:
+
+- fresh bootstrap opens one uniquely named absent file with
+  `SQLITE_OPEN_READWRITE | SQLITE_OPEN_CREATE | SQLITE_OPEN_PRIVATECACHE |
+  SQLITE_OPEN_EXRESCODE | SQLITE_OPEN_NOFOLLOW`;
+- every ordinary/migration reopen omits `SQLITE_OPEN_CREATE`, does not use URI
+  mode, and verifies `connection.readonly("main") is False`;
+- no `ATTACH`, extension loading, shared cache, network filesystem, or user SQL
+  is allowed.
+
+SQLite WAL requires all processes to be on the same host and uses `-wal` and
+`-shm` sidecars; it is not supported on a network filesystem
+([SQLite WAL](https://sqlite.org/wal.html)). The application-data resolver must
+reject known network locations or fail closed when locality cannot be established
+for an authority-capable store.
+
+### Per-connection invariants
+
+On every ordinary open, before domain SQL, configure and read back:
+
+| Invariant | Required value |
+| --- | --- |
+| `foreign_keys` | `ON` |
+| `journal_mode` | `WAL` (set during bootstrap, verify on every open) |
+| `synchronous` | `FULL` |
+| `busy_timeout` | `5000` ms via `set_busy_timeout(5000)`, then read back |
+| `wal_autocheckpoint` | `1000` pages |
+| `trusted_schema` | `OFF` |
+| `read_uncommitted` | `OFF` |
+| `locking_mode` | `NORMAL` |
+| `application_id` | `0x444A5350` (`1145721680`, ASCII `DJSP`) |
+| `user_version` | exact latest migration version |
+
+Also enable SQLite defensive mode and keep extension loading disabled through
+APSW's connection configuration surface. Do not call the process-global APSW
+recommended-hook bundle: its defaults and global hooks are not the reviewed DJ
+Support connection contract. SQLite encourages disabling trusted schema on every
+connection, and APSW's explicit PRAGMA method returns the effective value
+([SQLite `trusted_schema`](https://sqlite.org/pragma.html#pragma_trusted_schema),
+[APSW PRAGMA method](https://rogerbinns.github.io/apsw/connection.html#apsw.Connection.pragma),
+[APSW best practice](https://rogerbinns.github.io/apsw/bestpractice.html)).
+
+Any set/read mismatch closes the connection and raises a typed store error.
+Never silently accept rollback-journal mode, a shorter durability setting, a
+replaced busy handler, or a read-only fallback.
+
+Fresh bootstrap is the only pre-schema exception to the final identity rows in
+that table. Under the exclusive maintenance lease, the create path first proves
+the newly created file has `application_id=0`, `user_version=0`, and no user
+schema objects; it then configures the connection and installs schema v1,
+application ID, migration registry, and `user_version` atomically. It closes the
+bootstrap connection and reopens through the ordinary path, which must satisfy
+the complete table before any Preview operation. A non-empty or non-zero
+pre-bootstrap file is rejected rather than adopted.
+
+### Read and write units
+
+A read-oriented domain operation starts a short read transaction only when
+multiple queries must share one snapshot, fully consumes every result, maps rows
+to immutable domain values, and exits before returning. WAL gives each read
+transaction a stable snapshot while allowing a writer to proceed
+([SQLite isolation](https://sqlite.org/isolation.html)).
+
+A write-oriented domain operation sets `transaction_mode = "IMMEDIATE"` and
+enters one outer APSW connection context. It re-reads all expected revisions
+after acquiring write intent, applies its complete private unit-of-work plan,
+increments the store commit sequence, inserts its events, verifies mutation
+counts, and exits. All remote reads,
+matching computation, user interaction, and Spotify calls occur before or after
+this context. `Connection.txn_state("main")` must report no transaction at every
+external call Seam and before the connection closes
+([APSW transaction state](https://rogerbinns.github.io/apsw/connection.html#apsw.Connection.txn_state)).
+
+SQLite documents that escalating an old WAL read snapshot can fail with
+`SQLITE_BUSY_SNAPSHOT`; starting a known read-then-write operation with
+`BEGIN IMMEDIATE` prevents that history fork
+([SQLite isolation](https://sqlite.org/isolation.html)). No hidden retry may
+replay an operation intent against newer facts.
+
+## 8. Revisions and atomic commits
+
+Revisions are aggregate-scoped opaque concurrency tokens represented as
+non-negative integers at the Interface:
+
+- a new caller value has revision `0` and means “expected absent”;
+- initial durable insertion returns revision `1`;
+- each successful mutation of that aggregate increments it exactly once;
+- an unchanged aggregate does not advance merely because another aggregate
+  commits; and
+- the store commit sequence advances exactly once for every successful
+  domain write operation and never for a rejected or rolled-back operation.
+
+Mutable v1 scopes are Transfer, Batch, and matching-knowledge entity. Child rows
+take their concurrency scope from their owning aggregate. Later schema issues
+add publication, Approval, Qualification, Mirror, and Effect Journal scopes; #138
+must not pre-empt their domain decisions.
+
+Use APSW iteration over a revision-qualified statement, not a DB-API row count:
+
+```sql
+UPDATE transfers
+   SET status = ?, next_track_index = ?, revision = revision + 1
+ WHERE transfer_id = ? AND revision = ?
+ RETURNING revision;
+```
+
+Fully consume the result and require exactly one row. Zero rows triggers an
+existence/revision check inside the same `BEGIN IMMEDIATE` transaction so
+`EntityMissing` and `StaleRevision` remain distinct; more than one is an
+invariant failure. Insert with expected revision `0`; a uniqueness conflict is
+stale/existing, never an implicit overwrite. SQLite `RETURNING` reports values
+from the modifying statement but the transaction is not durable until commit,
+so the Adapter returns the receipt only after successful context exit
+([SQLite RETURNING](https://sqlite.org/lang_returning.html),
+[APSW execution model](https://rogerbinns.github.io/apsw/execution.html)).
+
+For a multi-aggregate domain operation, every compare-and-swap must succeed or the
+entire transaction rolls back, including child replacement, checkpoints,
+events, and store sequence. Never mutate the caller's revision in place; return
+new values in the immutable operation receipt.
+
+## 9. WAL, busy, and result-code translation
+
+WAL allows readers and one writer to proceed concurrently, but still permits
+only one writer. A long read can delay checkpoint progress; therefore all
+snapshots and cursors are bounded and fully consumed. Keep the default-sized
+1,000-page automatic passive checkpoint and do not add a hidden checkpoint
+scheduler or rollback-journal fallback in #138/#139
+([SQLite WAL concurrency](https://sqlite.org/wal.html#concurrency),
+[SQLite automatic checkpoint](https://sqlite.org/wal.html#automatic_checkpoint)).
+
+Each connection installs exactly one 5,000 ms busy timeout. After it expires,
+translate `apsw.BusyError` by extended result code:
+
+- plain `SQLITE_BUSY` becomes `StoreBusy`;
+- `SQLITE_BUSY_SNAPSHOT` becomes a stale-snapshot outcome requiring a fresh
+  unit of work;
+- a revision mismatch remains `StaleRevision`, never `StoreBusy`;
+- `SQLITE_LOCKED` with private cache indicates Implementation misuse and becomes
+  `StoreInvariantError`;
+- constraint errors become the specific revision/invariant outcome after local
+  classification;
+- corrupt/not-a-database becomes `StoreIntegrityError`; and
+- read-only, full, I/O, permission, cannot-open, and unknown storage errors become
+  `StoreUnavailable` unless a more specific fail-closed type applies.
+
+APSW exposes both primary and extended result codes on its exceptions and has a
+specific busy-timeout method
+([APSW errors](https://rogerbinns.github.io/apsw/exceptions.html),
+[APSW busy timeout](https://rogerbinns.github.io/apsw/connection.html#apsw.Connection.set_busy_timeout),
+[SQLite result codes](https://sqlite.org/rescode.html)). Translation tests use
+the numeric APSW/SQLite constants, not error-message matching.
+
+There is no Adapter-level retry loop. A CLI/web/Agent caller may offer a later
+retry only by acquiring a new shared lease, opening a new connection, loading a
+new snapshot, and rebuilding the domain decision. Tests shorten the timeout only
+through an injected private connection policy and coordinate contenders with
+process events, never timing sleeps.
+
+## 10. Integrity and fail-closed startup
+
+Integrity is layered:
+
+| Boundary | Required checks |
+| --- | --- |
+| Every connection | Runtime proof, connection invariant read-back, application ID, exact registry/user version, expected schema fingerprint |
+| First open in each process and every crash reopen | `PRAGMA quick_check`, `PRAGMA foreign_key_check`, plus domain integrity queries |
+| Fresh bootstrap and after each migration | Full `PRAGMA integrity_check`, foreign-key check, registry/fingerprint, and domain invariants |
+| Exclusive maintenance, backup/restore, and later cutover | Full integrity, foreign-key, normalized counts, revisions, order, and canonical domain digest |
+
+`integrity_check` returns one `ok` row on success but does not find foreign-key
+errors; `foreign_key_check` is separately mandatory. `quick_check` omits some
+index/uniqueness work in exchange for linear-time checking
+([SQLite integrity checks](https://sqlite.org/pragma.html#pragma_integrity_check),
+[SQLite foreign keys](https://sqlite.org/foreignkeys.html)).
+
+Domain integrity queries require, at minimum:
+
+- contiguous occurrence and Batch positions;
+- no orphan or cross-selection proposal/checkpoint rows;
+- no durable mutable revision below 1;
+- every event ordinal contiguous within its commit sequence;
+- every event aggregate reference valid without making events authority;
+- metadata commit sequence at least the largest event sequence;
+- exactly one metadata row and one exact migration prefix; and
+- canonical Interface re-materialization that passes domain constructors and
+  status/identity invariants.
+
+Any failure makes the Adapter unavailable. It does not create a replacement,
+continue with partial tables, downgrade, delete sidecars, fall back to JSON, or
+return partial snapshots. Since JSON is still production authority in #138/#139,
+the existing product path remains unchanged; the failed SQLite Preview path is
+reported unavailable rather than silently substituted.
+
+## 11. Deterministic crash contract
+
+Every committed domain write operation has exactly two valid post-crash outcomes: the
+complete previous snapshot or the complete next snapshot. “Complete next”
+includes every changed aggregate revision, child row, checkpoint, event, and the
+one new store commit sequence. Any mix is a failure.
+
+Use three complementary fault Seams:
+
+1. ordinary Python exceptions at before-BEGIN, after-BEGIN, after each mutation
+   family, before sequence/event retention, before context exit, and after context
+   exit but before receipt mapping;
+2. a child process that calls `os._exit()` at the same phases, leaving normal
+   cleanup and rollback handlers unrun; and
+3. a test-only derived APSW VFS that delegates to the platform VFS but injects
+   typed failures from WAL/database `xWrite`, `xSync`, `xTruncate`, and `xDelete`
+   operations around commit/checkpoint phases.
+
+APSW exposes VFS/VFSFile inheritance specifically to augment file operations and
+requires VFS routines to report errors by raising exceptions
+([APSW VFS](https://rogerbinns.github.io/apsw/vfs.html)). Python documents
+`os._exit()` as immediate process exit without cleanup handlers
+([Python `os._exit`](https://docs.python.org/3.10/library/os.html#os._exit)).
+
+Each fault case starts from a copied synthetic seed in its own temporary
+application-data directory, uses a unique VFS name, terminates the writer, then
+reopens through the public `OperationalStore.resume_transfer_preview()` Interface
+in a new process using the normal VFS. The verifier runs runtime qualification,
+connection read-back, full integrity, foreign-key and domain checks, then compares
+a canonical semantic digest to the old and new expected snapshots. It retains
+the synthetic database/WAL/SHM family only inside the ephemeral runner workspace
+for that test and deletes it before job completion. It uploads no workflow
+artifact and prints only privacy-redacted synthetic outcome facts.
+
+Migration crash tests apply the same phases to every statement and registry
+write. The observed schema/registry must be the complete prior or next migration
+prefix. Busy and hard-exit tests use process events/pipes to prove exact phase;
+they do not infer it from sleeps or log timing.
+
+## 12. Scale and cross-platform verification matrix
+
+The merged delivery catalog claims 25 exact native cells: five Python minors
+(3.10–3.14) on Ubuntu 24.04 x86-64, Ubuntu 24.04 arm64, macOS 15 Intel, macOS 15
+Apple silicon, and Windows Server 2025 x64
+([artifact catalog](../../djsupport/contracts/apsw-runtime-artifacts.v1.json),
+[#167](https://github.com/spontain112/djsupport/issues/167)). Store support must
+not exceed the cells that run the required store evidence.
+
+| Suite | Required cells | Required evidence |
+| --- | --- | --- |
+| Pure Interface conformance | Every ordinary Python 3.10–3.14 CI cell | Same snapshots, receipts, typed failures for memory and APSW Implementations |
+| Qualified APSW foundation | All 25 catalog cells | Gate-before-path, bootstrap/reopen, PRAGMA read-back, schema registry/fingerprint, exact Preview round trip, CAS win/loss, WAL persistence, quick/FK checks |
+| Native concurrency and hard exit | All 25 catalog cells | Two independent processes/connections, distinct writes, same-aggregate stale write, bounded busy, before/during/after-commit hard exit, old-or-new digest |
+| VFS fault campaign | At least one exact Python patch on each of the five native OS/architecture shapes, plus Python 3.10 and 3.14 on Ubuntu x86-64 | Deterministic WAL/database write/sync/truncate/delete failures and verified reopen |
+| #138 scale | Python 3.10 and 3.14 on Ubuntu x86-64, plus one macOS Apple-silicon and one Windows x64 cell | 10,000 Transfers, exactly 100,000 occurrences, deliberate adjacent/non-adjacent duplicates, matching/checkpoint/event facts, restart and semantic digest |
+| Migration prefixes | All 25 for clean bootstrap/reopen; full fault matrix on the VFS campaign cells | Every prefix, idempotence, concurrent starter, drift/gap/newer/foreign/tampered failures |
+
+The 100,000-occurrence fixture is arithmetic and synthetic: ten ordered
+occurrences for each of 10,000 Transfers, deterministic IDs, positions, nullable
+facts, and duplicate patterns. Assertions use aggregate counts, ordered identity
+digests, revision sums, event/checkpoint categories, and sampled complete
+snapshots rather than retaining all mapped domain objects at once. Record elapsed
+time, peak memory, database/WAL size, and checkpoint progress as non-secret CI
+metrics, but make correctness—not an unresearched timing threshold—the #138
+acceptance gate.
+
+No required row may skip, xfail, continue on error, emulate another architecture,
+or silently select a different APSW artifact. A failed runtime classifier means
+the persistence suite fails before path access. Release qualification must rerun
+the focused foundation suite against the exact release-candidate artifact and
+commit.
+
+## 13. Rejected implementations
+
+| Reject | Why | Required replacement |
+| --- | --- | --- |
+| One wrapper over the existing three JSON stores | Callers still coordinate authority and no cross-aggregate atomicity exists | One `OperationalStore` Interface and one private atomic unit of work per domain write operation |
+| Whole `TransferState`/`BatchState`/cache JSON blobs | Hides identity, ordering, constraints, revisions, and migrations | Normalized aggregate and ordered child tables |
+| Content-deduplicated source tracks | Collapses duplicate selected occurrences | Occurrence identity plus explicit position; content not unique |
+| Standard-library SQLite connection in production or tests | Violates accepted sole binding and risks mixed SQLite libraries | APSW 3.53.4.0 only; pure-Python memory Adapter for independent conformance |
+| Path resolution before qualification | Unsupported native code can touch private owner state | Lazy path thunk inside `run_qualified()` |
+| APSW connection/cursor/error exposed to Transfer | Leaks mechanism and makes callers coordinate transactions | Binding-neutral domain intents, snapshots, receipts, and store errors |
+| DB-API row counts or last-insert state | Not the selected mechanism and can obscure exact mutation identity | `RETURNING`, fully consumed and cardinality checked |
+| Deferred read then write for authority mutation | Can attempt to fork an old WAL snapshot | Short `IMMEDIATE` write unit and in-transaction revision re-read |
+| Hidden busy or stale retry | Replays a decision against new facts | Typed outcome, fresh connection, reload-before-retry |
+| Database transaction across Spotify | Holds writer lock across uncertain network work | Commit local intent/checkpoint, close transaction, call externally, commit observation later |
+| File-copy backup or deleting WAL/SHM | Can separate one database family at inconsistent points | Later APSW Online Backup workflow; preserve sidecars during active recovery |
+| Production selector or dual write in #138/#139 | Exceeds the issue authority scope | Non-authoritative SQLite Preview only; later explicit migration/cutover |
+
+## 14. Ready-to-paste issue amendments
+
+### Amendment for #138
+
+Append the following after the existing acceptance criteria:
+
+```markdown
+## Foundation implementation contract (2026-08-16)
+
+The implementation follows
+[`docs/research/2026-08-16-operational-store-foundation-implementation-contract.md`](https://github.com/spontain112/djsupport/blob/main/docs/research/2026-08-16-operational-store-foundation-implementation-contract.md).
+It supersedes the standard-library-shaped mechanisms in the older concurrency
+research. APSW 3.53.4.0 is the only SQLite binding; Python's standard `sqlite3`
+must not open or test the Operational Store.
+
+- [ ] Add one deep, binding-neutral `OperationalStore` interface whose #138
+  surface has domain-named persist/resume Transfer Preview operations. Callers
+  see immutable intents/snapshots/receipts and stable store errors, never a
+  generic `commit(change)`, SQL, paths, transactions, APSW values, or separate
+  persistence adapters. Keep mutation composition private so later issues extend
+  this same port with reviewed domain operations rather than a second interface.
+- [ ] Add a strict pure-Python in-memory adapter and one private APSW adapter;
+  run the same interface conformance fixtures against both.
+- [ ] Keep the sole direct APSW import in
+  `djsupport/operational_store/apsw.py` and retain the architecture test that
+  rejects binding leakage or any standard-library SQLite use.
+- [ ] Require #166/#167 qualification before path resolution, stat, mkdir,
+  lease, open, logging, or mutation; test the order with rejecting path spies.
+- [ ] Add the shared-operation/exclusive-maintenance lifecycle lease after the
+  runtime gate; lease acquisition is bounded and process death releases it.
+- [ ] Implement normalized STRICT schema v1 and an immutable, digest-checked,
+  contiguous migration registry with application ID `0x444A5350`, matching
+  `user_version`, and post-migration schema fingerprints; reject drift, gaps,
+  foreign/newer schemas, and partial prefixes.
+- [ ] Encode each selected source occurrence as `(selection_id, occurrence_id,
+  position)` with zero-based contiguous positions. Provider IDs, source entity
+  IDs, URLs, matching keys, and Spotify URIs are not unique and must not collapse
+  duplicate occurrences.
+- [ ] Normalize Transfer, Batch, matching-knowledge, proposals, failures,
+  checkpoints, and compact event facts; no authority-bearing aggregate
+  `state_json`, pickle, generic key/value table, or ORM.
+- [ ] Make Transfer, Batch, and matching-knowledge revisions conformant: caller
+  revision 0 means expected absent, first durable revision is 1, each successful
+  aggregate mutation advances once, and one successful domain write operation
+  advances the store commit sequence once.
+- [ ] Configure and read back WAL, `synchronous=FULL`, foreign keys,
+  `busy_timeout=5000`, `wal_autocheckpoint=1000`, `trusted_schema=OFF`, normal
+  locking, exact application ID, and exact schema version on each APSW open.
+- [ ] Run fresh/idempotent/concurrent bootstrap plus every-prefix,
+  statement-failure, digest-drift, gap, newer, foreign-ID, and tampered-schema
+  migration tests.
+- [ ] Run the 10,000-Transfer/100,000-occurrence synthetic fixture with deliberate
+  adjacent and non-adjacent duplicates, restart, integrity checks, and a canonical
+  semantic digest.
+- [ ] Keep this SQLite Preview non-authoritative: do not create a production
+  selector, dual-write, cut over, or fall back from SQLite to JSON.
+- [ ] Document and ignore the database, WAL, SHM, and lease as private user data;
+  exclude them from packages and repository fixtures.
+- [ ] Verify owner-only application-data permissions after qualification and
+  before open: POSIX directories `0700`, files `0600`, and equivalent
+  current-user-only Windows ACLs. Reject symlinks, special files, foreign or
+  broadly accessible objects, and permission checks that cannot be completed.
+```
+
+The existing “Completed prerequisites” list for #166/#167 remains accurate. Do
+not remove the #136 human gate.
+
+### Amendment for #139
+
+Append the following after the existing acceptance criteria:
+
+```markdown
+## Concurrency and crash implementation contract (2026-08-16)
+
+The implementation follows
+[`docs/research/2026-08-16-operational-store-foundation-implementation-contract.md`](https://github.com/spontain112/djsupport/blob/main/docs/research/2026-08-16-operational-store-foundation-implementation-contract.md).
+
+- [ ] Use one short-lived qualified APSW connection per unit of work; never share
+  a connection/cursor concurrently across threads, processes, or a fork.
+- [ ] Start every read-then-write domain operation with an outer APSW transaction whose
+  `transaction_mode` is `IMMEDIATE`; re-read all expected revisions inside it and
+  ensure `txn_state("main")` is none before every Spotify call.
+- [ ] Implement compare-and-swap for Transfer, Batch, and matching-knowledge
+  entities with revision-qualified `UPDATE ... RETURNING revision`; fully consume
+  exactly one row, distinguish missing from stale, and roll back the complete
+  domain operation if any member conflicts.
+- [ ] Return new revisions only after commit; never mutate caller objects. A stale
+  revision fails with a reload-before-retry outcome and is never silently retried.
+- [ ] Install exactly one 5,000 ms APSW busy timeout per connection. Translate
+  primary/extended APSW result codes to stable store errors; busy, stale revision,
+  locked/misuse, integrity, and unavailable storage remain distinct.
+- [ ] Prove two independent processes can update distinct work, one writer is
+  bounded behind another, and two copies of the same revision yield one winner
+  and one stale result without lost updates.
+- [ ] On process startup run quick, foreign-key, schema, and domain integrity
+  checks; after crash and under exclusive maintenance run full integrity plus
+  canonical domain-digest verification. Any failure is fail-closed.
+- [ ] Inject ordinary exceptions and `os._exit()` before, during, and after commit,
+  and use a test-only derived APSW VFS to fail WAL/database write, sync, truncate,
+  and delete phases. Reopen through the public interface and accept only the
+  complete old or complete new snapshot, including revisions, events, and store
+  commit sequence.
+- [ ] Run the focused qualified APSW foundation/concurrency/hard-exit suite on all
+  25 approved #167 cells: Python 3.10–3.14 on Ubuntu 24.04 x64/arm64, macOS 15
+  Intel/Apple silicon, and Windows Server 2025 x64. Run the full VFS campaign on
+  every native OS/architecture shape and both Linux Python edges.
+- [ ] Preserve existing CLI, web, and Agent Client privacy-redacted behavior and
+  keep JSON as production authority; #139 does not activate a selector, dual
+  write, cutover, fallback, or release.
+```
+
+Keep `Blocked by #138` unchanged.
+
+## 15. Implementation order
+
+The lowest-risk dependency order is:
+
+1. binding-neutral Interface values/errors and the pure-Python Adapter;
+2. shared conformance fixtures, including exact duplicate/order and revision
+   semantics;
+3. immutable schema/migration registry and pure schema tests;
+4. runtime-gated path thunk and lifecycle lease;
+5. qualified APSW connection factory and error translation;
+6. normalized APSW snapshot/commit mapping;
+7. migration, integrity, multi-process busy/CAS, hard-exit, and VFS tests;
+8. Runtime Assembly's one non-authoritative Preview route;
+9. 100,000-occurrence scale and the 25-cell focused native matrix; and
+10. privacy/package/docs/release-note checks.
+
+Do not replace the existing production JSON Implementations in #138/#139. The
+later migration, backup, cutover, and writer-retirement issues consume this
+foundation only after their separate verification and review gates.
+
+## Primary sources
+
+### Project
+
+- [ADR-0005](../adr/0005-use-one-local-transactional-operational-store.md)
+- [#138](https://github.com/spontain112/djsupport/issues/138) and
+  [#139](https://github.com/spontain112/djsupport/issues/139)
+- [#165](https://github.com/spontain112/djsupport/issues/165),
+  [#166](https://github.com/spontain112/djsupport/issues/166), and
+  [#167](https://github.com/spontain112/djsupport/issues/167)
+- [Operational Store runtime package](../../djsupport/operational_store/)
+- [Runtime Assembly](../../djsupport/runtime.py),
+  [Transfer model/storage](../../djsupport/transfer.py),
+  [source facts](../../djsupport/source_facts.py), and
+  [matching cache](../../djsupport/cache.py)
+- [Package metadata](../../pyproject.toml) and
+  [qualified artifact catalog](../../djsupport/contracts/apsw-runtime-artifacts.v1.json)
+
+### APSW 3.53.4.0
+
+- [About and release identity](https://rogerbinns.github.io/apsw/about.html)
+- [Connections, contexts, PRAGMAs, transaction mode/state, and busy timeout](https://rogerbinns.github.io/apsw/connection.html)
+- [Execution model](https://rogerbinns.github.io/apsw/execution.html)
+- [Exceptions and extended result codes](https://rogerbinns.github.io/apsw/exceptions.html)
+- [VFS](https://rogerbinns.github.io/apsw/vfs.html)
+- [APSW and standard-library differences](https://rogerbinns.github.io/apsw/pysqlite.html)
+
+### SQLite
+
+- [WAL](https://sqlite.org/wal.html),
+  [transactions](https://sqlite.org/lang_transaction.html), and
+  [isolation](https://sqlite.org/isolation.html)
+- [RETURNING](https://sqlite.org/lang_returning.html) and
+  [result codes](https://sqlite.org/rescode.html)
+- [STRICT tables](https://sqlite.org/stricttables.html),
+  [foreign keys](https://sqlite.org/foreignkeys.html), and
+  [PRAGMAs/integrity](https://sqlite.org/pragma.html)
+- [Open flags](https://sqlite.org/c3ref/open.html),
+  [security guidance](https://sqlite.org/security.html), and
+  [crash/corruption guidance](https://sqlite.org/howtocorrupt.html)
+
+### Python platform process testing
+
+- [`os._exit`](https://docs.python.org/3.10/library/os.html#os._exit)
+- [Multiprocessing start methods and contexts](https://docs.python.org/3.14/library/multiprocessing.html#contexts-and-start-methods)


### PR DESCRIPTION
## Summary

- define the deep Operational Store foundation and APSW concurrency contract for #138–#139
- define the Effect Journal claim/call/observation protocol for #140–#143
- define backup-first migration, APSW backup/restore, cutover, rollback, and JSON retirement for #144–#147
- define the post-#147 Qualification deletion test and private diagnostics contract for #130/#132
- reconcile #148–#151 with the merged publication-free candidate harness from #181/#182

## Review corrections incorporated

- correct SQLite application ID decimal and fresh-bootstrap ordering
- keep the store interface domain-named; transaction composition remains private
- add a process-death-releasing per-effect claimant lock
- require owner-only native filesystem permissions and ephemeral-only crash evidence
- keep JSON authority through verified backup and Preview before entering transition
- retain `(commit_sequence, event_ordinal)` as Operational Event identity
- require RC qualification only after the RC version commit exists
- make accepted issue bodies authoritative over proposed research amendments

## Verification

- full offline test suite passed
- `python3 -m pytest tests/test_documentation.py tests/test_repository_privacy.py -q` — 62 passed
- `python3 scripts/release_records.py check origin/main HEAD` — no distributable changes
- cached/final diff checks clean
- independent Spec and Standards reviews — no findings

Exactly five files under `docs/research/`. No runtime implementation, production authority switch, user data, live provider call, tag, Release, artifact upload, package publication, or advisory publication.

Related to #130, #132, and #138–#151. #138 remains blocked by the human gate in #136.