### PR TITLE
Validation: freeze the replacement DJ Support 0.6.0 candidate

### DIFF
--- a/.release-notes/private-source-loopback.md
+++ b/.release-notes/private-source-loopback.md
@@ -1,7 +1,0 @@
----
-bump: patch
-section: Security
----
-
-Require loopback peer, Host, and Origin checks before private Rekordbox web
-routes inspect user-selected local paths.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Security
 
+- Private Rekordbox web routes now require loopback peer, Host, and Origin checks before inspecting user-selected local paths.
 - Unsupported matching-knowledge schemas fail closed without rewriting private state, and changed Preview/publication scope cannot resume an earlier Batch.
 
 ### Fixed


### PR DESCRIPTION
## Validation-only final freeze

This draft is the second half of the #136 replacement-candidate review route.
It depends on #186 and compares the exact reviewed
security head with the final 0.6.0 refreeze commit. Do not merge this pull
request; its purpose is exact-SHA CI and review, not integration into main.

Scope:

- consume the private-source Security release record
- add its summary to the existing 0.6.0 changelog
- preserve package metadata at exactly 0.6.0

Final candidate: fca14510b4bef19f66988ce0d16171ff17458a01

Local exact-tree validation passed the complete 746-test suite, compilation,
privacy, migration, backup, archive inspection, a supported older framework
regression, and isolated wheel installation. Local artifacts were
validation-only and were not uploaded.

No tag, GitHub Release, package upload, live-provider call, owner-data access,
or main-branch change is authorized or performed here.
