### PR TITLE
Validation: complete the private-source boundary for 0.6.0

### DIFF
--- a/.release-notes/private-source-loopback.md
+++ b/.release-notes/private-source-loopback.md
@@ -1,0 +1,7 @@
+---
+bump: patch
+section: Security
+---
+
+Require loopback peer, Host, and Origin checks before private Rekordbox web
+routes inspect user-selected local paths.

--- a/djsupport/web.py
+++ b/djsupport/web.py
@@ -308,14 +308,14 @@ def create_app(
         inspect_readiness = first_transfer_readiness
 
     @web_app.middleware("http")
-    async def qualification_privacy(request: FastAPIRequest, call_next):
-        qualification_route = (
-            request.url.path.startswith("/rekordbox/qualification/")
+    async def private_source_privacy(request: FastAPIRequest, call_next):
+        private_source_route = (
+            request.url.path.startswith("/rekordbox/")
             or request.url.path.startswith("/qualification/")
         )
-        if qualification_route:
+        if private_source_route:
             try:
-                require_qualification_loopback(request)
+                require_private_source_loopback(request)
             except HTTPException as exc:
                 response = JSONResponse(
                     status_code=exc.status_code,
@@ -345,7 +345,7 @@ def create_app(
         if not token or mgr.is_token_expired(token):
             raise HTTPException(status_code=401, detail="Not authenticated with Spotify")
 
-    def require_qualification_loopback(request: FastAPIRequest) -> None:
+    def require_private_source_loopback(request: FastAPIRequest) -> None:
         peer = request.client.host if request.client else ""
 
         def is_loopback(value: str, *, allow_test: bool = False) -> bool:
@@ -360,7 +360,7 @@ def create_app(
         if not (peer_is_test or is_loopback(peer)):
             raise HTTPException(
                 status_code=403,
-                detail="Qualification Workspace is available only on loopback",
+                detail="Private-source routes are available only on loopback",
             )
         host_header = request.headers.get("host", "")
         try:
@@ -370,7 +370,7 @@ def create_app(
         if not is_loopback(request_host, allow_test=peer_is_test):
             raise HTTPException(
                 status_code=403,
-                detail="Qualification Workspace requires a loopback Host",
+                detail="Private-source routes require a loopback Host",
             )
         if request.method not in {"GET", "HEAD", "OPTIONS"}:
             origin = request.headers.get("origin")
@@ -382,9 +382,7 @@ def create_app(
                 if not is_loopback(origin_host, allow_test=peer_is_test):
                     raise HTTPException(
                         status_code=403,
-                        detail=(
-                            "Qualification Workspace requires a loopback Origin"
-                        ),
+                        detail="Private-source routes require a loopback Origin",
                     )
 
     def transfer_for(transfer_id: str, request: SyncRequest | None = None):
@@ -726,7 +724,7 @@ def create_app(
     def create_qualification_draft(
         request: FastAPIRequest, payload: QualificationDraftRequest,
     ):
-        require_qualification_loopback(request)
+        require_private_source_loopback(request)
         if not payload.authorize_private_source:
             raise HTTPException(
                 status_code=403, detail="Private source authorization required",
@@ -760,7 +758,7 @@ def create_app(
         request: FastAPIRequest,
         authorize_private_source: bool = False,
     ):
-        require_qualification_loopback(request)
+        require_private_source_loopback(request)
         if not authorize_private_source:
             raise HTTPException(
                 status_code=403, detail="Private source authorization required",
@@ -783,7 +781,7 @@ def create_app(
         request: FastAPIRequest,
         payload: QualificationDecisionRequest,
     ):
-        require_qualification_loopback(request)
+        require_private_source_loopback(request)
         if not payload.authorize_private_source:
             raise HTTPException(
                 status_code=403, detail="Private source authorization required",
@@ -813,7 +811,7 @@ def create_app(
         request: FastAPIRequest,
         payload: QualificationAuthorizationRequest,
     ):
-        require_qualification_loopback(request)
+        require_private_source_loopback(request)
         if not payload.authorize_private_source:
             raise HTTPException(
                 status_code=403, detail="Private source authorization required",
@@ -851,7 +849,7 @@ def create_app(
         request: FastAPIRequest,
         payload: QualificationAuthorizationRequest,
     ):
-        require_qualification_loopback(request)
+        require_private_source_loopback(request)
         if not payload.authorize_private_source:
             raise HTTPException(
                 status_code=403, detail="Private source authorization required",
@@ -891,7 +889,7 @@ def create_app(
         request: FastAPIRequest,
         payload: QualificationAuthorizationRequest,
     ):
-        require_qualification_loopback(request)
+        require_private_source_loopback(request)
         if not payload.authorize_private_source:
             raise HTTPException(
                 status_code=403, detail="Private source authorization required",
@@ -928,7 +926,7 @@ def create_app(
         request: FastAPIRequest,
         payload: QualificationLinkRequest,
     ):
-        require_qualification_loopback(request)
+        require_private_source_loopback(request)
         if not payload.authorize_private_source:
             raise HTTPException(
                 status_code=403, detail="Private source authorization required",
@@ -956,7 +954,7 @@ def create_app(
         request: FastAPIRequest,
         payload: QualificationAuthorizationRequest,
     ):
-        require_qualification_loopback(request)
+        require_private_source_loopback(request)
         if not payload.authorize_private_source:
             raise HTTPException(
                 status_code=403, detail="Private source authorization required",
@@ -978,7 +976,7 @@ def create_app(
         request: FastAPIRequest,
         payload: QualificationAuthorizationRequest,
     ):
-        require_qualification_loopback(request)
+        require_private_source_loopback(request)
         if not payload.authorize_private_source:
             raise HTTPException(
                 status_code=403, detail="Private source authorization required",
@@ -1005,7 +1003,7 @@ def create_app(
         request: FastAPIRequest,
         payload: QualificationAuthorizationRequest,
     ):
-        require_qualification_loopback(request)
+        require_private_source_loopback(request)
         if not payload.authorize_private_source:
             raise HTTPException(
                 status_code=403, detail="Private source authorization required",
@@ -1044,7 +1042,7 @@ def create_app(
 
     @web_app.get("/rekordbox/qualification/media/{handle}")
     def qualification_media(handle: str, request: FastAPIRequest):
-        require_qualification_loopback(request)
+        require_private_source_loopback(request)
         privacy_headers = QUALIFICATION_PRIVACY_HEADERS
         try:
             stream = audition.stream(handle, request.headers.get("range"))
@@ -1132,7 +1130,7 @@ def create_app(
 
     @web_app.get("/qualification/{draft_id}")
     def qualification_workspace(draft_id: str, request: FastAPIRequest):
-        require_qualification_loopback(request)
+        require_private_source_loopback(request)
         del draft_id
         return HTMLResponse((STATIC_DIR / "index.html").read_text())
 

--- a/djsupport/web.py
+++ b/djsupport/web.py
@@ -309,9 +309,10 @@ def create_app(
 
     @web_app.middleware("http")
     async def private_source_privacy(request: FastAPIRequest, call_next):
+        request_path = request.scope["path"]
         private_source_route = (
-            request.url.path.startswith("/rekordbox/")
-            or request.url.path.startswith("/qualification/")
+            request_path.startswith("/rekordbox/")
+            or request_path.startswith("/qualification/")
         )
         if private_source_route:
             try:
@@ -324,9 +325,7 @@ def create_app(
             else:
                 response = await call_next(request)
             privacy_headers = dict(PRIVATE_SOURCE_PRIVACY_HEADERS)
-            if request.url.path.startswith(
-                "/rekordbox/qualification/media/"
-            ):
+            if request_path.startswith("/rekordbox/qualification/media/"):
                 privacy_headers["Content-Security-Policy"] = (
                     "default-src 'none'; media-src 'self'"
                 )

--- a/djsupport/web.py
+++ b/djsupport/web.py
@@ -159,7 +159,7 @@ class QualificationLinkRequest(BaseModel):
     authorize_private_source: bool = False
 
 
-QUALIFICATION_PRIVACY_HEADERS = {
+PRIVATE_SOURCE_PRIVACY_HEADERS = {
     "Cache-Control": "private, no-store",
     "Content-Security-Policy": (
         "default-src 'self'; script-src 'self' 'unsafe-inline'; "
@@ -323,7 +323,7 @@ def create_app(
                 )
             else:
                 response = await call_next(request)
-            privacy_headers = dict(QUALIFICATION_PRIVACY_HEADERS)
+            privacy_headers = dict(PRIVATE_SOURCE_PRIVACY_HEADERS)
             if request.url.path.startswith(
                 "/rekordbox/qualification/media/"
             ):
@@ -372,18 +372,17 @@ def create_app(
                 status_code=403,
                 detail="Private-source routes require a loopback Host",
             )
-        if request.method not in {"GET", "HEAD", "OPTIONS"}:
-            origin = request.headers.get("origin")
-            if origin:
-                try:
-                    origin_host = urlparse(origin).hostname or ""
-                except ValueError:
-                    origin_host = ""
-                if not is_loopback(origin_host, allow_test=peer_is_test):
-                    raise HTTPException(
-                        status_code=403,
-                        detail="Private-source routes require a loopback Origin",
-                    )
+        origin = request.headers.get("origin")
+        if origin:
+            try:
+                origin_host = urlparse(origin).hostname or ""
+            except ValueError:
+                origin_host = ""
+            if not is_loopback(origin_host, allow_test=peer_is_test):
+                raise HTTPException(
+                    status_code=403,
+                    detail="Private-source routes require a loopback Origin",
+                )
 
     def transfer_for(transfer_id: str, request: SyncRequest | None = None):
         probe_request = request or SyncRequest(
@@ -1043,7 +1042,7 @@ def create_app(
     @web_app.get("/rekordbox/qualification/media/{handle}")
     def qualification_media(handle: str, request: FastAPIRequest):
         require_private_source_loopback(request)
-        privacy_headers = QUALIFICATION_PRIVACY_HEADERS
+        privacy_headers = PRIVATE_SOURCE_PRIVACY_HEADERS
         try:
             stream = audition.stream(handle, request.headers.get("range"))
         except AuditionHandleUnavailable as exc:

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -113,6 +113,11 @@ def test_first_transfer_rejects_nonlocal_context_before_inspecting_a_path():
 
     responses = (
         remote_client.post("/rekordbox/first-transfer", json=payload),
+        remote_client.post(
+            "/rekordbox/first-transfer",
+            headers={"Host": "attacker.example/escape"},
+            json=payload,
+        ),
         local_client.post(
             "/rekordbox/first-transfer",
             headers={"Host": "attacker.example"},
@@ -129,7 +134,13 @@ def test_first_transfer_rejects_nonlocal_context_before_inspecting_a_path():
         ),
     )
 
-    assert [response.status_code for response in responses] == [403, 403, 403, 403]
+    assert [response.status_code for response in responses] == [
+        403,
+        403,
+        403,
+        403,
+        403,
+    ]
     assert inspected_paths == []
 
 

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -95,6 +95,40 @@ def test_first_transfer_web_route_is_a_thin_agent_contract_rendering():
     assert "Private/Selection" not in response.text
 
 
+def test_first_transfer_rejects_nonlocal_context_before_inspecting_a_path():
+    inspected_paths = []
+
+    def inspect_readiness(path, authorized):
+        inspected_paths.append((path, authorized))
+        return FirstTransferReadiness(False, False, True, True, path)
+
+    web = create_app(first_transfer_readiness=inspect_readiness)
+    remote_client = TestClient(
+        web,
+        base_url="http://127.0.0.1",
+        client=("198.51.100.23", 50000),
+    )
+    local_client = TestClient(web)
+    payload = {"xml_path": "/synthetic/outside.xml"}
+
+    responses = (
+        remote_client.post("/rekordbox/first-transfer", json=payload),
+        local_client.post(
+            "/rekordbox/first-transfer",
+            headers={"Host": "attacker.example"},
+            json=payload,
+        ),
+        local_client.post(
+            "/rekordbox/first-transfer",
+            headers={"Origin": "https://attacker.example"},
+            json=payload,
+        ),
+    )
+
+    assert [response.status_code for response in responses] == [403, 403, 403]
+    assert inspected_paths == []
+
+
 def test_first_transfer_web_route_ignores_caller_asserted_readiness():
     transfer = MagicMock()
     web = create_app(
@@ -778,7 +812,9 @@ class TestAuthEndpoints:
         mock_mgr_fn.return_value = mgr
         res = client.get("/auth/login", follow_redirects=False)
         assert res.status_code == 307
-        assert "spotify.com" in res.headers["location"]
+        assert res.headers["location"] == (
+            "https://accounts.spotify.com/authorize?..."
+        )
 
     @patch("djsupport.web._auth_manager")
     def test_auth_callback_success(self, mock_mgr_fn):

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -123,9 +123,13 @@ def test_first_transfer_rejects_nonlocal_context_before_inspecting_a_path():
             headers={"Origin": "https://attacker.example"},
             json=payload,
         ),
+        local_client.get(
+            "/qualification/synthetic-draft",
+            headers={"Origin": "https://attacker.example"},
+        ),
     )
 
-    assert [response.status_code for response in responses] == [403, 403, 403]
+    assert [response.status_code for response in responses] == [403, 403, 403, 403]
     assert inspected_paths == []
 
 


### PR DESCRIPTION
## Validation-only review route

This draft exists only to review and run CI for the complete private-source
security change required by #136. Its base is the preserved original 0.6.0
candidate, not main. Do not merge this pull request.

Scope:

- add the Security release record
- require loopback peer, Host, and supplied Origin checks before private
  Rekordbox or qualification routes can inspect local paths
- classify protected routes from the ASGI routing path across the supported
  FastAPI/Starlette range
- add synthetic regression coverage

The dependent refreeze pull request consumes this release record and runs CI on
the exact replacement-candidate SHA.

No tag, GitHub Release, package upload, live-provider call, owner-data access,
or main-branch change is authorized or performed here.
