### PR TITLE
Fix README architecture rendering on mobile

### DIFF
--- a/.release-notes/readme-mobile-architecture.md
+++ b/.release-notes/readme-mobile-architecture.md
@@ -3,5 +3,5 @@ bump: patch
 section: Fixed
 ---
 
-Make the README architecture overview readable on renderers that do not
-support Mermaid diagrams.
+Render the README architecture flowchart as a mobile-friendly SVG with a text
+fallback instead of exposed Mermaid source.

--- a/.release-notes/readme-mobile-architecture.md
+++ b/.release-notes/readme-mobile-architecture.md
@@ -1,0 +1,7 @@
+---
+bump: patch
+section: Fixed
+---
+
+Make the README architecture overview readable on renderers that do not
+support Mermaid diagrams.

--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ Every client uses the same public Transfer policy. Source data enters only for
 an explicitly selected operation; retained knowledge and recovery state stay in
 private local storage; Spotify changes require separate authority.
 
+![DJ Support authority architecture: selected sources and clients enter Transfer, Spotify effects remain reviewable, and only human review creates playlist-scoped Approval](docs/assets/djsupport-architecture-mobile.svg)
+
 - **Sources → Transfer:** Rekordbox XML or an explicitly selected Beatport
   chart or label enters the Transfer policy.
 - **Clients → Transfer:** the CLI, local web interface, and Agent Client all

--- a/README.md
+++ b/README.md
@@ -18,19 +18,18 @@ Every client uses the same public Transfer policy. Source data enters only for
 an explicitly selected operation; retained knowledge and recovery state stay in
 private local storage; Spotify changes require separate authority.
 
-```mermaid
-flowchart LR
-    R["Rekordbox XML"] --> T
-    B["Beatport chart or label"] --> T
-    C["CLI"] --> T["Transfer<br/>policy authority"]
-    W["Local web interface"] --> T
-    A["Agent Client"] --> T
-    T --> L["Private local state"]
-    T --> S["Spotify"]
-    S --> P["Provisional Playlist"]
-    P --> H["Human review and Approval"]
-    H --> L
-```
+- **Sources → Transfer:** Rekordbox XML or an explicitly selected Beatport
+  chart or label enters the Transfer policy.
+- **Clients → Transfer:** the CLI, local web interface, and Agent Client all
+  use that same policy authority.
+- **Transfer → private local state:** retained knowledge and recovery state
+  stay on the user's device.
+- **Transfer → Spotify:** Spotify changes happen only with separate explicit
+  authority.
+- **Spotify → Provisional Playlist → human review:** published results remain
+  reviewable before Approval.
+- **Approval → private local state:** accepted matches become reusable local
+  matching knowledge.
 
 This view intentionally omits recovery states and internal adapters. See the
 [architecture documentation](docs/architecture.md) for the full module map,

--- a/tests/test_documentation.py
+++ b/tests/test_documentation.py
@@ -55,13 +55,25 @@ def test_canonical_documentation_surfaces_are_navigable() -> None:
         assert f"({Path(filename).name})" in index
 
 
-def test_documentation_has_rendered_and_plain_text_architecture_views() -> None:
+def test_documentation_has_portable_and_detailed_architecture_views() -> None:
     readme = _read("README.md")
     architecture = _read("docs/architecture.md")
     domain_model = _read("docs/domain-model.md")
     lifecycles = _read("docs/lifecycles.md")
 
-    assert "```mermaid\nflowchart" in readme
+    overview = readme.split("### How it fits together", 1)[1].split(
+        "## Requirements", 1
+    )[0]
+    assert "```mermaid" not in overview
+    for relationship in (
+        "**Sources → Transfer:**",
+        "**Clients → Transfer:**",
+        "**Transfer → private local state:**",
+        "**Transfer → Spotify:**",
+        "**Spotify → Provisional Playlist → human review:**",
+        "**Approval → private local state:**",
+    ):
+        assert relationship in overview
     assert "```mermaid\nflowchart" in architecture
     assert "```text" in architecture
     assert "```mermaid\nerDiagram" in domain_model
@@ -208,7 +220,10 @@ def test_client_and_abandonment_docs_follow_canonical_behavior() -> None:
     architecture = _read("docs/architecture.md")
     lifecycles = _read("docs/lifecycles.md")
 
-    assert 'A["Agent Client"]' in readme
+    assert (
+        "the CLI, local web interface, and Agent Client all use that same "
+        "policy authority."
+    ) in " ".join(readme.split())
     assert "AI agent" not in architecture
     assert "RetainingPublication --> Abandoned" in lifecycles
     assert "does not infer playlist deletion or Approval" in " ".join(

--- a/tests/test_documentation.py
+++ b/tests/test_documentation.py
@@ -65,6 +65,7 @@ def test_documentation_has_portable_and_detailed_architecture_views() -> None:
         "## Requirements", 1
     )[0]
     assert "```mermaid" not in overview
+    assert "(docs/assets/djsupport-architecture-mobile.svg)" in overview
     for relationship in (
         "**Sources → Transfer:**",
         "**Clients → Transfer:**",
@@ -82,6 +83,7 @@ def test_documentation_has_portable_and_detailed_architecture_views() -> None:
     assert "## Transition tables" in lifecycles
 
     portrait = DOCS / "assets" / "djsupport-architecture-mobile.svg"
+    assert "(docs/assets/djsupport-architecture-mobile.svg)" in readme
     assert "(assets/djsupport-architecture-mobile.svg)" in architecture
     assert portrait.read_text(encoding="utf-8").startswith("<svg ")
 


### PR DESCRIPTION
## What changed

- replace the README-only Mermaid flowchart with a compact native Markdown
  relationship map
- preserve the source, client, Transfer, local-state, Spotify, review, and
  Approval relationships
- update the documentation contract so the overview remains portable
- add the required patch release-note record

## Why

GitHub's mobile repository view can expose the raw Mermaid source instead of a
diagram. The architecture overview then becomes horizontally clipped code
rather than readable documentation. Native Markdown wraps correctly across
GitHub mobile, PyPI, and plain-text renderers.

## Impact

Documentation presentation only. Product behavior and the detailed Mermaid,
plain-text, and SVG architecture views under `docs/` remain unchanged.

## Checks

- `python3 scripts/release_records.py check origin/main HEAD`
- `python3 -m pytest tests/test_documentation.py tests/test_repository_privacy.py tests/test_release_records.py -q`
- `python3 -m compileall -q tests/test_documentation.py`
- `git diff --check origin/main...HEAD`
